### PR TITLE
Auto-redirect lobby and game pages on invalid access

### DIFF
--- a/app/src/app/api/game/[gameId]/route.test.ts
+++ b/app/src/app/api/game/[gameId]/route.test.ts
@@ -68,14 +68,34 @@ describe("GET /api/game/[gameId]", () => {
     expect(Array.isArray(body.data.visibleTeammates)).toBe(true);
   });
 
-  it("should return 404 when the game does not exist", async () => {
+  it("should return 401 with no session header", async () => {
+    const res = await getGameState(
+      new Request("http://localhost/api/game/nonexistent-id"),
+      makeGameParams("nonexistent-id"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("should return 403 when the game does not exist", async () => {
     const res = await getGameState(
       new Request("http://localhost/api/game/nonexistent-id", {
         headers: { "x-session-id": "any-session-id" },
       }),
       makeGameParams("nonexistent-id"),
     );
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(403);
+  });
+
+  it("should return 403 with wrong session header for a valid game", async () => {
+    const { gameId } = await setupStartedGame();
+
+    const res = await getGameState(
+      new Request(`http://localhost/api/game/${gameId}`, {
+        headers: { "x-session-id": "not-a-real-session-id" },
+      }),
+      makeGameParams(gameId),
+    );
+    expect(res.status).toBe(403);
   });
 
   it("should show bad role player their teammates", async () => {

--- a/app/src/app/api/game/[gameId]/route.ts
+++ b/app/src/app/api/game/[gameId]/route.ts
@@ -13,22 +13,19 @@ export async function GET(
 ): Promise<Response> {
   const { gameId } = await params;
   const sessionId = request.headers.get("x-session-id") ?? undefined;
-  const game = gameService.getGame(gameId);
-
-  if (!game) {
+  if (!sessionId) {
     return Response.json(
-      { status: ServerResponseStatus.Error, error: "Game not found" },
-      { status: 404 },
+      { status: ServerResponseStatus.Error, error: "No session" },
+      { status: 401 },
     );
   }
 
-  const caller = sessionId
-    ? game.players.find((p) => p.sessionId === sessionId)
-    : undefined;
+  const game = gameService.getGame(gameId);
+  const caller = game?.players.find((p) => p.sessionId === sessionId);
 
-  if (!caller) {
+  if (!game || !caller) {
     return Response.json(
-      { status: ServerResponseStatus.Error, error: "Unauthorized" },
+      { status: ServerResponseStatus.Error, error: "Forbidden" },
       { status: 403 },
     );
   }

--- a/app/src/app/api/lobby/[lobbyId]/route.test.ts
+++ b/app/src/app/api/lobby/[lobbyId]/route.test.ts
@@ -7,7 +7,7 @@ import {
 } from "@/app/api/test-utils";
 
 describe("GET /api/lobby/[lobbyId]", () => {
-  it("should return 404 with no session header", async () => {
+  it("should return 401 with no session header", async () => {
     const createRes = await createLobby(
       postRequest("http://localhost/api/lobby/create", { playerName: "Alice" }),
     );
@@ -18,10 +18,10 @@ describe("GET /api/lobby/[lobbyId]", () => {
       new Request(`http://localhost/api/lobby/${lobbyId}`),
       makeParams(lobbyId),
     );
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(401);
   });
 
-  it("should return 404 with wrong session header", async () => {
+  it("should return 403 with wrong session header", async () => {
     const createRes = await createLobby(
       postRequest("http://localhost/api/lobby/create", { playerName: "Alice" }),
     );
@@ -34,7 +34,7 @@ describe("GET /api/lobby/[lobbyId]", () => {
       }),
       makeParams(lobbyId),
     );
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(403);
   });
 
   it("should return the lobby with a valid session", async () => {

--- a/app/src/app/api/lobby/[lobbyId]/route.ts
+++ b/app/src/app/api/lobby/[lobbyId]/route.ts
@@ -10,10 +10,24 @@ export async function GET(
   const sessionId = request.headers.get("x-session-id") ?? undefined;
   const lobby = lobbyService.getLobby(lobbyId);
 
-  if (!lobby || !sessionId || !isValidSession(lobby, sessionId)) {
+  if (!lobby) {
     return Response.json(
       { status: ServerResponseStatus.Error, error: "Lobby not found" },
       { status: 404 },
+    );
+  }
+
+  if (!sessionId) {
+    return Response.json(
+      { status: ServerResponseStatus.Error, error: "No session" },
+      { status: 401 },
+    );
+  }
+
+  if (!isValidSession(lobby, sessionId)) {
+    return Response.json(
+      { status: ServerResponseStatus.Error, error: "Invalid session" },
+      { status: 403 },
     );
   }
 

--- a/app/src/app/game/[gameId]/page.tsx
+++ b/app/src/app/game/[gameId]/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useParams } from "next/navigation";
+import { useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { getGameState } from "@/lib/api";
 
 export default function GamePage() {
   const { gameId } = useParams<{ gameId: string }>();
+  const router = useRouter();
 
   const {
     data: gameState,
@@ -14,11 +16,20 @@ export default function GamePage() {
   } = useQuery({
     queryKey: ["game", gameId],
     queryFn: async () => {
-      const response = await getGameState(gameId);
-      if (response.status === "error") throw new Error(response.error);
-      return response.data;
+      const { data, httpStatus } = await getGameState(gameId);
+      if (httpStatus === 401 || httpStatus === 403)
+        throw new Error(`${httpStatus}`);
+      if (data.status === "error") throw new Error(data.error);
+      return data.data;
     },
+    retry: false,
   });
+
+  useEffect(() => {
+    if (error?.message === "401" || error?.message === "403") {
+      router.push("/");
+    }
+  }, [error, router]);
 
   return (
     <div style={{ padding: "20px", fontFamily: "sans-serif" }}>
@@ -26,7 +37,7 @@ export default function GamePage() {
 
       {isLoading && <p>Loading...</p>}
 
-      {error && (
+      {error && error.message !== "401" && error.message !== "403" && (
         <div style={{ color: "red", marginBottom: "10px" }}>
           Error: {error.message}
         </div>

--- a/app/src/app/lobby/[lobbyId]/page.tsx
+++ b/app/src/app/lobby/[lobbyId]/page.tsx
@@ -29,15 +29,18 @@ export default function LobbyPage() {
   } = useQuery({
     queryKey: ["lobby", lobbyId],
     queryFn: async () => {
-      const response = await getLobby(lobbyId);
-      if (response.status === "error") return null;
-      return response.data;
+      const { data, httpStatus } = await getLobby(lobbyId);
+      if (httpStatus === 404 || httpStatus === 403)
+        throw new Error(`${httpStatus}`);
+      if (data.status === "error") return null;
+      return data.data;
     },
     refetchInterval: (query) => {
       if (!query.state.data) return false;
       if (query.state.data.gameId) return false;
       return 3_000;
     },
+    retry: false,
   });
 
   const myPlayerId = getPlayerId();
@@ -47,6 +50,12 @@ export default function LobbyPage() {
   useEffect(() => {
     if (gameId) router.push(`/game/${gameId}`);
   }, [gameId, router]);
+
+  useEffect(() => {
+    if (error?.message === "404" || error?.message === "403") {
+      router.push("/");
+    }
+  }, [error, router]);
 
   const removeMutation = useMutation({
     mutationFn: (targetPlayerId: string) =>
@@ -91,7 +100,7 @@ export default function LobbyPage() {
 
       {isLoading && <p>Loading...</p>}
 
-      {error && (
+      {error && error.message !== "404" && error.message !== "403" && (
         <div style={{ color: "red", marginBottom: "10px" }}>
           Error: {error.message}
         </div>

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -51,12 +51,12 @@ export async function createLobby(
 
 export async function getLobby(
   lobbyId: string,
-): Promise<ServerResponse<PublicLobby>> {
+): Promise<{ data: ServerResponse<PublicLobby>; httpStatus: number }> {
   const sessionId = getSessionId();
   const headers: HeadersInit = {};
   if (sessionId) headers["x-session-id"] = sessionId;
   const response = await fetch(`/api/lobby/${lobbyId}`, { headers });
-  return response.json();
+  return { data: await response.json(), httpStatus: response.status };
 }
 
 export async function joinLobby(
@@ -107,12 +107,12 @@ export async function startGame(
 
 export async function getGameState(
   gameId: string,
-): Promise<ServerResponse<PlayerGameState>> {
+): Promise<{ data: ServerResponse<PlayerGameState>; httpStatus: number }> {
   const sessionId = getSessionId();
   const headers: HeadersInit = {};
   if (sessionId) headers["x-session-id"] = sessionId;
   const response = await fetch(`/api/game/${gameId}`, { headers });
-  return response.json();
+  return { data: await response.json(), httpStatus: response.status };
 }
 
 export async function removePlayer(


### PR DESCRIPTION
## Summary
- Lobby page now redirects to root on 404 (no such lobby) or 403 (invalid session ID); continues to show the join prompt on 401 (lobby exists, no session sent)
- Game page now redirects to root on 401 (no session) or 403 (no game or invalid session)
- Lobby API returns distinct status codes: 404 (no lobby), 401 (no session), 403 (invalid session)
- Game API returns 401 (no session) or 403 for both missing game and invalid session — hiding whether the game ID is valid

## Test plan
- [x] Navigate to a lobby URL that doesn't exist → should redirect to root
- [x] Navigate to a lobby URL with a valid ID but no session → should show join prompt
- [x] Navigate to a lobby URL with a valid ID but an invalid session (e.g. clear localStorage and set a fake `x-session-id`) → should redirect to root
- [x] Navigate to a game URL with no session → should redirect to root
- [x] Navigate to a game URL with an invalid session → should redirect to root
- [x] Confirm all existing tests pass (`pnpm test --run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)