### PR TITLE
Add cron job to prune stale lobbies and games

### DIFF
--- a/app/src/app/api/cron/prune-stale/route.ts
+++ b/app/src/app/api/cron/prune-stale/route.ts
@@ -1,0 +1,45 @@
+import type { NextRequest } from "next/server";
+import { getAdminDatabase } from "@/lib/firebase/admin";
+
+const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  const secret = process.env["CRON_SECRET"];
+  if (!secret || authHeader !== `Bearer ${secret}`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const cutoff = Date.now() - MAX_AGE_MS;
+  const db = getAdminDatabase();
+
+  const lobbiesSnap = await db
+    .ref("lobbies")
+    .orderByChild("public/createdAt")
+    .endAt(cutoff)
+    .once("value");
+
+  const gamesSnap = await db
+    .ref("games")
+    .orderByChild("public/createdAt")
+    .endAt(cutoff)
+    .once("value");
+
+  const updates: Record<string, null> = {};
+
+  lobbiesSnap.forEach((child) => {
+    updates[`lobbies/${child.key}`] = null;
+  });
+
+  gamesSnap.forEach((child) => {
+    updates[`games/${child.key}`] = null;
+  });
+
+  const pruned = Object.keys(updates).length;
+
+  if (pruned > 0) {
+    await db.ref().update(updates);
+  }
+
+  return Response.json({ pruned });
+}

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/prune-stale",
+      "schedule": "0 5 * * *"
+    }
+  ]
+}

--- a/database.rules.json
+++ b/database.rules.json
@@ -1,6 +1,7 @@
 {
   "rules": {
     "lobbies": {
+      ".indexOn": ["public/createdAt"],
       "$lobbyId": {
         "public": {
           ".read": true,
@@ -13,6 +14,7 @@
       }
     },
     "games": {
+      ".indexOn": ["public/createdAt"],
       "$gameId": {
         "public": {
           ".read": false,


### PR DESCRIPTION
## Summary
- Adds `GET /api/cron/prune-stale` route that deletes Firebase RTDB lobbies and games with `createdAt` older than 7 days
- Secured with `CRON_SECRET` bearer token auth (Vercel sets this automatically)
- Adds `vercel.json` with a daily cron schedule (5:00 AM UTC)
- Adds `.indexOn` rules for `public/createdAt` on both `lobbies` and `games` collections to support the `orderByChild` queries

Closes #15

## Setup
After merging, add a `CRON_SECRET` environment variable in the Vercel project settings (Vercel auto-generates one if you use their UI). Also apply the updated `database.rules.json` to the Firebase RTDB console.

## Test plan
- [x] Build passes
- [ ] Deploy to Vercel and verify the cron job appears in the Vercel dashboard
- [ ] Confirm `CRON_SECRET` env var is set in Vercel
- [ ] Verify pruning works by checking logs after a cron invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)