### PR TITLE
Prevent Bodyguard and Spellcaster from targeting same player twice in a row

### DIFF
--- a/app/src/components/game/werewolf/OwnerGameNightScreen.tsx
+++ b/app/src/components/game/werewolf/OwnerGameNightScreen.tsx
@@ -154,6 +154,10 @@ export function OwnerGameNightScreen({
       vote.targetPlayerId,
   }));
 
+  const previousTargetId = activeRoleDef?.preventRepeatTarget
+    ? turnState.lastTargets?.[activePhaseKey]
+    : undefined;
+
   const targetablePlayers = getTargetablePlayers(
     gameState.players,
     gameState.gameOwner?.id,
@@ -206,6 +210,7 @@ export function OwnerGameNightScreen({
               activeTarget={activeTarget}
               onTargetClick={handleTargetClick}
               isPending={action.isPending}
+              previousTargetId={previousTargetId}
             />
           ))}
         {investigationResult && (

--- a/app/src/components/game/werewolf/OwnerNightTargetPanel.tsx
+++ b/app/src/components/game/werewolf/OwnerNightTargetPanel.tsx
@@ -18,6 +18,7 @@ interface Props {
   activeTarget?: string;
   onTargetClick: (playerId: string | undefined) => void;
   isPending: boolean;
+  previousTargetId?: string;
 }
 
 export function OwnerNightTargetPanel({
@@ -29,6 +30,7 @@ export function OwnerNightTargetPanel({
   activeTarget,
   onTargetClick,
   isPending,
+  previousTargetId,
 }: Props) {
   return (
     <div className="mb-4 rounded-md border p-3">
@@ -72,9 +74,10 @@ export function OwnerNightTargetPanel({
             onClick={() => {
               onTargetClick(activeTarget === player.id ? undefined : player.id);
             }}
-            disabled={isPending}
+            disabled={isPending || player.id === previousTargetId}
           >
             {player.name}
+            {player.id === previousTargetId && " (unavailable)"}
           </Button>
         ))}
         <Button

--- a/app/src/components/game/werewolf/PlayerGameNightScreen.tsx
+++ b/app/src/components/game/werewolf/PlayerGameNightScreen.tsx
@@ -145,6 +145,7 @@ export function PlayerGameNightScreen({
         myNightTarget={gameState.myNightTarget}
         witchAbilityUsed={gameState.witchAbilityUsed}
         attackedPlayerIds={attackedPlayerIds}
+        previousNightTargetId={gameState.previousNightTargetId}
       />
       {gameState.investigationResult && (
         <PlayerInvestigationResult

--- a/app/src/components/game/werewolf/PlayerTargetSelection.tsx
+++ b/app/src/components/game/werewolf/PlayerTargetSelection.tsx
@@ -28,6 +28,7 @@ interface Props {
   myNightTarget?: string;
   witchAbilityUsed?: boolean;
   attackedPlayerIds?: string[];
+  previousNightTargetId?: string;
 }
 
 export function PlayerTargetSelection({
@@ -45,6 +46,7 @@ export function PlayerTargetSelection({
   myNightTarget,
   witchAbilityUsed,
   attackedPlayerIds,
+  previousNightTargetId,
 }: Props) {
   const action = useGameAction(gameId);
 
@@ -109,11 +111,16 @@ export function PlayerTargetSelection({
                 },
               });
             }}
-            disabled={action.isPending || isConfirmed}
+            disabled={
+              action.isPending ||
+              isConfirmed ||
+              player.id === previousNightTargetId
+            }
             className="justify-start"
           >
             {player.name}
             {isSelected && " (selected)"}
+            {player.id === previousNightTargetId && " (unavailable)"}
           </Button>
         ))}
         {!isConfirmed && (

--- a/app/src/lib/firebase/schema.ts
+++ b/app/src/lib/firebase/schema.ts
@@ -294,6 +294,7 @@ export interface FirebasePlayerState {
   amDead?: boolean;
   deadPlayerIds?: string[];
   nightStatus?: NightStatusEntry[];
+  previousNightTargetId?: string;
   investigationResult?: { targetPlayerId: string; isWerewolfTeam: boolean };
   witchAbilityUsed?: boolean;
   timerConfig?: TimerConfig;
@@ -328,6 +329,9 @@ export function playerStateToFirebase(
       ? { deadPlayerIds: state.deadPlayerIds }
       : {}),
     ...(state.nightStatus?.length ? { nightStatus: state.nightStatus } : {}),
+    ...(state.previousNightTargetId
+      ? { previousNightTargetId: state.previousNightTargetId }
+      : {}),
     ...(state.investigationResult
       ? { investigationResult: state.investigationResult }
       : {}),
@@ -378,6 +382,9 @@ export function firebaseToPlayerState(
     ...(raw.amDead ? { amDead: true } : {}),
     ...(raw.deadPlayerIds?.length ? { deadPlayerIds: raw.deadPlayerIds } : {}),
     ...(raw.nightStatus?.length ? { nightStatus: raw.nightStatus } : {}),
+    ...(raw.previousNightTargetId
+      ? { previousNightTargetId: raw.previousNightTargetId }
+      : {}),
     ...(raw.investigationResult
       ? { investigationResult: raw.investigationResult }
       : {}),

--- a/app/src/lib/game-modes/werewolf/actions.ts
+++ b/app/src/lib/game-modes/werewolf/actions.ts
@@ -57,6 +57,7 @@ export const WEREWOLF_ACTIONS: Record<WerewolfAction, GameAction> = {
           },
           deadPlayerIds: ts.deadPlayerIds,
           ...(ts.witchAbilityUsed ? { witchAbilityUsed: true } : {}),
+          ...(ts.lastTargets ? { lastTargets: ts.lastTargets } : {}),
         },
       };
     },
@@ -78,6 +79,21 @@ export const WEREWOLF_ACTIONS: Record<WerewolfAction, GameAction> = {
       const newDeadIds = nightResolution
         .filter((e) => e.type === "killed" && e.died)
         .map((e) => e.targetPlayerId);
+
+      // Build lastTargets for roles that prevent consecutive same-player targeting.
+      const lastTargets: Record<string, string> = {};
+      for (const [phaseKey, action] of Object.entries(
+        nightPhase.nightActions,
+      )) {
+        if (isTeamNightAction(action)) continue;
+        const roleDef = (
+          WEREWOLF_ROLES as Record<string, WerewolfRoleDefinition>
+        )[phaseKey];
+        if (roleDef?.preventRepeatTarget && action.targetPlayerId) {
+          lastTargets[phaseKey] = action.targetPlayerId;
+        }
+      }
+
       game.status = {
         type: GameStatus.Playing,
         turnState: {
@@ -90,6 +106,7 @@ export const WEREWOLF_ACTIONS: Record<WerewolfAction, GameAction> = {
           },
           deadPlayerIds: [...ts.deadPlayerIds, ...newDeadIds],
           ...(ts.witchAbilityUsed ? { witchAbilityUsed: true } : {}),
+          ...(Object.keys(lastTargets).length > 0 ? { lastTargets } : {}),
         },
       };
     },
@@ -170,6 +187,16 @@ export const WEREWOLF_ACTIONS: Record<WerewolfAction, GameAction> = {
       if (targetPlayerId === game.ownerPlayerId) return false;
       if (!game.players.some((p) => p.id === targetPlayerId)) return false;
       if (ts.deadPlayerIds.includes(targetPlayerId)) return false;
+
+      // Roles with preventRepeatTarget cannot target the same player twice in a row.
+      const phaseRoleDef = (
+        WEREWOLF_ROLES as Record<string, WerewolfRoleDefinition>
+      )[phaseKey];
+      if (
+        phaseRoleDef?.preventRepeatTarget &&
+        ts.lastTargets?.[phaseKey] === targetPlayerId
+      )
+        return false;
 
       // Attack and Investigate roles cannot target themselves.
       if (targetPlayerId === callerId) {

--- a/app/src/lib/game-modes/werewolf/roles.ts
+++ b/app/src/lib/game-modes/werewolf/roles.ts
@@ -22,6 +22,8 @@ export interface WerewolfRoleDefinition extends RoleDefinition<
   targetCategory: TargetCategory;
   /** When true, all players with this role on the same team wake and target together. */
   teamTargeting?: boolean;
+  /** When true, the role cannot target the same player on consecutive nights. */
+  preventRepeatTarget?: boolean;
 }
 
 export const MIN_PLAYERS = 5;
@@ -75,6 +77,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     team: Team.Good,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Special,
+    preventRepeatTarget: true,
   },
   [WerewolfRole.Mason]: {
     id: WerewolfRole.Mason,
@@ -104,5 +107,6 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     team: Team.Good,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Protect,
+    preventRepeatTarget: true,
   },
 };

--- a/app/src/lib/game-modes/werewolf/types.ts
+++ b/app/src/lib/game-modes/werewolf/types.ts
@@ -80,6 +80,12 @@ export interface WerewolfTurnState {
   deadPlayerIds: string[];
   /** True once the Witch has used her once-per-game special ability. */
   witchAbilityUsed?: boolean;
+  /**
+   * Maps phase key → player ID that was targeted last night.
+   * Used to prevent roles with preventRepeatTarget from targeting the same
+   * player on consecutive nights.
+   */
+  lastTargets?: Record<string, string>;
 }
 
 export interface TargetablePlayer {

--- a/app/src/server/types/game.ts
+++ b/app/src/server/types/game.ts
@@ -89,6 +89,13 @@ export interface PlayerGameState {
    */
   nightStatus?: NightStatusEntry[];
   /**
+  /**
+   * For roles with preventRepeatTarget, the player ID that cannot be targeted
+   * this night (was targeted last night). Shown as disabled in the UI.
+   * Only populated for non-owner players during their nighttime phase.
+   */
+  previousNightTargetId?: string;
+  /**
    * Investigation result for the Seer during nighttime.
    * Only populated after the narrator explicitly reveals it.
    */

--- a/app/src/services/GameSerializationService.ts
+++ b/app/src/services/GameSerializationService.ts
@@ -143,18 +143,41 @@ export class GameSerializationService {
 
     const myAction = nightActions[myRole.id];
     if (!myAction || isTeamNightAction(myAction)) {
-      return { myNightTarget: undefined, myNightTargetConfirmed: false };
+      const ts =
+        game.status.type === GameStatus.Playing
+          ? (game.status.turnState as WerewolfTurnState | undefined)
+          : undefined;
+      const myRoleDefForRepeat = GAME_MODES[game.gameMode].roles[myRole.id] as
+        | WerewolfRoleDefinition
+        | undefined;
+      const previousNightTargetId = myRoleDefForRepeat?.preventRepeatTarget
+        ? ts?.lastTargets?.[myRole.id]
+        : undefined;
+      return {
+        myNightTarget: undefined,
+        myNightTargetConfirmed: false,
+        ...(previousNightTargetId ? { previousNightTargetId } : {}),
+      };
     }
+
+    const ts =
+      game.status.type === GameStatus.Playing
+        ? (game.status.turnState as WerewolfTurnState | undefined)
+        : undefined;
+    const myRoleDef = GAME_MODES[game.gameMode].roles[myRole.id] as
+      | WerewolfRoleDefinition
+      | undefined;
+    const previousNightTargetId = myRoleDef?.preventRepeatTarget
+      ? ts?.lastTargets?.[myRole.id]
+      : undefined;
 
     const result: Partial<PlayerGameState> = {
       myNightTarget: myAction.targetPlayerId,
       myNightTargetConfirmed: myAction.confirmed ?? false,
+      ...(previousNightTargetId ? { previousNightTargetId } : {}),
     };
 
     // For Investigate roles, include the result once the narrator has revealed it.
-    const myRoleDef = GAME_MODES[game.gameMode].roles[myRole.id] as
-      | WerewolfRoleDefinition
-      | undefined;
     if (
       myRoleDef?.targetCategory === TargetCategory.Investigate &&
       myAction.confirmed &&


### PR DESCRIPTION
## Summary

- Adds `preventRepeatTarget` property to `WerewolfRoleDefinition`; enabled for Bodyguard and Spellcaster
- `WerewolfTurnState.lastTargets` records each restricted role's confirmed target when day starts
- `StartNight` carries `lastTargets` forward; `SetNightTarget` rejects the previous target for restricted roles
- `GameSerializationService` sends `previousNightTargetId` to the active player on their night phase
- Player and narrator target buttons are disabled and labeled "(unavailable)" for the restricted target

Closes #146

## Test plan

- [x] Bodyguard cannot select the same player they protected last night; other players are selectable
- [x] Spellcaster cannot select the same player they silenced last night
- [x] If a restricted role skips (no target), they can target anyone freely the following night
- [x] Narrator sees the previous target disabled in the owner panel
- [x] Server rejects a `set-night-target` request for the previous target even if the UI is bypassed
- [x] No restrictions on turn 1 (no previous target exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)