### PR TITLE
Add clipboard icon to lobby share URL

### DIFF
--- a/app/src/components/lobby/ShareLobby.tsx
+++ b/app/src/components/lobby/ShareLobby.tsx
@@ -51,18 +51,25 @@ export function ShareLobby({ lobbyId }: Props) {
 
         <div className="flex flex-col items-center gap-4">
           <QRCodeSVG value={lobbyUrl} size={200} />
-          <button
-            type="button"
-            onClick={() => void handleCopy()}
-            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground text-center break-all hover:text-foreground transition-colors cursor-pointer"
-          >
-            {copied ? (
-              <CheckIcon className="size-3.5 shrink-0" />
-            ) : (
-              <ClipboardIcon className="size-3.5 shrink-0" />
+          <div className="relative">
+            {copied && (
+              <span className="absolute -top-7 left-1/2 -translate-x-1/2 rounded bg-foreground px-2 py-0.5 text-xs text-background animate-in fade-in slide-in-from-bottom-1 duration-150">
+                Copied!
+              </span>
             )}
-            {lobbyUrl}
-          </button>
+            <button
+              type="button"
+              onClick={() => void handleCopy()}
+              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground text-center break-all hover:text-foreground transition-colors cursor-pointer"
+            >
+              {copied ? (
+                <CheckIcon className="size-3.5 shrink-0" />
+              ) : (
+                <ClipboardIcon className="size-3.5 shrink-0" />
+              )}
+              {lobbyUrl}
+            </button>
+          </div>
         </div>
 
         {canShare && (


### PR DESCRIPTION
## Summary
- Replace plain URL text with a clickable button that copies the lobby URL to clipboard
- Shows a clipboard icon that changes to a checkmark on copy
- Remove the separate "Copy Link" button; "Share" is now the primary footer action (only shown when Web Share API is available)

## Test plan
- [x] Open the share dialog → verify clipboard icon appears next to the URL
- [x] Click the URL → verify it copies and icon changes to checkmark
- [x] On mobile (or Share API supported) → verify "Share" button appears as primary action
- [ ] On desktop (no Share API) → verify no footer buttons, copy via inline icon only

🤖 Generated with [Claude Code](https://claude.com/claude-code)