### PR TITLE
Add transfer ownership feature

### DIFF
--- a/app/src/app/api/lobby/[lobbyId]/owner/route.ts
+++ b/app/src/app/api/lobby/[lobbyId]/owner/route.ts
@@ -1,0 +1,61 @@
+import { ServerResponseStatus } from "@/server/models";
+import { lobbyService } from "@/services/LobbyService";
+import { isValidSession, toPublicLobby } from "@/server/lobby-helpers";
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ lobbyId: string }> },
+): Promise<Response> {
+  const { lobbyId } = await params;
+  const sessionId = request.headers.get("x-session-id") ?? undefined;
+  const lobby = lobbyService.getLobby(lobbyId);
+
+  if (!lobby) {
+    return Response.json(
+      { status: ServerResponseStatus.Error, error: "Lobby not found" },
+      { status: 404 },
+    );
+  }
+
+  if (!sessionId || !isValidSession(lobby, sessionId)) {
+    return Response.json(
+      { status: ServerResponseStatus.Error, error: "Unauthorized" },
+      { status: 403 },
+    );
+  }
+
+  if (lobby.ownerSessionId !== sessionId) {
+    return Response.json(
+      {
+        status: ServerResponseStatus.Error,
+        error: "Only the owner can transfer ownership",
+      },
+      { status: 403 },
+    );
+  }
+
+  if (lobby.game) {
+    return Response.json(
+      {
+        status: ServerResponseStatus.Error,
+        error: "Cannot transfer ownership after the game has started",
+      },
+      { status: 409 },
+    );
+  }
+
+  const { playerId } = await request.json();
+  const updated = lobbyService.transferOwner(lobbyId, playerId);
+
+  if (!updated) {
+    return Response.json(
+      { status: ServerResponseStatus.Error, error: "Player not found" },
+      { status: 404 },
+    );
+  }
+
+  return Response.json({
+    status: ServerResponseStatus.Success,
+    data: { lobby: toPublicLobby(updated) },
+  });
+}

--- a/app/src/app/api/lobby/lobby.test.ts
+++ b/app/src/app/api/lobby/lobby.test.ts
@@ -3,6 +3,7 @@ import { POST as createLobby } from "./create/route";
 import { GET as getLobby } from "./[lobbyId]/route";
 import { POST as joinLobby } from "./[lobbyId]/join/route";
 import { DELETE as removePlayer } from "./[lobbyId]/players/[playerId]/route";
