### PR TITLE
Rename generic Props interfaces to component-specific names

### DIFF
--- a/app/src/components/RoleLabel.tsx
+++ b/app/src/components/RoleLabel.tsx
@@ -3,12 +3,12 @@ import type { GameMode } from "@/lib/types";
 import type { PublicRoleInfo } from "@/server/types";
 import { Badge } from "@/components/ui/badge";
 
-interface Props {
+interface RoleLabelProps {
   role: PublicRoleInfo;
   gameMode?: GameMode;
 }
 
-export function RoleLabel({ role, gameMode }: Props) {
+export function RoleLabel({ role, gameMode }: RoleLabelProps) {
   const teamLabels = gameMode ? GAME_MODES[gameMode].teamLabels : undefined;
   const teamLabel = teamLabels?.[role.team] ?? role.team;
   return (

--- a/app/src/components/game/werewolf/NightOutcomeSummary.tsx
+++ b/app/src/components/game/werewolf/NightOutcomeSummary.tsx
@@ -1,7 +1,7 @@
 import type { NightResolutionEvent } from "@/lib/game-modes/werewolf";
 import { NightOutcomeSummaryItem } from "./NightOutcomeSummaryItem";
 
-interface Props {
+interface NightOutcomeSummaryProps {
   nightResolution: NightResolutionEvent[];
   players: { id: string; name: string }[];
   roles: Record<string, { name: string }>;
@@ -11,7 +11,7 @@ export function NightOutcomeSummary({
   nightResolution,
   players,
   roles,
-}: Props) {
+}: NightOutcomeSummaryProps) {
   if (nightResolution.length === 0) return null;
 
   return (

--- a/app/src/components/game/werewolf/OwnerGameNightScreen.tsx
+++ b/app/src/components/game/werewolf/OwnerGameNightScreen.tsx
@@ -19,13 +19,17 @@ import { OwnerHeader } from "./OwnerHeader";
 import { OwnerNightTargetPanel } from "./OwnerNightTargetPanel";
 import { OwnerPlayerActionsGrid } from "./OwnerPlayerActionsGrid";
 
-interface Props {
+interface OwnerGameNightScreenProps {
   gameId: string;
   gameState: PlayerGameState;
   turnState: WerewolfTurnState;
 }
 
-export function OwnerGameNightScreen({ gameId, gameState, turnState }: Props) {
+export function OwnerGameNightScreen({
+  gameId,
+  gameState,
+  turnState,
+}: OwnerGameNightScreenProps) {
   const nightPhaseSeconds = gameState.timerConfig?.nightPhaseSeconds ?? null;
   const action = useGameAction(gameId);
 

--- a/app/src/components/game/werewolf/OwnerGameScreen.tsx
+++ b/app/src/components/game/werewolf/OwnerGameScreen.tsx
@@ -3,11 +3,11 @@
 import type { PlayerGameState } from "@/server/types";
 import { GameRolesList, PlayersRoleList } from "@/components/game";
 
-interface Props {
+interface OwnerGameScreenProps {
   gameState: PlayerGameState;
 }
 
-export function OwnerGameScreen({ gameState }: Props) {
+export function OwnerGameScreen({ gameState }: OwnerGameScreenProps) {
   return (
     <div className="p-5">
       <h1 className="text-2xl font-bold mb-4">Game In Progress</h1>

--- a/app/src/components/game/werewolf/PlayerGameNightScreen.tsx
+++ b/app/src/components/game/werewolf/PlayerGameNightScreen.tsx
@@ -12,7 +12,7 @@ import { GameTimer } from "@/components/game";
 import { PlayerFirstTurnScreen } from "./PlayerFirstTurnScreen";
 import { PlayerTargetSelection } from "./PlayerTargetSelection";
 
-interface Props {
+interface PlayerGameNightScreenProps {
   gameId: string;
   gameState: PlayerGameState;
   phase: WerewolfNighttimePhase;
@@ -26,7 +26,7 @@ export function PlayerGameNightScreen({
   phase,
   turn,
   deadPlayerIds,
-}: Props) {
+}: PlayerGameNightScreenProps) {
   const nightPhaseSeconds = gameState.timerConfig?.nightPhaseSeconds ?? null;
 
   const phaseStartedAt = useMemo(

--- a/app/src/components/game/werewolf/WerewolfPlayerScreen.tsx
+++ b/app/src/components/game/werewolf/WerewolfPlayerScreen.tsx
@@ -5,12 +5,15 @@ import type { PlayerGameState } from "@/server/types";
 import { PlayerStartingScreen } from "./PlayerStartingScreen";
 import { PlayerGameScreen } from "./PlayerGameScreen";
 
-interface Props {
+interface WerewolfPlayerScreenProps {
   gameId: string;
   gameState: PlayerGameState;
 }
 
-export function WerewolfPlayerScreen({ gameId, gameState }: Props) {
+export function WerewolfPlayerScreen({
+  gameId,
+  gameState,
+}: WerewolfPlayerScreenProps) {
   if (gameState.status.type === GameStatus.Starting) {
     return <PlayerStartingScreen gameState={gameState} />;
   }

--- a/app/src/components/lobby/ConfigurationToggles.tsx
+++ b/app/src/components/lobby/ConfigurationToggles.tsx
@@ -3,7 +3,7 @@
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 
-interface Props {
+interface ConfigurationTogglesProps {
   showConfigToPlayers: boolean;
   disabled?: boolean;
   onShowConfigToPlayersChange?: (value: boolean) => void;
@@ -13,7 +13,7 @@ export function ConfigurationToggles({
   showConfigToPlayers,
   disabled,
   onShowConfigToPlayersChange,
-}: Props) {
+}: ConfigurationTogglesProps) {
   return (
     <div className="flex items-center gap-2">
       <Switch

--- a/app/src/components/lobby/Incrementer.tsx
+++ b/app/src/components/lobby/Incrementer.tsx
@@ -2,7 +2,7 @@ import { Button } from "@/components/ui/button";
 
 export type IncrementDirection = "increment" | "decrement";
 
-interface Props {
+interface IncrementerProps {
   value: number;
   onChange: (direction: IncrementDirection) => void;
   disabled?: boolean;
@@ -16,7 +16,7 @@ export function Incrementer({
   disabled,
   minValue,
   maxValue,
-}: Props) {
+}: IncrementerProps) {
   function handleDecrement() {
     onChange("decrement");
   }

--- a/app/src/components/lobby/JoinPrompt.tsx
+++ b/app/src/components/lobby/JoinPrompt.tsx
@@ -8,12 +8,12 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-interface Props {
+interface JoinPromptProps {
   lobbyId: string;
   onJoined?: () => void;
 }
 
-export function JoinPrompt({ lobbyId, onJoined }: Props) {
+export function JoinPrompt({ lobbyId, onJoined }: JoinPromptProps) {
   const queryClient = useQueryClient();
   const [playerName, setPlayerName] = useState("");
 

--- a/app/src/components/lobby/PlayerList.tsx
+++ b/app/src/components/lobby/PlayerList.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PlayerRow } from "./PlayerRow";
 
-interface Props {
+interface PlayerListProps {
   lobby: PublicLobby;
   userPlayerId: string | null;
   showLeave: boolean;
@@ -29,7 +29,7 @@ export function PlayerList({
   onRefetch,
   onRemovePlayer,
   onTransferOwner,
-}: Props) {
+}: PlayerListProps) {
   return (
     <Card className="mb-5">
       <CardHeader className="flex flex-row items-center gap-3 space-y-0">

--- a/app/src/components/lobby/PlayerRow.tsx
+++ b/app/src/components/lobby/PlayerRow.tsx
@@ -2,7 +2,7 @@ import type { PublicLobbyPlayer } from "@/server/types";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 
-interface Props {
+interface PlayerRowProps {
   player: PublicLobbyPlayer;
   ownerPlayerId: string;
   isCurrentUser: boolean;
@@ -24,7 +24,7 @@ export function PlayerRow({
   disabled,
   onRemovePlayer,
   onTransferOwner,
-}: Props) {
+}: PlayerRowProps) {
   function handleLeave() {
     if (window.confirm("Leave this lobby?")) onRemovePlayer(player.id);
   }

--- a/app/src/components/lobby/RoleConfigModePicker.tsx
+++ b/app/src/components/lobby/RoleConfigModePicker.tsx
@@ -6,11 +6,11 @@ import { setRoleConfigMode } from "@/store/game-config-slice";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
-interface Props {
+interface RoleConfigModePickerProps {
   disabled?: boolean;
 }
 
-export function RoleConfigModePicker({ disabled }: Props) {
+export function RoleConfigModePicker({ disabled }: RoleConfigModePickerProps) {
   const dispatch = useAppDispatch();
   const roleConfigMode = useAppSelector((s) => s.gameConfig.roleConfigMode);
 

--- a/app/src/components/lobby/ShareLobby.tsx
+++ b/app/src/components/lobby/ShareLobby.tsx
@@ -13,11 +13,11 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 
-interface Props {
+interface ShareLobbyProps {
   lobbyId: string;
 }
 
-export function ShareLobby({ lobbyId }: Props) {
+export function ShareLobby({ lobbyId }: ShareLobbyProps) {
   const [copied, setCopied] = useState(false);
   const lobbyUrl = `${window.location.origin}/lobby/${lobbyId}`;
 

--- a/app/src/components/lobby/ShowRolesInPlayPicker.tsx
+++ b/app/src/components/lobby/ShowRolesInPlayPicker.tsx
@@ -43,13 +43,17 @@ const SHOW_ROLES_OPTIONS: {
   },
 ];
 
-interface Props {
+interface ShowRolesInPlayPickerProps {
   value: ShowRolesInPlay;
   disabled?: boolean;
   onChange?: (value: ShowRolesInPlay) => void;
 }
 
-export function ShowRolesInPlayPicker({ value, disabled, onChange }: Props) {
+export function ShowRolesInPlayPicker({
+  value,
+  disabled,
+  onChange,
+}: ShowRolesInPlayPickerProps) {
   return (
     <div className="space-y-1">
       <Label>Show roles in play</Label>


### PR DESCRIPTION
## Summary
Renames all generic `interface Props` definitions to component-scoped names (e.g. `RoleLabelProps`, `PlayerListProps`) across 14 components.

Improves grep-ability and makes the intent of each props type self-evident without needing to look at its enclosing file.

## Test plan
- [x] No type errors (`pnpm tsc --noEmit`)
- [x] Pure rename — no behaviour changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)