### PR TITLE
Add Firebase RTDB security rules and client auth (#86)

### DIFF
--- a/app/src/app/api/auth/firebase-token/route.ts
+++ b/app/src/app/api/auth/firebase-token/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { getAdminAuth } from "@/lib/firebase/admin";
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const sessionId = request.headers.get("x-session-id");
+  if (!sessionId) {
+    return NextResponse.json({ error: "Missing session ID" }, { status: 400 });
+  }
+
+  const auth = getAdminAuth();
+  const token = await auth.createCustomToken(sessionId, { sessionId });
+  return NextResponse.json({ token });
+}

--- a/app/src/hooks/firebaseAuth.ts
+++ b/app/src/hooks/firebaseAuth.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { signInWithCustomToken } from "firebase/auth";
+import { getClientAuth } from "@/lib/firebase/client";
+import { getSessionId } from "@/lib/api";
+
+// Module-level deduplication: only one sign-in attempt at a time.
+let signInPromise: Promise<void> | null = null;
+
+async function doSignIn(): Promise<void> {
+  const auth = getClientAuth();
+  if (auth.currentUser) return;
+  const sessionId = getSessionId();
+  if (!sessionId) return;
+  const res = await fetch("/api/auth/firebase-token", {
+    method: "POST",
+    headers: { "x-session-id": sessionId },
+  });
+  if (!res.ok) throw new Error(`Token fetch failed: ${String(res.status)}`);
+  const { token } = (await res.json()) as { token: string };
+  await signInWithCustomToken(auth, token);
+}
+
+function ensureSignedIn(): Promise<void> {
+  signInPromise ??= doSignIn().catch((err: unknown) => {
+    // Reset so the next caller can retry.
+    signInPromise = null;
+    throw err;
+  });
+  return signInPromise;
+}
+
+/**
+ * Ensures the Firebase client SDK is authenticated with a custom token tied
+ * to the current session ID. Returns `isReady` once signed in.
+ */
+export function useFirebaseAuth(): { isReady: boolean } {
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    ensureSignedIn()
+      .then(() => {
+        if (!cancelled) setIsReady(true);
+      })
+      .catch((err: unknown) => {
+        console.error("[useFirebaseAuth] Sign-in failed", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { isReady };
+}

--- a/app/src/hooks/game.ts
+++ b/app/src/hooks/game.ts
@@ -19,6 +19,7 @@ import {
   type FirebasePlayerState,
 } from "@/lib/firebase/schema";
 import { getSessionId } from "@/lib/api";
+import { useFirebaseAuth } from "@/hooks/firebaseAuth";
 
 export function useStartGame(lobbyId: string) {
   const queryClient = useQueryClient();
@@ -44,10 +45,11 @@ export function useStartGame(lobbyId: string) {
  */
 export function useGameStateQuery(gameId: string, refetchInterval?: number) {
   const queryClient = useQueryClient();
+  const { isReady } = useFirebaseAuth();
 
   useEffect(() => {
     const sessionId = getSessionId();
-    if (!sessionId) return;
+    if (!sessionId || !isReady) return;
 
     const db = getClientDatabase();
     const stateRef = ref(db, `games/${gameId}/playerState/${sessionId}`);
@@ -69,7 +71,7 @@ export function useGameStateQuery(gameId: string, refetchInterval?: number) {
     return () => {
       unsubscribe();
     };
-  }, [gameId, queryClient]);
+  }, [gameId, isReady, queryClient]);
 
   return useQuery({
     queryKey: ["game", gameId],

--- a/app/src/hooks/index.ts
+++ b/app/src/hooks/index.ts
@@ -3,3 +3,4 @@ export * from "./lobbySocket";
 export * from "./players";
 export * from "./game";
 export * from "./configSync";
+export * from "./firebaseAuth";

--- a/app/src/hooks/lobbySocket.ts
+++ b/app/src/hooks/lobbySocket.ts
@@ -8,6 +8,7 @@ import type { PublicLobby } from "@/server/types";
 import type { FirebaseLobbyPublic } from "@/lib/firebase/schema";
 import { firebaseToPublicLobby } from "@/lib/firebase/schema";
 import { getPlayerId } from "@/lib/api";
+import { useFirebaseAuth } from "@/hooks/firebaseAuth";
 
 /**
  * Subscribes to the lobby's public Firebase RTDB node and updates the
@@ -20,9 +21,10 @@ export function useLobbyWebSocket(
 ): { isConnected: boolean } {
   const queryClient = useQueryClient();
   const isActive = useRef(false);
+  const { isReady } = useFirebaseAuth();
 
   useEffect(() => {
-    if (!sessionId) return;
+    if (!sessionId || !isReady) return;
 
     const db = getClientDatabase();
     const lobbyPublicRef = ref(db, `lobbies/${lobbyId}/public`);
@@ -64,7 +66,7 @@ export function useLobbyWebSocket(
       isActive.current = false;
       unsubscribe();
     };
-  }, [lobbyId, sessionId, queryClient]);
+  }, [lobbyId, sessionId, isReady, queryClient]);
 
   return { isConnected: !!sessionId };
 }

--- a/app/src/lib/firebase/admin.ts
+++ b/app/src/lib/firebase/admin.ts
@@ -1,5 +1,6 @@
 import { initializeApp, getApps, cert } from "firebase-admin/app";
 import { getDatabase } from "firebase-admin/database";
+import { getAuth } from "firebase-admin/auth";
 
 function initAdminApp() {
   const existing = getApps().find((a) => a.name === "[DEFAULT]");
@@ -18,4 +19,9 @@ function initAdminApp() {
 export function getAdminDatabase() {
   initAdminApp();
   return getDatabase();
+}
+
+export function getAdminAuth() {
+  initAdminApp();
+  return getAuth();
 }

--- a/app/src/lib/firebase/client.ts
+++ b/app/src/lib/firebase/client.ts
@@ -2,6 +2,7 @@
 
 import { initializeApp, getApps } from "firebase/app";
 import { getDatabase } from "firebase/database";
+import { getAuth } from "firebase/auth";
 
 const firebaseConfig = {
   apiKey: process.env["NEXT_PUBLIC_FIREBASE_API_KEY"],
@@ -19,4 +20,8 @@ function getClientApp() {
 
 export function getClientDatabase() {
   return getDatabase(getClientApp());
+}
+
+export function getClientAuth() {
+  return getAuth(getClientApp());
 }

--- a/database.rules.json
+++ b/database.rules.json
@@ -1,0 +1,38 @@
+{
+  "rules": {
+    "lobbies": {
+      "$lobbyId": {
+        "public": {
+          ".read": true,
+          ".write": false
+        },
+        "private": {
+          ".read": false,
+          ".write": false
+        }
+      }
+    },
+    "games": {
+      "$gameId": {
+        "public": {
+          ".read": false,
+          ".write": false
+        },
+        "playerState": {
+          "$sessionId": {
+            ".read": "auth != null && auth.token.sessionId == $sessionId",
+            ".write": false
+          }
+        },
+        "sessionIndex": {
+          ".read": false,
+          ".write": false
+        }
+      }
+    },
+    "$other": {
+      ".read": false,
+      ".write": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `POST /api/auth/firebase-token` route that mints a Firebase custom token scoped to the caller's `sessionId` claim using the Admin SDK
- Adds `useFirebaseAuth` hook with module-level promise deduplication — signs in once per browser session before any RTDB subscription fires
- Gates `useLobbyWebSocket` and `useGameStateQuery` on `isReady` from `useFirebaseAuth` so unauthenticated reads are never attempted against Firebase
- Adds `database.rules.json` with the following rule set:
  - `lobbies/$lobbyId/public` — world-readable (players need the lobby state before signing in), no writes from client
  - `lobbies/$lobbyId/private` — fully blocked
  - `games/$gameId/playerState/$sessionId` — readable only when `auth.token.sessionId == $sessionId`
  - All other paths — fully blocked

## Test plan
- [x] Create a lobby — confirm lobby screen loads and real-time updates work
- [x] Join as a second player — confirm both players see each other
- [x] Transfer ownership — confirm new owner sees updated UI without refresh
- [x] Start a game — confirm both players reach the game screen with correct role state
- [x] Apply the rules in `database.rules.json` to the Firebase RTDB console and verify no permission-denied errors appear in browser console during normal gameplay

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)