### PR TITLE
Allow narrator to mark Werewolf players as dead

### DIFF
--- a/app/src/components/game/PlayersRoleList.tsx
+++ b/app/src/components/game/PlayersRoleList.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { GameMode } from "@/lib/types";
 import type { VisibleTeammate } from "@/server/types";
 import {
@@ -13,10 +14,20 @@ import { RoleLabel } from "@/components/RoleLabel";
 interface Props {
   assignments: VisibleTeammate[];
   gameMode?: GameMode;
+  deadPlayerIds?: string[];
+  /** Optional render prop for per-player action buttons (e.g., kill/revive). */
+  renderActions?: (playerId: string, isDead: boolean) => ReactNode;
 }
 
-export function PlayersRoleList({ assignments, gameMode }: Props) {
+export function PlayersRoleList({
+  assignments,
+  gameMode,
+  deadPlayerIds,
+  renderActions,
+}: Props) {
   if (assignments.length === 0) return null;
+
+  const deadSet = new Set(deadPlayerIds ?? []);
 
   return (
     <Card className="mb-5">
@@ -25,16 +36,26 @@ export function PlayersRoleList({ assignments, gameMode }: Props) {
       </CardHeader>
       <CardContent>
         <ItemGroup>
-          {assignments.map((t) => (
-            <Item key={t.player.id} size="sm">
-              <ItemContent>
-                <ItemTitle>{t.player.name}</ItemTitle>
-              </ItemContent>
-              <ItemActions>
-                <RoleLabel role={t.role} gameMode={gameMode} />
-              </ItemActions>
-            </Item>
-          ))}
+          {assignments.map((t) => {
+            const isDead = deadSet.has(t.player.id);
+            return (
+              <Item key={t.player.id} size="sm">
+                <ItemContent>
+                  <ItemTitle
+                    className={
+                      isDead ? "italic text-muted-foreground line-through" : ""
+                    }
+                  >
+                    {t.player.name}
+                  </ItemTitle>
+                </ItemContent>
+                <ItemActions>
+                  <RoleLabel role={t.role} gameMode={gameMode} />
+                  {renderActions?.(t.player.id, isDead)}
+                </ItemActions>
+              </Item>
+            );
+          })}
         </ItemGroup>
       </CardContent>
     </Card>

--- a/app/src/components/game/werewolf/OwnerGameDayScreen.tsx
+++ b/app/src/components/game/werewolf/OwnerGameDayScreen.tsx
@@ -67,6 +67,41 @@ export function OwnerGameDayScreen({ gameId, gameState, turnState }: Props) {
       <PlayersRoleList
         assignments={gameState.visibleRoleAssignments}
         gameMode={gameState.gameMode}
+        deadPlayerIds={gameState.deadPlayerIds}
+        renderActions={(playerId, isDead) =>
+          playerId !== gameState.gameOwner?.id &&
+          (isDead ? (
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={() => {
+                action.mutate({
+                  actionId: WerewolfAction.MarkPlayerAlive,
+                  payload: { playerId },
+                });
+              }}
+              disabled={action.isPending}
+            >
+              Revive
+            </Button>
+          ) : (
+            <Button
+              variant="destructive"
+              size="xs"
+              onClick={() => {
+                if (window.confirm("Mark this player as dead?")) {
+                  action.mutate({
+                    actionId: WerewolfAction.MarkPlayerDead,
+                    payload: { playerId },
+                  });
+                }
+              }}
+              disabled={action.isPending}
+            >
+              Kill
+            </Button>
+          ))
+        }
       />
       <GameRolesList
         roles={gameState.rolesInPlay ?? []}

--- a/app/src/components/game/werewolf/OwnerGameNightScreen.tsx
+++ b/app/src/components/game/werewolf/OwnerGameNightScreen.tsx
@@ -65,6 +65,41 @@ export function OwnerGameNightScreen({ gameId, gameState, turnState }: Props) {
       <PlayersRoleList
         assignments={gameState.visibleRoleAssignments}
         gameMode={gameState.gameMode}
+        deadPlayerIds={gameState.deadPlayerIds}
+        renderActions={(playerId, isDead) =>
+          playerId !== gameState.gameOwner?.id &&
+          (isDead ? (
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={() => {
+                action.mutate({
+                  actionId: WerewolfAction.MarkPlayerAlive,
+                  payload: { playerId },
+                });
+              }}
+              disabled={action.isPending}
+            >
+              Revive
+            </Button>
+          ) : (
+            <Button
+              variant="destructive"
+              size="xs"
+              onClick={() => {
+                if (window.confirm("Mark this player as dead?")) {
+                  action.mutate({
+                    actionId: WerewolfAction.MarkPlayerDead,
+                    payload: { playerId },
+                  });
+                }
+              }}
+              disabled={action.isPending}
+            >
+              Kill
+            </Button>
+          ))
+        }
       />
       <GameRolesList
         roles={gameState.rolesInPlay ?? []}

--- a/app/src/components/game/werewolf/PlayerGameDayScreen.tsx
+++ b/app/src/components/game/werewolf/PlayerGameDayScreen.tsx
@@ -13,6 +13,12 @@ export function PlayerGameDayScreen({ gameState }: Props) {
       <h1 className="text-2xl font-bold mb-2">Hidden Role Game</h1>
       <p className="mb-4 text-muted-foreground">The game is underway.</p>
 
+      {gameState.amDead && (
+        <p className="mb-4 font-semibold text-muted-foreground italic">
+          You have been eliminated.
+        </p>
+      )}
+
       {gameState.myRole && (
         <div className="mb-5">
           <h2 className="text-lg font-semibold mb-2">Your Role</h2>
@@ -23,6 +29,7 @@ export function PlayerGameDayScreen({ gameState }: Props) {
       <PlayersRoleList
         assignments={gameState.visibleRoleAssignments}
         gameMode={gameState.gameMode}
+        deadPlayerIds={gameState.deadPlayerIds}
       />
 
       <GameRolesList

--- a/app/src/components/game/werewolf/PlayerGameNightScreen.tsx
+++ b/app/src/components/game/werewolf/PlayerGameNightScreen.tsx
@@ -9,6 +9,19 @@ interface Props {
 }
 
 export function PlayerGameNightScreen({ gameState, phase }: Props) {
+  if (gameState.amDead) {
+    return (
+      <div className="p-5">
+        <h1 className="text-2xl font-bold mb-2 text-muted-foreground">
+          You Have Been Eliminated
+        </h1>
+        <p className="text-muted-foreground">
+          You are no longer in the game. Stay quiet while the night continues.
+        </p>
+      </div>
+    );
+  }
+
   const isMyTurn =
     gameState.myRole?.id === phase.nightPhaseOrder[phase.currentPhaseIndex];
 

--- a/app/src/lib/firebase/schema.ts
+++ b/app/src/lib/firebase/schema.ts
@@ -264,6 +264,8 @@ export interface FirebasePlayerState {
     role: { id: string; name: string; team: string };
   }[];
   rolesInPlay?: RoleInPlay[] | null;
+  amDead?: boolean;
+  deadPlayerIds?: string[];
 }
 
 export function playerStateToFirebase(
@@ -277,6 +279,10 @@ export function playerStateToFirebase(
     myRole: state.myRole,
     visibleRoleAssignments: state.visibleRoleAssignments,
     rolesInPlay: state.rolesInPlay,
+    ...(state.amDead ? { amDead: true } : {}),
+    ...(state.deadPlayerIds?.length
+      ? { deadPlayerIds: state.deadPlayerIds }
+      : {}),
   };
 }
 
@@ -306,5 +312,7 @@ export function firebaseToPlayerState(
       }),
     ),
     rolesInPlay: raw.rolesInPlay ?? null,
+    ...(raw.amDead ? { amDead: true } : {}),
+    ...(raw.deadPlayerIds?.length ? { deadPlayerIds: raw.deadPlayerIds } : {}),
   };
 }

--- a/app/src/lib/game-modes/werewolf/actions.ts
+++ b/app/src/lib/game-modes/werewolf/actions.ts
@@ -12,6 +12,8 @@ export enum WerewolfAction {
   StartNight = "start-night",
   StartDay = "start-day",
   SetNightPhase = "set-night-phase",
+  MarkPlayerDead = "mark-player-dead",
+  MarkPlayerAlive = "mark-player-alive",
 }
 
 export const WEREWOLF_ACTIONS: Record<WerewolfAction, GameAction> = {
@@ -37,6 +39,7 @@ export const WEREWOLF_ACTIONS: Record<WerewolfAction, GameAction> = {
             nightPhaseOrder,
             currentPhaseIndex: 0,
           },
+          deadPlayerIds: ts.deadPlayerIds,
         },
       };
     },
@@ -54,6 +57,7 @@ export const WEREWOLF_ACTIONS: Record<WerewolfAction, GameAction> = {
         turnState: {
           turn: ts.turn,
           phase: { type: WerewolfPhase.Daytime, startedAt: Date.now() },
+          deadPlayerIds: ts.deadPlayerIds,
         },
       };
     },
@@ -82,6 +86,40 @@ export const WEREWOLF_ACTIONS: Record<WerewolfAction, GameAction> = {
           phase: { ...phase, currentPhaseIndex: phaseIndex },
         },
       };
+    },
+  },
+  [WerewolfAction.MarkPlayerDead]: {
+    isValid(game: Game, callerId: string, payload: unknown) {
+      if (!isOwnerPlaying(game, callerId)) return false;
+      const ts = currentTurnState(game);
+      if (!ts) return false;
+      const { playerId } = payload as { playerId?: unknown };
+      if (typeof playerId !== "string") return false;
+      if (playerId === game.ownerPlayerId) return false;
+      if (ts.deadPlayerIds.includes(playerId)) return false;
+      return game.players.some((p) => p.id === playerId);
+    },
+    apply(game: Game, payload: unknown) {
+      const ts = currentTurnState(game);
+      if (!ts) return;
+      const { playerId } = payload as { playerId: string };
+      ts.deadPlayerIds = [...ts.deadPlayerIds, playerId];
+    },
+  },
+  [WerewolfAction.MarkPlayerAlive]: {
+    isValid(game: Game, callerId: string, payload: unknown) {
+      if (!isOwnerPlaying(game, callerId)) return false;
+      const ts = currentTurnState(game);
+      if (!ts) return false;
+      const { playerId } = payload as { playerId?: unknown };
+      if (typeof playerId !== "string") return false;
+      return ts.deadPlayerIds.includes(playerId);
+    },
+    apply(game: Game, payload: unknown) {
+      const ts = currentTurnState(game);
+      if (!ts) return;
+      const { playerId } = payload as { playerId: string };
+      ts.deadPlayerIds = ts.deadPlayerIds.filter((id) => id !== playerId);
     },
   },
 };

