### PR TITLE
Enable Dependabot automatic PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  # Root workspace dependencies
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"
+
+  # Next.js app dependencies
+  - package-ecosystem: npm
+    directory: /app
+    schedule:
+      interval: weekly
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        patterns:
+          - "*"
+      production-dependencies:
+        dependency-type: production
+        patterns:
+          - "*"
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Closes #212

## Summary
- Adds `.github/dependabot.yml` with weekly update checks for:
  - Root workspace devDependencies (ESLint, Prettier, Husky, etc.)
  - `app/` production and development dependencies (grouped separately)
  - GitHub Actions workflow dependencies

## Test plan
- [ ] Verify Dependabot is enabled in repo Settings → Code security → Dependabot
- [ ] Confirm PRs appear from Dependabot on next weekly cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)