### PR TITLE
Narrator night screen: show player names and use team labels

### DIFF
--- a/app/src/components/game/werewolf/OwnerGameNightScreen.tsx
+++ b/app/src/components/game/werewolf/OwnerGameNightScreen.tsx
@@ -89,8 +89,25 @@ export function OwnerGameNightScreen({ gameId, gameState, turnState }: Props) {
   if (!isNighttime) return null;
 
   const modeConfig = GAME_MODES[gameState.gameMode];
-  const activePhaseLabel = getPhaseLabel(activePhaseKey, modeConfig.roles);
+  const activePhaseLabel = getPhaseLabel(
+    activePhaseKey,
+    modeConfig.roles,
+    modeConfig.teamLabels as Record<string, string>,
+  );
   const isTeamPhase = isTeamPhaseKey(activePhaseKey);
+
+  const activePlayerNames = gameState.visibleRoleAssignments
+    .filter((a) =>
+      isTeamPhase
+        ? (a.role.team as string) === activePhaseKey.slice("team:".length)
+        : a.role.id === activePhaseKey,
+    )
+    .filter((a) => !turnState.deadPlayerIds.includes(a.player.id))
+    .map(
+      (a) =>
+        gameState.players.find((p) => p.id === a.player.id)?.name ??
+        a.player.id,
+    );
 
   const activeTargetName = activeTarget
     ? gameState.players.find((p) => p.id === activeTarget)?.name
@@ -144,6 +161,9 @@ export function OwnerGameNightScreen({ gameId, gameState, turnState }: Props) {
         <p className="mb-4 text-muted-foreground">
           Currently awake:{" "}
           <strong className="text-foreground">{activePhaseLabel}</strong>
+          {activePlayerNames.length > 0 && (
+            <span> ({activePlayerNames.join(", ")})</span>
+          )}
         </p>
         {!isFirstTurn && (
           <OwnerNightTargetPanel

--- a/app/src/lib/game-modes/werewolf/utils/display.ts
+++ b/app/src/lib/game-modes/werewolf/utils/display.ts
@@ -44,9 +44,11 @@ export function buildNightSummary(
 export function getPhaseLabel(
   phaseKey: string,
   roles: Record<string, { name: string }>,
+  teamLabels?: Partial<Record<string, string>>,
 ): string {
   if (isTeamPhaseKey(phaseKey)) {
-    return `${phaseKey.slice(TEAM_PHASE_PREFIX.length)} Team`;
+    const team = phaseKey.slice(TEAM_PHASE_PREFIX.length);
+    return teamLabels?.[team] ?? `${team} Team`;
   }
   return roles[phaseKey]?.name ?? phaseKey;
 }


### PR DESCRIPTION
## Summary
- Active player names shown in parentheses next to the role: "Currently awake: **Witch** (Alice, Bob)"
- Team phases use `teamLabels` from game config instead of raw enum: "Currently awake: **Werewolves**" instead of "Currently awake: **Bad Team**"
- Dead players are excluded from the names list

## Test plan
- [x] Start a game with multiple werewolves — night screen shows "Werewolves (Alice, Bob)"
- [x] Start a game with Witch — night screen shows "Witch (Charlie)"
- [x] Mark a player dead, advance to next night — their name no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)