### PR TITLE
Fix noisy stack traces in game hook tests

### DIFF
--- a/app/src/hooks/game.test.ts
+++ b/app/src/hooks/game.test.ts
@@ -28,6 +28,10 @@ vi.mock("@/lib/firebase/client", () => ({
   getClientDatabase: vi.fn(() => ({})),
 }));
 
+vi.mock("@/hooks/firebaseAuth", () => ({
+  useFirebaseAuth: vi.fn().mockReturnValue({ isReady: true }),
+}));
+
 import * as api from "@/lib/api";
 import { useStartGame, useGameStateQuery } from "./game";
 


### PR DESCRIPTION
## Summary
- Mocks `useFirebaseAuth` directly in `game.test.ts` so the Firebase sign-in side effect doesn't run during tests
- Eliminates the `[useFirebaseAuth] Sign-in failed` stack traces that were printed to stderr on every `pnpm vitest run`

## Root cause
`useGameStateQuery` calls `useFirebaseAuth`, which internally calls `getClientAuth()` from `@/lib/firebase/client`. The test mock for that module only exported `getClientDatabase`, so Vitest threw a "No export defined" error that was caught and logged with `console.error`. The tests still passed because the query is gated on `!!gameMode`, not `isReady` — but the stderr noise was misleading.

## Test plan
- [ ] `pnpm vitest run src/hooks/game.test.ts` passes with no stack traces in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)