--- a/app/src/lib/game-modes/werewolf/types.ts
+++ b/app/src/lib/game-modes/werewolf/types.ts
@@ -22,6 +22,8 @@ export type WerewolfTurnPhase = WerewolfNighttimePhase | WerewolfDaytimePhase;
 export interface WerewolfTurnState {
   turn: number;
   phase: WerewolfTurnPhase;
+  /** Player IDs that have been marked as dead by the narrator. */
+  deadPlayerIds: string[];
 }
 
 export enum WakesAtNight {

--- a/app/src/server/types/game.ts
+++ b/app/src/server/types/game.ts
@@ -40,4 +40,8 @@ export interface PlayerGameState {
   myRole: PublicRoleInfo | null;
   visibleRoleAssignments: VisibleTeammate[];
   rolesInPlay: RoleInPlay[] | null;
+  /** Whether this player has been marked as dead by the narrator. */
+  amDead?: boolean;
+  /** Player IDs marked as dead by the narrator. */
+  deadPlayerIds?: string[];
 }

--- a/app/src/services/FirebaseGameService.ts
+++ b/app/src/services/FirebaseGameService.ts
@@ -83,7 +83,7 @@ export class FirebaseGameService {
       nightPhaseOrder,
       currentPhaseIndex: 0,
     };
-    return { turn: 1, phase };
+    return { turn: 1, phase, deadPlayerIds: [] };
   }
 
   private buildRolesInPlay(game: Game): RoleInPlay[] | null {
@@ -169,6 +169,9 @@ export class FirebaseGameService {
     const playerById = new Map(game.players.map((p) => [p.id, p]));
     const publicPlayers = game.players.map((p) => ({ id: p.id, name: p.name }));
 
+    // Extract deadPlayerIds from Werewolf turn state.
+    const deadPlayerIds = this.extractDeadPlayerIds(game);
+
     if (callerId === game.ownerPlayerId) {
       const visibleRoleAssignments = game.roleAssignments.flatMap(
         (assignment) => {
@@ -191,6 +194,7 @@ export class FirebaseGameService {
         myRole: null,
         visibleRoleAssignments,
         rolesInPlay: this.buildRolesInPlay(game),
+        ...(deadPlayerIds.length > 0 ? { deadPlayerIds } : {}),
       };
     }
 
@@ -202,6 +206,7 @@ export class FirebaseGameService {
     const myRole = roles[myAssignment.roleDefinitionId];
     if (!myRole) return null;
 
+    // Start with teammate visibility.
     const visibleRoleAssignments = caller.visibleRoles.flatMap((assignment) => {
       const player = playerById.get(assignment.playerId);
       const role = roles[assignment.roleDefinitionId];
@@ -218,6 +223,27 @@ export class FirebaseGameService {
       ];
     });
 
+    // Reveal dead players' roles to all players.
+    const visiblePlayerIds = new Set(
+      visibleRoleAssignments.map((v) => v.player.id),
+    );
+    for (const deadId of deadPlayerIds) {
+      if (deadId === callerId || visiblePlayerIds.has(deadId)) continue;
+      const deadAssignment = game.roleAssignments.find(
+        (a) => a.playerId === deadId,
+      );
+      if (!deadAssignment) continue;
+      const deadPlayer = playerById.get(deadId);
+      const deadRole = roles[deadAssignment.roleDefinitionId];
+      if (!deadPlayer || !deadRole) continue;
+      visibleRoleAssignments.push({
+        player: { id: deadPlayer.id, name: deadPlayer.name },
+        role: { id: deadRole.id, name: deadRole.name, team: deadRole.team },
+      });
+    }
+
+    const amDead = deadPlayerIds.includes(callerId);
+
     return {
       status: game.status,
       gameMode: game.gameMode,
@@ -226,7 +252,16 @@ export class FirebaseGameService {
       myRole: { id: myRole.id, name: myRole.name, team: myRole.team },
       visibleRoleAssignments,
       rolesInPlay: this.buildRolesInPlay(game),
+      ...(amDead ? { amDead: true } : {}),
+      ...(deadPlayerIds.length > 0 ? { deadPlayerIds } : {}),
     };
+  }
+
+  /** Extracts deadPlayerIds from the Werewolf turn state. */
+  private extractDeadPlayerIds(game: Game): string[] {
+    if (game.status.type !== GameStatus.Playing) return [];
+    const ts = game.status.turnState as WerewolfTurnState | undefined;
+    return ts?.deadPlayerIds ?? [];
   }
 
   /** Writes pre-computed PlayerGameState for every player in the game. */


### PR DESCRIPTION
## Summary
- Add `MarkPlayerDead` / `MarkPlayerAlive` actions so the narrator can toggle player death status during any game phase
- Dead players shown with strikethrough + muted styling; their roles are revealed to all players
- Dead players see an elimination message instead of their night turn prompt
- Death status persists across night/day transitions via `WerewolfTurnState.deadPlayerIds`

Closes #53

## Test plan
- [x] Start a Werewolf game, advance to Playing
- [x] As narrator, mark a player as dead → verify italic/strikethrough styling and role revealed to all
- [x] Verify dead player sees "You Have Been Eliminated" during night instead of "It's Your Turn"
- [x] Verify dead player sees elimination notice during day
- [x] Revive the player → verify normal display restored, role no longer revealed to non-teammates
- [x] Verify dead status persists across night→day and day→night transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)