### PR TITLE
Add Avalon game mode

### DIFF
--- a/app/src/app/api/game/[gameId]/route.test.ts
+++ b/app/src/app/api/game/[gameId]/route.test.ts
@@ -99,7 +99,7 @@ describe("GET /api/game/[gameId]", () => {
     expect(res.status).toBe(403);
   });
 
-  it("should show bad role player their teammates", async () => {
+  it("should show Secret Villain bad role player their bad teammates", async () => {
     const { gameId, aliceSession, bobSession } = await setupStartedGame();
 
     const aliceRes = await getGameState(
@@ -118,14 +118,77 @@ describe("GET /api/game/[gameId]", () => {
     );
     const bobBody = await bobRes.json();
 
-    // The player with "bad" role should see their teammates (who are knownToTeammates)
-    // The player with "good" role should see nobody
+    // Bad role can see Bad team players; with only 1 bad player there are none to see
     const badPlayer =
       aliceBody.data.myRole.id === "bad" ? aliceBody.data : bobBody.data;
     const goodPlayer =
       aliceBody.data.myRole.id === "good" ? aliceBody.data : bobBody.data;
 
-    expect(badPlayer.visibleTeammates).toHaveLength(0); // bad has no other bad players
+    expect(badPlayer.visibleTeammates).toHaveLength(0); // no other bad players
     expect(goodPlayer.visibleTeammates).toHaveLength(0); // good cannot see anyone
+  });
+
+  it("should show Avalon special good role player all bad role players", async () => {
+    const createRes = await createLobby(
+      postRequest("http://localhost/api/lobby/create", { playerName: "Alice" }),
+    );
+    const { data: createData } = await createRes.json();
+    const { lobby, sessionId: aliceSession } = createData;
+
+    const joinRes = await joinLobby(
+      postRequest(`http://localhost/api/lobby/${lobby.id}/join`, {
+        playerName: "Bob",
+      }),
+      makeLobbyParams(lobby.id),
+    );
+    const { data: joinData } = await joinRes.json();
+    const bobSession = joinData.sessionId as string;
+
+    const startRes = await startGame(
+      new Request("http://localhost/api/game/create", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-session-id": aliceSession,
+        },
+        body: JSON.stringify({
+          lobbyId: lobby.id,
+          gameMode: "avalon",
+          roleSlots: [
+            { roleId: "avalon-special-good", count: 1 },
+            { roleId: "avalon-bad", count: 1 },
+          ],
+        }),
+      }),
+    );
+    const { data: startData } = await startRes.json();
+    const gameId = startData.lobby.gameId as string;
+
+    const aliceRes = await getGameState(
+      new Request(`http://localhost/api/game/${gameId}`, {
+        headers: { "x-session-id": aliceSession },
+      }),
+      makeGameParams(gameId),
+    );
+    const aliceBody = await aliceRes.json();
+
+    const bobRes = await getGameState(
+      new Request(`http://localhost/api/game/${gameId}`, {
+        headers: { "x-session-id": bobSession },
+      }),
+      makeGameParams(gameId),
+    );
+    const bobBody = await bobRes.json();
+
+    const specialGoodPlayer =
+      aliceBody.data.myRole.id === "avalon-special-good"
+        ? aliceBody.data
+        : bobBody.data;
+    const badPlayer =
+      aliceBody.data.myRole.id === "avalon-bad" ? aliceBody.data : bobBody.data;
+
+    expect(specialGoodPlayer.visibleTeammates).toHaveLength(1);
+    expect(specialGoodPlayer.visibleTeammates[0].role.id).toBe("avalon-bad");
+    expect(badPlayer.visibleTeammates).toHaveLength(0);
   });
 });

--- a/app/src/app/api/game/[gameId]/route.ts
+++ b/app/src/app/api/game/[gameId]/route.ts
@@ -61,13 +61,14 @@ export async function GET(
   };
 
   const visibleTeammates: VisibleTeammate[] = [];
