### PR TITLE
Show narrator night phase order

### DIFF
--- a/app/src/components/game/werewolf/NightPhaseOrderList.tsx
+++ b/app/src/components/game/werewolf/NightPhaseOrderList.tsx
@@ -1,0 +1,58 @@
+import { getPhaseLabel } from "@/lib/game-modes/werewolf";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Item, ItemContent, ItemTitle } from "@/components/ui/item";
+
+interface NightPhaseOrderListProps {
+  nightPhaseOrder: string[];
+  currentPhaseIndex: number;
+  roles: Record<string, { name: string }>;
+  teamLabels?: Partial<Record<string, string>>;
+}
+
+export function NightPhaseOrderList({
+  nightPhaseOrder,
+  currentPhaseIndex,
+  roles,
+  teamLabels,
+}: NightPhaseOrderListProps) {
+  if (nightPhaseOrder.length === 0) return null;
+
+  return (
+    <Card className="mb-5">
+      <CardHeader>
+        <CardTitle>Night Order</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ol className="list-none space-y-1">
+          {nightPhaseOrder.map((phaseKey, index) => {
+            const isCurrent = index === currentPhaseIndex;
+            const isPast = index < currentPhaseIndex;
+            const label = getPhaseLabel(phaseKey, roles, teamLabels);
+            return (
+              <Item
+                key={`${phaseKey}-${String(index)}`}
+                size="sm"
+                variant={isCurrent ? "muted" : "default"}
+                className={isPast ? "opacity-40" : undefined}
+              >
+                <ItemContent>
+                  <ItemTitle>
+                    <span className="text-muted-foreground mr-2 tabular-nums">
+                      {String(index + 1)}.
+                    </span>
+                    {label}
+                    {isCurrent && (
+                      <span className="ml-2 text-xs font-normal text-muted-foreground">
+                        (current)
+                      </span>
+                    )}
+                  </ItemTitle>
+                </ItemContent>
+              </Item>
+            );
+          })}
+        </ol>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/src/components/game/werewolf/OwnerGameNightScreen.tsx
+++ b/app/src/components/game/werewolf/OwnerGameNightScreen.tsx
@@ -26,6 +26,7 @@ import { OwnerHeader } from "./OwnerHeader";
 import { OwnerInvestigationConfirm } from "./OwnerInvestigationConfirm";
 import { OwnerNightTargetPanel } from "./OwnerNightTargetPanel";
 import { OwnerPlayerActionsGrid } from "./OwnerPlayerActionsGrid";
+import { NightPhaseOrderList } from "./NightPhaseOrderList";
 
 interface OwnerGameNightScreenProps {
   gameId: string;
@@ -228,6 +229,12 @@ export function OwnerGameNightScreen({
         gameMode={gameState.gameMode}
         deadPlayerIds={gameState.deadPlayerIds}
         gameOwnerId={gameState.gameOwner?.id}
+      />
+      <NightPhaseOrderList
+        nightPhaseOrder={nightPhaseOrder}
+        currentPhaseIndex={currentPhaseIndex}
+        roles={modeConfig.roles}
+        teamLabels={modeConfig.teamLabels as Record<string, string>}
       />
       <GameRolesList
         roles={gameState.rolesInPlay ?? []}


### PR DESCRIPTION
## Summary
- Adds `NightPhaseOrderList` component that shows the narrator the full sequence of night phases for the current night
- Current phase is highlighted; completed phases are dimmed
- Displayed below the player actions grid and above the roles-in-play list on the narrator night screen

Closes #106

## Test plan
- [x] Start a game with multiple night roles (e.g. Werewolf, Seer, Bodyguard)
- [x] Verify the Night Order list appears on the narrator's night screen with all phases listed in order
- [x] Advance through phases and confirm the current phase is highlighted and past phases are dimmed
- [x] Verify the list still appears correctly when only one phase exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)