+import { PUT as transferOwner } from "./[lobbyId]/owner/route";
 
 function makeParams(lobbyId: string) {
   return { params: Promise.resolve({ lobbyId }) };
@@ -162,6 +163,90 @@ describe("Lobby API", () => {
     const body = await res.json();
     expect(body.status).toBe("error");
     expect(body.error).toBe("Lobby not found");
+  });
+
+  describe("transfer owner", () => {
+    it("should allow the owner to transfer ownership to another player", async () => {
+      const createRes = await createLobby(
+        postRequest("http://localhost/api/lobby/create", {
+          playerName: "Alice",
+        }),
+      );
+      const { data: createData } = await createRes.json();
+      const { lobby, sessionId: aliceSession } = createData;
+
+      const joinRes = await joinLobby(
+        postRequest(`http://localhost/api/lobby/${lobby.id}/join`, {
+          playerName: "Bob",
+        }),
+        makeParams(lobby.id),
+      );
+      const { data: joinData } = await joinRes.json();
+      const bob = joinData.lobby.players[1];
+
+      const res = await transferOwner(
+        new Request(`http://localhost/api/lobby/${lobby.id}/owner`, {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            "x-session-id": aliceSession,
+          },
+          body: JSON.stringify({ playerId: bob.id }),
+        }),
+        makeParams(lobby.id),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.status).toBe("success");
+      expect(body.data.lobby.ownerPlayerId).toBe(bob.id);
+    });
+
+    it("should return 403 when a non-owner tries to transfer ownership", async () => {
+      const createRes = await createLobby(
+        postRequest("http://localhost/api/lobby/create", {
+          playerName: "Alice",
+        }),
+      );
+      const { data: createData } = await createRes.json();
+      const { lobby } = createData;
+
+      const joinRes = await joinLobby(
+        postRequest(`http://localhost/api/lobby/${lobby.id}/join`, {
+          playerName: "Bob",
+        }),
+        makeParams(lobby.id),
+      );
+      const { data: joinData } = await joinRes.json();
+      const alice = lobby.players[0];
+
+      const res = await transferOwner(
+        new Request(`http://localhost/api/lobby/${lobby.id}/owner`, {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            "x-session-id": joinData.sessionId,
+          },
+          body: JSON.stringify({ playerId: alice.id }),
+        }),
+        makeParams(lobby.id),
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it("should return 404 when transferring ownership in a nonexistent lobby", async () => {
+      const res = await transferOwner(
+        new Request("http://localhost/api/lobby/nonexistent-id/owner", {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            "x-session-id": "any-session-id",
+          },
+          body: JSON.stringify({ playerId: "some-player-id" }),
+        }),
+        makeParams("nonexistent-id"),
+      );
+      expect(res.status).toBe(404);
+    });
   });
 
   describe("remove player", () => {

--- a/app/src/app/lobby/[lobbyId]/PlayerList.tsx
+++ b/app/src/app/lobby/[lobbyId]/PlayerList.tsx
@@ -4,23 +4,27 @@ import PlayerRow from "./PlayerRow";
 interface Props {
   lobby: PublicLobby;
   userPlayerId: string | null;
+  showLeave: boolean;
   showRemovePlayer: boolean;
-  gameStarted: boolean;
+  showMakeOwner: boolean;
   isFetching: boolean;
-  isRemovePending: boolean;
+  disabled: boolean;
   onRefetch: () => void;
   onRemovePlayer: (playerId: string) => void;
+  onTransferOwner: (playerId: string) => void;
 }
 
 export default function PlayerList({
   lobby,
   userPlayerId,
+  showLeave,
   showRemovePlayer,
-  gameStarted,
+  showMakeOwner,
   isFetching,
-  isRemovePending,
+  disabled,
   onRefetch,
   onRemovePlayer,
+  onTransferOwner,
 }: Props) {
   return (
     <>
@@ -36,11 +40,13 @@ export default function PlayerList({
             key={player.id}
             player={player}
             ownerPlayerId={lobby.ownerPlayerId}
-            userPlayerId={userPlayerId}
+            isCurrentUser={player.id === userPlayerId}
+            showLeave={showLeave}
             showRemovePlayer={showRemovePlayer}
-            gameStarted={gameStarted}
-            isRemovePending={isRemovePending}
+            showMakeOwner={showMakeOwner}
+            disabled={disabled}
             onRemovePlayer={onRemovePlayer}
+            onTransferOwner={onTransferOwner}
           />
         ))}
       </ul>

--- a/app/src/app/lobby/[lobbyId]/PlayerRow.tsx
+++ b/app/src/app/lobby/[lobbyId]/PlayerRow.tsx
@@ -3,21 +3,25 @@ import type { PublicLobbyPlayer } from "@/server/models";
 interface Props {
   player: PublicLobbyPlayer;
   ownerPlayerId: string;
-  userPlayerId: string | null;
+  isCurrentUser: boolean;
+  showLeave: boolean;
   showRemovePlayer: boolean;
-  gameStarted: boolean;
-  isRemovePending: boolean;
+  showMakeOwner: boolean;
+  disabled: boolean;
   onRemovePlayer: (playerId: string) => void;
+  onTransferOwner: (playerId: string) => void;
 }
 
 export default function PlayerRow({
   player,
   ownerPlayerId,
-  userPlayerId,
+  isCurrentUser,
+  showLeave,
   showRemovePlayer,
-  gameStarted,
-  isRemovePending,
+  showMakeOwner,
+  disabled,
   onRemovePlayer,
+  onTransferOwner,
 }: Props) {
   function handleLeave() {
     if (window.confirm("Leave this lobby?")) onRemovePlayer(player.id);
@@ -28,18 +32,28 @@ export default function PlayerRow({
       onRemovePlayer(player.id);
   }
 
+  function handleTransferOwner() {
+    if (window.confirm(`Make ${player.name} the lobby owner?`))
+      onTransferOwner(player.id);
+  }
+
   return (
     <li style={{ display: "flex", gap: "8px", alignItems: "center" }}>
       {player.name}
       {player.id === ownerPlayerId && "(Lobby owner)"}
-      {player.id === userPlayerId && !showRemovePlayer && !gameStarted && (
-        <button onClick={handleLeave} disabled={isRemovePending}>
+      {isCurrentUser && showLeave && (
+        <button onClick={handleLeave} disabled={disabled}>
           Leave
         </button>
       )}
-      {showRemovePlayer && player.id !== userPlayerId && !gameStarted && (
-        <button onClick={handleRemove} disabled={isRemovePending}>
+      {!isCurrentUser && showRemovePlayer && (
+        <button onClick={handleRemove} disabled={disabled}>
           Remove
+        </button>
+      )}
+      {!isCurrentUser && showMakeOwner && (
+        <button onClick={handleTransferOwner} disabled={disabled}>
+          Make Owner
         </button>
       )}
     </li>

--- a/app/src/app/lobby/[lobbyId]/page.tsx
+++ b/app/src/app/lobby/[lobbyId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useParams, useRouter } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { getLobby, removePlayer, getPlayerId } from "@/lib/api";
+import { getLobby, removePlayer, transferOwner, getPlayerId } from "@/lib/api";
 import JoinPrompt from "./JoinPrompt";
 import PlayerList from "./PlayerList";
 
@@ -44,6 +44,15 @@ export default function LobbyPage() {
     },
   });
 
+  const transferOwnerMutation = useMutation({
+    mutationFn: (targetPlayerId: string) =>
+      transferOwner(lobbyId, targetPlayerId),
+    onSuccess: (response) => {
+      if (response.status === "error") return;
+      queryClient.invalidateQueries({ queryKey: ["lobby", lobbyId] });
+    },
+  });
+
   function handleRefetch() {
     refetch();
   }
@@ -75,12 +84,20 @@ export default function LobbyPage() {
         <PlayerList
           lobby={lobby}
           userPlayerId={myPlayerId}
+          showLeave={!isOwner}
           showRemovePlayer={isOwner}
-          gameStarted={gameStarted}
+          showMakeOwner={isOwner}
           isFetching={isFetching}
-          isRemovePending={removeMutation.isPending}
+          disabled={
+            removeMutation.isPending ||
+            transferOwnerMutation.isPending ||
+            gameStarted
+          }
           onRefetch={handleRefetch}
           onRemovePlayer={(playerId: string) => removeMutation.mutate(playerId)}
+          onTransferOwner={(playerId: string) =>
+            transferOwnerMutation.mutate(playerId)
+          }
         />
       )}
     </div>

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -73,6 +73,21 @@ export async function joinLobby(
   return data;
 }
 
+export async function transferOwner(
+  lobbyId: string,
+  playerId: string,
+): Promise<ServerResponse<{ lobby: PublicLobby }>> {
+  const sessionId = getSessionId();
+  const headers: HeadersInit = { "Content-Type": "application/json" };
+  if (sessionId) headers["x-session-id"] = sessionId;
+  const response = await fetch(`/api/lobby/${lobbyId}/owner`, {
+    method: "PUT",
+    headers,
+    body: JSON.stringify({ playerId }),
+  });
+  return response.json();
+}
+
 export async function removePlayer(
   lobbyId: string,
   playerId: string,

--- a/app/src/services/LobbyService.ts
+++ b/app/src/services/LobbyService.ts
@@ -11,6 +11,20 @@ export class LobbyService {
     return this.lobbies[lobbyId];
   }
 
+  public transferOwner(
+    lobbyId: string,
+    targetPlayerId: string,
+  ): Lobby | undefined {
+    const lobby = this.lobbies[lobbyId];
+    if (!lobby) return undefined;
+
+    const target = lobby.players.find((p) => p.id === targetPlayerId);
+    if (!target) return undefined;
+
+    lobby.ownerSessionId = target.sessionId;
+    return lobby;
+  }
+
   public removePlayer(lobbyId: string, playerId: string): Lobby | undefined {
     const lobby = this.lobbies[lobbyId];
     if (!lobby) return undefined;


### PR DESCRIPTION
## Summary

- New `PUT /api/lobby/[lobbyId]/owner` route lets the lobby owner assign ownership to another player
- `LobbyService.transferOwner()` updates `ownerSessionId` to the target player's session
- `api.ts` `transferOwner()` client function
- **Make Owner** button appears on other players' rows for the lobby owner (disabled once the game starts)
- Refactored `PlayerRow`/`PlayerList` props along the way:
  - Consolidated `isRemovePending`/`isTransferOwnerPending` + `gameStarted` into a single `disabled` prop
  - Split `showRemovePlayer` into `showLeave`, `showRemovePlayer`, `showMakeOwner`
  - Moved `isCurrentUser` check into `PlayerRow` so `PlayerList` passes flags straight through

## Test plan

- [x] 3 new API tests: owner can transfer, non-owner gets 403, nonexistent lobby gets 404
- [x] Manual: create lobby, have a second player join, use Make Owner to transfer — verify "(Lobby owner)" label moves and buttons update

🤖 Generated with [Claude Code](https://claude.com/claude-code)