-  if (myRoleDef.canSeeTeammates) {
+  if (myRoleDef.canSeeTeam.length > 0) {
+    const visibleTeams = new Set(myRoleDef.canSeeTeam);
     for (const assignment of game.roleAssignments) {
       if (assignment.playerId === caller.id) continue;
       const roleDef = roleDefs.find(
         (r) => r.id === assignment.roleDefinitionId,
       );
-      if (!roleDef?.knownToTeammates) continue;
+      if (!roleDef || !visibleTeams.has(roleDef.team)) continue;
       const player = game.players.find((p) => p.id === assignment.playerId);
       if (!player) continue;
       visibleTeammates.push({

--- a/app/src/app/api/game/create/route.test.ts
+++ b/app/src/app/api/game/create/route.test.ts
@@ -96,6 +96,78 @@ describe("POST /api/game/create", () => {
     expect(res.status).toBe(403);
   });
 
+  it("should allow starting an Avalon game with Avalon role slots", async () => {
+    const { lobbyId, aliceSession } = await setupLobbyWithPlayers();
+
+    const res = await startGame(
+      new Request("http://localhost/api/game/create", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-session-id": aliceSession,
+        },
+        body: JSON.stringify({
+          lobbyId,
+          gameMode: "avalon",
+          roleSlots: [
+            { roleId: "avalon-good", count: 1 },
+            { roleId: "avalon-bad", count: 1 },
+          ],
+        }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("success");
+    expect(body.data.lobby.gameId).toBeDefined();
+  });
+
+  it("should return 400 when using a role from the wrong game mode", async () => {
+    const { lobbyId, aliceSession } = await setupLobbyWithPlayers();
+
+    const res = await startGame(
+      new Request("http://localhost/api/game/create", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-session-id": aliceSession,
+        },
+        body: JSON.stringify({
+          lobbyId,
+          gameMode: "avalon",
+          roleSlots: [
+            { roleId: "good", count: 1 },
+            { roleId: "bad", count: 1 },
+          ],
+        }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("should return 400 for an unknown game mode", async () => {
+    const { lobbyId, aliceSession } = await setupLobbyWithPlayers();
+
+    const res = await startGame(
+      new Request("http://localhost/api/game/create", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-session-id": aliceSession,
+        },
+        body: JSON.stringify({
+          lobbyId,
+          gameMode: "not-a-real-mode",
+          roleSlots: [
+            { roleId: "good", count: 1 },
+            { roleId: "bad", count: 1 },
+          ],
+        }),
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
   it("should return 409 when the game has already started", async () => {
     const { lobbyId, aliceSession } = await setupLobbyWithPlayers();
     const slots = [

--- a/app/src/lib/game-modes.ts
+++ b/app/src/lib/game-modes.ts
@@ -7,26 +7,44 @@ export const GAME_MODE_ROLES: Record<GameMode, RoleDefinition[]> = {
       id: "good",
       name: "Good Role",
       team: Team.Good,
-      canSeeTeammates: false,
-      knownToTeammates: false,
+      canSeeTeam: [],
     },
     {
       id: "bad",
       name: "Bad Role",
       team: Team.Bad,
-      canSeeTeammates: true,
-      knownToTeammates: true,
+      canSeeTeam: [Team.Bad],
     },
     {
       id: "special-bad",
       name: "Special Bad Role",
       team: Team.Bad,
-      canSeeTeammates: false,
-      knownToTeammates: true,
+      canSeeTeam: [],
+    },
+  ],
+  [GameMode.Avalon]: [
+    {
+      id: "avalon-good",
+      name: "Good Role",
+      team: Team.Good,
+      canSeeTeam: [],
+    },
+    {
+      id: "avalon-special-good",
+      name: "Special Good Role",
+      team: Team.Good,
+      canSeeTeam: [Team.Bad],
+    },
+    {
+      id: "avalon-bad",
+      name: "Bad Role",
+      team: Team.Bad,
+      canSeeTeam: [],
     },
   ],
 };
 
 export const GAME_MODE_NAMES: Record<GameMode, string> = {
   [GameMode.SecretVillain]: "Secret Villain",
+  [GameMode.Avalon]: "Avalon",
 };

--- a/app/src/lib/models/game.ts
+++ b/app/src/lib/models/game.ts
@@ -33,6 +33,7 @@ export type GameStatusState =
 
 export enum GameMode {
   SecretVillain = "secret-villain",
+  Avalon = "avalon",
 }
 
 // --- Roles ---
@@ -46,8 +47,7 @@ export interface RoleDefinition {
   id: string;
   name: string;
   team: Team;
-  canSeeTeammates: boolean;
-  knownToTeammates: boolean;
+  canSeeTeam: Team[];
 }
 
 export interface PlayerRoleAssignment {

--- a/app/src/services/AvalonService.ts
+++ b/app/src/services/AvalonService.ts
@@ -1,0 +1,24 @@
+import { GameMode } from "@/lib/models";
+import type {
+  LobbyPlayer,
+  PlayerRoleAssignment,
+  RoleDefinition,
+} from "@/lib/models";
+import type { RoleSlot } from "@/server/models";
+import { GAME_MODE_ROLES } from "@/lib/game-modes";
+import { assignRoles } from "./assignRoles";
+
+export class AvalonService {
+  getRoleDefinitions(): RoleDefinition[] {
+    return GAME_MODE_ROLES[GameMode.Avalon];
+  }
+
+  createRoleAssignments(
+    players: LobbyPlayer[],
+    roleSlots: RoleSlot[],
+  ): PlayerRoleAssignment[] {
+    return assignRoles(players, roleSlots);
+  }
+}
+
+export const avalonService = new AvalonService();

--- a/app/src/services/GameService.ts
+++ b/app/src/services/GameService.ts
@@ -1,22 +1,29 @@
 import { randomUUID } from "crypto";
 import { GameStatus, GameMode } from "@/lib/models";
-import type { Game, LobbyPlayer, RoleDefinition } from "@/lib/models";
+import type {
+  Game,
+  LobbyPlayer,
+  PlayerRoleAssignment,
+  RoleDefinition,
+} from "@/lib/models";
 import type { RoleSlot } from "@/server/models";
-import {
-  secretVillainService,
-  SecretVillainService,
-} from "./SecretVillainService";
+import { secretVillainService } from "./SecretVillainService";
+import { avalonService } from "./AvalonService";
 
-type GameModeService = Pick<
-  SecretVillainService,
-  "getRoleDefinitions" | "createRoleAssignments"
->;
+interface GameModeService {
+  getRoleDefinitions(): RoleDefinition[];
+  createRoleAssignments(
+    players: LobbyPlayer[],
+    roleSlots: RoleSlot[],
+  ): PlayerRoleAssignment[];
+}
 
 export class GameService {
   private games: Record<string, Game> = {};
 
   private readonly modeServices: Record<GameMode, GameModeService> = {
     [GameMode.SecretVillain]: secretVillainService,
+    [GameMode.Avalon]: avalonService,
   };
 
   public createGame(


### PR DESCRIPTION
## Summary
- Changes `canSeeTeammates: boolean` / `knownToTeammates: boolean` on `RoleDefinition` to `canSeeTeam: Team[]`, allowing roles to specify which teams they can see
- Secret Villain Bad Role updated to `canSeeTeam: [Team.Bad]` (equivalent to previous behavior)
- Adds Avalon game mode with three roles: Good Role, Special Good Role (can see all Bad team players), Bad Role
- Visibility logic in the game state API updated to filter by team membership

## Test plan
- [ ] Start an Avalon game — "Avalon" option appears in game mode dropdown
- [ ] Special Good Role player sees all Bad Role players in their visible teammates
- [ ] Bad Role player sees no visible teammates in a 2-player Avalon game
- [ ] All existing tests pass (`pnpm test --run`)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)