### PR TITLE
Remove UI flashing from lobby loading states

### DIFF
--- a/app/src/app/lobby/[lobbyId]/page.tsx
+++ b/app/src/app/lobby/[lobbyId]/page.tsx
@@ -166,9 +166,7 @@ export default function LobbyPage() {
             config={fetchLobby.data.config}
             playerCount={fetchLobby.data.players.length}
             readOnly={false}
-            isPending={
-              updateConfigMutation.isPending || startGameMutation.isPending
-            }
+            isPending={startGameMutation.isPending}
             onConfigChange={(config) => {
               updateConfigMutation.mutate(config);
             }}
@@ -192,12 +190,7 @@ export default function LobbyPage() {
           showRemovePlayer={isOwner}
           showMakeOwner={isOwner}
           isFetching={fetchLobby.isFetching}
-          disabled={
-            removeMutation.isPending ||
-            transferOwnerMutation.isPending ||
-            startGameMutation.isPending ||
-            gameId !== undefined
-          }
+          disabled={startGameMutation.isPending || gameId !== undefined}
           onRefetch={handleRefetch}
           onRemovePlayer={(playerId: string) => {
             removeMutation.mutate(playerId);


### PR DESCRIPTION
## Summary

- Config panel inputs (checkboxes, role slots) no longer lock during auto-saves — the debounce already handles rapid changes and disabling on every save was visually jarring
- Player action buttons (Leave, Remove, Make Owner) no longer lock during remove/transfer mutations — the confirmation dialogs already prevent accidental double-clicks

Both disabled states now only apply during game start, which is the only action that genuinely invalidates further interaction.

## Test plan

- [x] Change a config option (e.g. toggle a checkbox) — no flash of disabled state
- [x] Rapidly change role slot counts — inputs remain interactive throughout
- [x] Remove or transfer ownership of a player — other buttons don't flash disabled
- [x] Click Start Game — all player and config inputs lock until the game begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)