### PR TITLE
Migrate vitest config to ESM (#235)

### DIFF
--- a/app/vitest.config.mts
+++ b/app/vitest.config.mts
@@ -12,7 +12,7 @@ export default defineConfig({
           exclude: ["src/hooks/**/*.test.ts"],
           setupFiles: ["src/test-setup/firebase-admin-mock.ts"],
         },
-        resolve: { alias: { "@": path.resolve(__dirname, "./src") } },
+        resolve: { alias: { "@": path.resolve(import.meta.dirname, "./src") } },
       },
       {
         test: {
@@ -20,7 +20,7 @@ export default defineConfig({
           environment: "happy-dom",
           include: ["src/hooks/**/*.test.ts"],
         },
-        resolve: { alias: { "@": path.resolve(__dirname, "./src") } },
+        resolve: { alias: { "@": path.resolve(import.meta.dirname, "./src") } },
       },
     ],
   },


### PR DESCRIPTION
## Summary
- Renames `vitest.config.ts` → `vitest.config.mts` so Vite loads it as an ES module
- Replaces `__dirname` (CJS-only global) with `import.meta.dirname` (available since Node 21.2)
- Silences the `The CJS build of Vite's Node API is deprecated` warning

## Test plan
- [ ] `pnpm vitest run` passes all 551 tests with no CJS deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)