### PR TITLE
Hide vote buttons for eliminated players during trial

### DIFF
--- a/app/src/components/game/werewolf/PlayerGameDayScreen.tsx
+++ b/app/src/components/game/werewolf/PlayerGameDayScreen.tsx
@@ -75,6 +75,7 @@ export function PlayerGameDayScreen({
           activeTrial={gameState.activeTrial}
           players={gameState.players}
           myPlayerId={gameState.myPlayerId}
+          amDead={gameState.amDead}
           votePhaseSeconds={gameState.timerConfig?.votePhaseSeconds}
         />
       )}

--- a/app/src/components/game/werewolf/TrialVotePanel.tsx
+++ b/app/src/components/game/werewolf/TrialVotePanel.tsx
@@ -14,6 +14,7 @@ interface TrialVotePanelProps {
   activeTrial: NonNullable<PlayerGameState["activeTrial"]>;
   players: PlayerGameState["players"];
   myPlayerId?: string;
+  amDead?: boolean;
   votePhaseSeconds?: number;
 }
 
@@ -22,6 +23,7 @@ export function TrialVotePanel({
   activeTrial,
   players,
   myPlayerId,
+  amDead,
   votePhaseSeconds,
 }: TrialVotePanelProps) {
   const action = useGameAction(gameId);
@@ -42,6 +44,7 @@ export function TrialVotePanel({
       : trial.verdictLabelInnocent
     : undefined;
   const isDefendant = myPlayerId === activeTrial.defendantId;
+  const canVote = !amDead && !isDefendant;
   const hasVoted = !!activeTrial.myVote;
   const trialStartedAt = new Date(activeTrial.startedAt);
   const timer = (
@@ -97,7 +100,7 @@ export function TrialVotePanel({
           {trial.mustVoteGuiltyNote}
         </p>
       )}
-      {!hasVoted && (
+      {canVote && !hasVoted && (
         <div className="flex justify-center gap-4">
           <Button
             size="sm"


### PR DESCRIPTION
## Summary

- Dead players could see Guilty/Innocent vote buttons during an active trial
- `castVoteAction.isValid` already rejects votes from dead players server-side, so this is a UI-only fix

## Changes

- **`TrialVotePanel`** — added `amDead?: boolean` prop and a derived `canVote = !amDead && !isDefendant` variable that gates the vote button rendering
- **`PlayerGameDayScreen`** — passes `amDead={gameState.amDead}` to `TrialVotePanel`

Dead players still see the trial panel and verdict so they can follow along, just without the vote buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)