### PR TITLE
Add Werewolf game mode

### DIFF
--- a/app/src/app/api/game/create/route.test.ts
+++ b/app/src/app/api/game/create/route.test.ts
@@ -206,4 +206,30 @@ describe("POST /api/game/create", () => {
     );
     expect(res.status).toBe(409);
   });
+
+  it("should allow starting a Werewolf game with Werewolf role slots", async () => {
+    const { lobbyId, aliceSession } = await setupLobbyWithPlayers();
+
+    const res = await startGame(
+      new Request("http://localhost/api/game/create", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-session-id": aliceSession,
+        },
+        body: JSON.stringify({
+          lobbyId,
+          gameMode: "werewolf",
+          roleSlots: [
+            { roleId: "werewolf-good", count: 1 },
+            { roleId: "werewolf-bad", count: 1 },
+          ],
+        }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("success");
+    expect(body.data.lobby.gameId).toBeDefined();
+  });
 });

--- a/app/src/lib/game-modes.ts
+++ b/app/src/lib/game-modes.ts
@@ -42,9 +42,24 @@ export const GAME_MODE_ROLES: Record<GameMode, RoleDefinition[]> = {
       canSeeTeam: [],
     },
   ],
+  [GameMode.Werewolf]: [
+    {
+      id: "werewolf-good",
+      name: "Good Role",
+      team: Team.Good,
+      canSeeTeam: [],
+    },
+    {
+      id: "werewolf-bad",
+      name: "Bad Role",
+      team: Team.Bad,
+      canSeeTeam: [],
+    },
+  ],
 };
 
 export const GAME_MODE_NAMES: Record<GameMode, string> = {
   [GameMode.SecretVillain]: "Secret Villain",
   [GameMode.Avalon]: "Avalon",
+  [GameMode.Werewolf]: "Werewolf",
 };

--- a/app/src/lib/models/game.ts
+++ b/app/src/lib/models/game.ts
@@ -34,6 +34,7 @@ export type GameStatusState =
 export enum GameMode {
   SecretVillain = "secret-villain",
   Avalon = "avalon",
+  Werewolf = "werewolf",
 }
 
 // --- Roles ---

--- a/app/src/services/GameService.ts
+++ b/app/src/services/GameService.ts
@@ -9,6 +9,7 @@ import type {
 import type { RoleSlot } from "@/server/models";
 import { secretVillainService } from "./SecretVillainService";
 import { avalonService } from "./AvalonService";
+import { werewolfService } from "./WerewolfService";
 
 interface GameModeService {
   getRoleDefinitions(): RoleDefinition[];
@@ -24,6 +25,7 @@ export class GameService {
   private readonly modeServices: Record<GameMode, GameModeService> = {
     [GameMode.SecretVillain]: secretVillainService,
     [GameMode.Avalon]: avalonService,
+    [GameMode.Werewolf]: werewolfService,
   };
 
   public createGame(

--- a/app/src/services/WerewolfService.ts
+++ b/app/src/services/WerewolfService.ts
@@ -1,0 +1,24 @@
+import { GameMode } from "@/lib/models";
+import type {
+  LobbyPlayer,
+  PlayerRoleAssignment,
+  RoleDefinition,
+} from "@/lib/models";
+import type { RoleSlot } from "@/server/models";
+import { GAME_MODE_ROLES } from "@/lib/game-modes";
+import { assignRoles } from "./assignRoles";
+
+export class WerewolfService {
+  getRoleDefinitions(): RoleDefinition[] {
+    return GAME_MODE_ROLES[GameMode.Werewolf];
+  }
+
+  createRoleAssignments(
+    players: LobbyPlayer[],
+    roleSlots: RoleSlot[],
+  ): PlayerRoleAssignment[] {
+    return assignRoles(players, roleSlots);
+  }
+}
+
+export const werewolfService = new WerewolfService();


### PR DESCRIPTION
## Summary
- Adds a Werewolf game mode with two teams (Good, Bad) and one role per team: Good Role and Bad Role
- Neither role has team visibility — Bad Role players do not see each other
- Registers `WerewolfService` with `GameService` following the same pattern as Secret Villain

## Test plan
- [ ] Start a Werewolf game — "Werewolf" option appears in game mode dropdown
- [ ] Both players receive a role with no visible teammates
- [ ] All existing tests pass (`pnpm test --run`)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)