### PR TITLE
Remove myLastNightAction from player state

### DIFF
--- a/app/src/components/game/werewolf/PlayerGameDayScreen.tsx
+++ b/app/src/components/game/werewolf/PlayerGameDayScreen.tsx
@@ -43,7 +43,6 @@ export function PlayerGameDayScreen({ gameState, turnState }: Props) {
       <PlayerNightSummary
         players={gameState.players}
         nightStatus={gameState.nightStatus}
-        myLastNightAction={gameState.myLastNightAction}
       />
 
       {gameState.amDead && (

--- a/app/src/components/game/werewolf/PlayerNightSummary.tsx
+++ b/app/src/components/game/werewolf/PlayerNightSummary.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import groupBy from "lodash/groupBy";
-import { getActionText } from "@/lib/game-modes/werewolf";
 import { getPlayerName } from "@/lib/player-utils";
 import type { PlayerGameState } from "@/server/types";
 import { PlayerNightSummaryItem } from "./PlayerNightSummaryItem";
@@ -9,13 +8,11 @@ import { PlayerNightSummaryItem } from "./PlayerNightSummaryItem";
 interface PlayerNightSummaryProps {
   players: PlayerGameState["players"];
   nightStatus?: PlayerGameState["nightStatus"];
-  myLastNightAction: PlayerGameState["myLastNightAction"];
 }
 
 export function PlayerNightSummary({
   players,
   nightStatus,
-  myLastNightAction,
 }: PlayerNightSummaryProps) {
   const byPlayer = groupBy(nightStatus ?? [], (e) => e.targetPlayerId);
   const playerEntries = Object.entries(byPlayer).map(
@@ -27,41 +24,23 @@ export function PlayerNightSummary({
     }),
   );
 
-  const hasEvents = playerEntries.length > 0;
-  if (!hasEvents && !myLastNightAction) return null;
-
-  const actionText = myLastNightAction
-    ? getActionText(
-        myLastNightAction.category,
-        getPlayerName(players, myLastNightAction.targetPlayerId) ??
-          myLastNightAction.targetPlayerId,
-        nightStatus,
-        myLastNightAction.targetPlayerId,
-      )
-    : null;
+  if (playerEntries.length === 0) return null;
 
   return (
     <div className="mb-5">
       <h2 className="text-lg font-semibold mb-2">Last Night</h2>
-      {hasEvents ? (
-        <ul className="space-y-1">
-          {playerEntries.map(
-            ({ targetPlayerId, playerName, killed, silenced }) => (
-              <PlayerNightSummaryItem
-                key={targetPlayerId}
-                playerName={playerName}
-                killed={killed}
-                silenced={silenced}
-              />
-            ),
-          )}
-        </ul>
-      ) : (
-        <p className="text-sm text-muted-foreground">Nothing happened.</p>
-      )}
-      {actionText && (
-        <p className="mt-2 text-sm text-muted-foreground">{actionText}</p>
-      )}
+      <ul className="space-y-1">
+        {playerEntries.map(
+          ({ targetPlayerId, playerName, killed, silenced }) => (
+            <PlayerNightSummaryItem
+              key={targetPlayerId}
+              playerName={playerName}
+              killed={killed}
+              silenced={silenced}
+            />
+          ),
+        )}
+      </ul>
     </div>
   );
 }

--- a/app/src/lib/firebase/schema.ts
+++ b/app/src/lib/firebase/schema.ts
@@ -20,7 +20,7 @@ import type {
   RoleSlot,
   TimerConfig,
 } from "@/lib/types";
-import type { AnyNightAction, TargetCategory } from "@/lib/game-modes/werewolf";
+import type { AnyNightAction } from "@/lib/game-modes/werewolf";
 import type {
   PublicLobby,
   PlayerGameState,
@@ -294,7 +294,6 @@ export interface FirebasePlayerState {
   amDead?: boolean;
   deadPlayerIds?: string[];
   nightStatus?: NightStatusEntry[];
-  myLastNightAction?: { targetPlayerId: string; category: string };
   investigationResult?: { targetPlayerId: string; isWerewolfTeam: boolean };
   witchAbilityUsed?: boolean;
   timerConfig?: TimerConfig;
@@ -329,9 +328,6 @@ export function playerStateToFirebase(
       ? { deadPlayerIds: state.deadPlayerIds }
       : {}),
     ...(state.nightStatus?.length ? { nightStatus: state.nightStatus } : {}),
-    ...(state.myLastNightAction
-      ? { myLastNightAction: state.myLastNightAction }
-      : {}),
     ...(state.investigationResult
       ? { investigationResult: state.investigationResult }
       : {}),
@@ -382,14 +378,6 @@ export function firebaseToPlayerState(
     ...(raw.amDead ? { amDead: true } : {}),
     ...(raw.deadPlayerIds?.length ? { deadPlayerIds: raw.deadPlayerIds } : {}),
     ...(raw.nightStatus?.length ? { nightStatus: raw.nightStatus } : {}),
-    ...(raw.myLastNightAction
-      ? {
-          myLastNightAction: {
-            targetPlayerId: raw.myLastNightAction.targetPlayerId,
-            category: raw.myLastNightAction.category as TargetCategory,
-          },
-        }
-      : {}),
     ...(raw.investigationResult
       ? { investigationResult: raw.investigationResult }
       : {}),

--- a/app/src/server/types/game.ts
+++ b/app/src/server/types/game.ts
@@ -5,7 +5,7 @@ import type {
   Team,
   TimerConfig,
 } from "@/lib/types";
-import type { AnyNightAction, TargetCategory } from "@/lib/game-modes/werewolf";
+import type { AnyNightAction } from "@/lib/game-modes/werewolf";
 import type { PublicLobbyPlayer } from "./lobby";
 
 export type { RoleSlot };
@@ -88,12 +88,6 @@ export interface PlayerGameState {
    * Only populated for non-owner players.
    */
   nightStatus?: NightStatusEntry[];
-  /**
-   * The target the player chose during the preceding night.
-   * Present even if the action was negated, so players can confirm
-   * their input was recorded. Only populated for non-owner players during daytime.
-   */
-  myLastNightAction?: { targetPlayerId: string; category: TargetCategory };
   /**
    * Investigation result for the Seer during nighttime.
    * Only populated after the narrator explicitly reveals it.

--- a/app/src/services/FirebaseGameService.ts
+++ b/app/src/services/FirebaseGameService.ts
@@ -138,11 +138,8 @@ export class FirebaseGameService {
     const amDead = deadPlayerIds.includes(callerId);
 
     // Daytime-only: sanitized night outcomes and personal action confirmation.
-    const daytimeNightState = gameSerializationService.extractDaytimeNightState(
-      game,
-      callerId,
-      myRole,
-    );
+    const daytimeNightState =
+      gameSerializationService.extractDaytimeNightState(game);
 
     return {
       status: game.status,

--- a/app/src/services/GameSerializationService.test.ts
+++ b/app/src/services/GameSerializationService.test.ts
@@ -4,7 +4,6 @@ import type { Game } from "@/lib/types";
 import {
   WerewolfPhase,
   WerewolfRole,
-  TargetCategory,
   getTeamPhaseKey,
 } from "@/lib/game-modes/werewolf";
 import type { WerewolfTurnState } from "@/lib/game-modes/werewolf";
@@ -13,18 +12,6 @@ import { GameSerializationService } from "./GameSerializationService";
 // ---------------------------------------------------------------------------
 // Test fixtures
 // ---------------------------------------------------------------------------
-
-const werewolfRole = {
-  id: WerewolfRole.Werewolf,
-  name: "Werewolf",
-  team: Team.Bad,
-};
-const seerRole = { id: WerewolfRole.Seer, name: "Seer", team: Team.Good };
-const bodyguardRole = {
-  id: WerewolfRole.Bodyguard,
-  name: "Bodyguard",
-  team: Team.Good,
-};
 
 function makeDaytimeGame(
   overrides: Partial<{
@@ -105,7 +92,7 @@ describe("GameSerializationService.extractDaytimeNightState", () => {
       ownerPlayerId: undefined,
     };
 
-    const result = service.extractDaytimeNightState(game, "p2", seerRole);
+    const result = service.extractDaytimeNightState(game);
     expect(result).toEqual({});
   });
 
@@ -122,7 +109,7 @@ describe("GameSerializationService.extractDaytimeNightState", () => {
       ],
     });
 
-    const result = service.extractDaytimeNightState(game, "p1", werewolfRole);
+    const result = service.extractDaytimeNightState(game);
     expect(result.nightStatus).toBeUndefined();
   });
 
@@ -146,7 +133,7 @@ describe("GameSerializationService.extractDaytimeNightState", () => {
       ],
     });
 
-    const result = service.extractDaytimeNightState(game, "p1", werewolfRole);
+    const result = service.extractDaytimeNightState(game);
     expect(result.nightStatus).toEqual([
       { targetPlayerId: "p2", effect: "killed" },
     ]);
@@ -157,7 +144,7 @@ describe("GameSerializationService.extractDaytimeNightState", () => {
       nightResolution: [{ type: "silenced", targetPlayerId: "p3" }],
     });
 
-    const result = service.extractDaytimeNightState(game, "p1", werewolfRole);
+    const result = service.extractDaytimeNightState(game);
     expect(result.nightStatus).toEqual([
       { targetPlayerId: "p3", effect: "silenced" },
     ]);
@@ -176,7 +163,7 @@ describe("GameSerializationService.extractDaytimeNightState", () => {
       ],
     });
 
-    const result = service.extractDaytimeNightState(game, "p1", werewolfRole);
+    const result = service.extractDaytimeNightState(game);
     const entry = result.nightStatus?.[0];
     expect(entry).not.toHaveProperty("attackedBy");
     expect(entry).not.toHaveProperty("protectedBy");
@@ -282,107 +269,5 @@ describe("GameSerializationService.extractPlayerNightState (Witch)", () => {
     );
     expect(result.witchAbilityUsed).toBe(true);
     expect(result.nightStatus).toBeUndefined();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// extractMyLastNightTarget
-// ---------------------------------------------------------------------------
-
-describe("GameSerializationService.extractMyLastNightTarget", () => {
-  const service = new GameSerializationService();
-
-  it("returns undefined when the player took no action", () => {
-    const game = makeDaytimeGame({ nightActions: {} });
-
-    const result = service.extractMyLastNightTarget({}, game, "p2", seerRole);
-    expect(result).toBeUndefined();
-  });
-
-  it("returns Attack category for a Werewolf team vote", () => {
-    const nightActions = {
-      [getTeamPhaseKey(Team.Bad)]: {
-        votes: [{ playerId: "p1", targetPlayerId: "p3" }],
-        confirmed: true,
-      },
-    };
-    const game = makeDaytimeGame({ nightActions });
-
-    const result = service.extractMyLastNightTarget(
-      nightActions,
-      game,
-      "p1",
-      werewolfRole,
-    );
-    expect(result).toEqual({
-      targetPlayerId: "p3",
-      category: TargetCategory.Attack,
-    });
-  });
-
-  it("returns Investigate category for the Seer's action", () => {
-    const nightActions = {
-      [WerewolfRole.Seer]: { targetPlayerId: "p1", confirmed: true },
-    };
-    const game = makeDaytimeGame({ nightActions });
-
-    const result = service.extractMyLastNightTarget(
-      nightActions,
-      game,
-      "p2",
-      seerRole,
-    );
-    expect(result).toEqual({
-      targetPlayerId: "p1",
-      category: TargetCategory.Investigate,
-    });
-  });
-
-  it("returns Protect category for the Bodyguard's action", () => {
-    const nightActions = {
-      [WerewolfRole.Bodyguard]: { targetPlayerId: "p1", confirmed: true },
-    };
-    const game = makeDaytimeGame({ nightActions });
-
-    const result = service.extractMyLastNightTarget(
-      nightActions,
-      game,
-      "p3",
-      bodyguardRole,
-    );
-    expect(result).toEqual({
-      targetPlayerId: "p1",
-      category: TargetCategory.Protect,
-    });
-  });
-
-  it("returns undefined when the Werewolf's team phase action is missing", () => {
-    const game = makeDaytimeGame({ nightActions: {} });
-
-    const result = service.extractMyLastNightTarget(
-      {},
-      game,
-      "p1",
-      werewolfRole,
-    );
-    expect(result).toBeUndefined();
-  });
-
-  it("returns undefined when the Werewolf voted but there is no matching vote entry", () => {
-    const nightActions = {
-      [getTeamPhaseKey(Team.Bad)]: {
-        votes: [{ playerId: "p99", targetPlayerId: "p3" }],
-        confirmed: false,
-      },
-    };
-    const game = makeDaytimeGame({ nightActions });
-
-    const result = service.extractMyLastNightTarget(
-      nightActions,
-      game,
-      "p1",
-      werewolfRole,
-    );
-    expect(result).toBeUndefined();
   });
 });

--- a/app/src/services/GameSerializationService.ts
+++ b/app/src/services/GameSerializationService.ts
@@ -183,15 +183,8 @@ export class GameSerializationService {
    *
    * nightStatus: killed entries from deaths and silenced entries from the
    * Spellcaster, with attacker/protector info stripped.
-   *
-   * myLastNightAction: the target the player chose, even if their action was
-   * negated, so they can confirm their input was recorded.
    */
-  extractDaytimeNightState(
-    game: Game,
-    callerId: string,
-    myRole: RoleDefinition,
-  ): Partial<PlayerGameState> {
+  extractDaytimeNightState(game: Game): Partial<PlayerGameState> {
     if (game.status.type !== GameStatus.Playing) return {};
     const ts = game.status.turnState as WerewolfTurnState | undefined;
     if (ts?.phase.type !== WerewolfPhase.Daytime) return {};
@@ -207,51 +200,9 @@ export class GameSerializationService {
       return [];
     });
 
-    const myLastNightAction = this.extractMyLastNightTarget(
-      phase.nightActions,
-      game,
-      callerId,
-      myRole,
-    );
-
     return {
       ...(nightStatus.length > 0 ? { nightStatus } : {}),
-      ...(myLastNightAction ? { myLastNightAction } : {}),
     };
-  }
-
-  /**
-   * Returns the target the player chose during the preceding night, or
-   * undefined if they took no action.
-   */
-  extractMyLastNightTarget(
-    nightActions: Record<string, AnyNightAction>,
-    game: Game,
-    callerId: string,
-    myRole: RoleDefinition,
-  ): { targetPlayerId: string; category: TargetCategory } | undefined {
-    const roleDef = GAME_MODES[game.gameMode].roles[myRole.id] as
-      | WerewolfRoleDefinition
-      | undefined;
-    if (!roleDef) return undefined;
-
-    const { targetCategory: category } = roleDef;
-
-    if (roleDef.teamTargeting) {
-      const phaseKey = getTeamPhaseKey(roleDef.team);
-      const action = nightActions[phaseKey];
-      if (!action || !isTeamNightAction(action)) return undefined;
-      const myVote = action.votes.find((v) => v.playerId === callerId);
-      return myVote
-        ? { targetPlayerId: myVote.targetPlayerId, category }
-        : undefined;
-    }
-
-    const myAction = nightActions[myRole.id];
-    if (!myAction || isTeamNightAction(myAction)) return undefined;
-    return myAction.targetPlayerId
-      ? { targetPlayerId: myAction.targetPlayerId, category }
-      : undefined;
   }
 }
 

--- a/docs/werewolf/data-flow.md
+++ b/docs/werewolf/data-flow.md
@@ -54,10 +54,9 @@ These fields are only populated when the active phase matches the player's role.
 
 ### Player Fields — Daytime (day start)
 
-| Field               | Description                                                                                                   |
-| ------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `nightStatus`       | `{ targetPlayerId, effect: "killed" \| "silenced" }[]` — outcome of the previous night                        |
-| `myLastNightAction` | `{ targetPlayerId, category }` — the player's own action from the previous night; confirms input was recorded |
+| Field         | Description                                                                            |
+| ------------- | -------------------------------------------------------------------------------------- |
+| `nightStatus` | `{ targetPlayerId, effect: "killed" \| "silenced" }[]` — outcome of the previous night |
 
 ## Game Phase State Machine
 


### PR DESCRIPTION
## Summary

- Removes `myLastNightAction` from `PlayerGameState`, `FirebasePlayerState`, serialization, and the `PlayerNightSummary` component
- Players are responsible for remembering who they targeted; the field was providing unnecessary assistance
- Also simplifies `extractDaytimeNightState` signature (no longer needs `callerId` or `myRole`)

Closes #143

## Test plan

- [x] All 330 tests pass
- [x] Verify the "Last Night" summary on the day screen only shows kills and silences, with no "you targeted X" line
- [x] Verify `PlayerNightSummary` returns null when no one was killed or silenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)