### PR TITLE
Fix Werewolf role tooltip for mobile (#227)

### DIFF
--- a/app/src/app/[gameMode]/lobby/[lobbyId]/page.tsx
+++ b/app/src/app/[gameMode]/lobby/[lobbyId]/page.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { getPlayerId, getLobbyId, getSessionId } from "@/lib/api";
-import { parseGameMode } from "@/lib/game-modes";
+import { GameMode } from "@/lib/types";
+import { parseGameMode, GAME_MODES } from "@/lib/game-modes";
 import {
   useLobbyQuery,
   useLobbyWebSocket,
@@ -19,6 +20,12 @@ import {
   PlayerList,
   ShareLobby,
 } from "@/components/lobby";
+import { RoleGlossaryDialog } from "@/components/game";
+import {
+  WEREWOLF_ROLE_CATEGORY_LABELS,
+  WEREWOLF_ROLE_CATEGORY_ORDER,
+} from "@/lib/game-modes/werewolf/roles";
+import { WEREWOLF_COPY } from "@/lib/game-modes/werewolf/copy";
 import { LOBBY_PAGE_COPY } from "../copy";
 
 export default function LobbyPage() {
@@ -125,6 +132,8 @@ export default function LobbyPage() {
 
   if (!validatedGameMode || !hasReadStorage || hasDifferentLobby) return null;
 
+  const werewolfAllRoles = Object.values(GAME_MODES[GameMode.Werewolf].roles);
+
   const configPanel =
     fetchLobby.data && !gameId ? (
       isOwner || fetchLobby.data.config.showConfigToPlayers ? (
@@ -187,6 +196,19 @@ export default function LobbyPage() {
       )}
 
       {configPanel}
+
+      {actualGameMode === GameMode.Werewolf && !gameId && (
+        <div className="mb-4">
+          <RoleGlossaryDialog
+            roles={werewolfAllRoles}
+            gameMode={GameMode.Werewolf}
+            title={WEREWOLF_COPY.glossary.dialogTitle}
+            triggerLabel={WEREWOLF_COPY.glossary.openButton}
+            categoryOrder={WEREWOLF_ROLE_CATEGORY_ORDER}
+            categoryLabels={WEREWOLF_ROLE_CATEGORY_LABELS}
+          />
+        </div>
+      )}
 
       {fetchLobby.data && (
         <PlayerList

--- a/app/src/app/api/lobby/create/route.ts
+++ b/app/src/app/api/lobby/create/route.ts
@@ -47,7 +47,7 @@ export async function POST(request: Request): Promise<Response> {
       roleConfigMode: RoleConfigMode.Default,
       roleSlots: getDefaultRoleSlots(selectedGameMode, 1),
       showConfigToPlayers: false,
-      showRolesInPlay: ShowRolesInPlay.None,
+      showRolesInPlay: ShowRolesInPlay.ConfiguredOnly,
       nominationsEnabled: true,
       timerConfig: DEFAULT_TIMER_CONFIG,
     },

--- a/app/src/components/RoleLabel.tsx
+++ b/app/src/components/RoleLabel.tsx
@@ -1,83 +1,78 @@
 "use client";
 
-import { useState } from "react";
 import { GAME_MODES } from "@/lib/game-modes";
 import type { GameMode } from "@/lib/types";
 import type { PublicRoleInfo } from "@/server/types";
 import { Badge } from "@/components/ui/badge";
 import { InfoIcon } from "lucide-react";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 
 interface RoleLabelProps {
   role: PublicRoleInfo;
   gameMode?: GameMode;
+  showTeam?: boolean;
 }
 
-export function RoleLabel({ role, gameMode }: RoleLabelProps) {
-  const [open, setOpen] = useState(false);
-
+export function RoleLabel({
+  role,
+  gameMode,
+  showTeam = false,
+}: RoleLabelProps) {
   const modeConfig = gameMode ? GAME_MODES[gameMode] : undefined;
   const teamLabel = modeConfig?.teamLabels[role.team] ?? role.team;
   const fullRole = modeConfig?.roles[role.id];
   const hasInfo = !!(fullRole?.summary ?? fullRole?.description);
 
-  // Team label is always visible when tooltip is open (covers tap case);
-  // otherwise revealed by CSS hover alone.
-  const teamRevealClass = open
+  const teamRevealClass = showTeam
     ? "max-w-[10rem] opacity-100"
     : "max-w-0 opacity-0 group-hover:max-w-[10rem] group-hover:opacity-100";
 
-  const teamReveal = (
-    <span
-      className={`inline-block overflow-hidden whitespace-nowrap transition-all duration-500 ${teamRevealClass}`}
-    >
-      &nbsp;({teamLabel})
-    </span>
-  );
-
   const badge = (
-    <Badge variant="secondary" className={hasInfo ? undefined : "group"}>
+    <Badge
+      variant="secondary"
+      className={!hasInfo && !showTeam ? "group" : undefined}
+    >
       {role.name}
-      {teamReveal}
+      <span
+        className={`inline-block overflow-hidden whitespace-nowrap transition-all duration-500 ${teamRevealClass}`}
+      >
+        &nbsp;({teamLabel})
+      </span>
       {hasInfo && <InfoIcon className="opacity-60" />}
     </Badge>
   );
 
   return hasInfo ? (
-    <TooltipProvider>
-      <Tooltip open={open} onOpenChange={setOpen}>
-        <TooltipTrigger
-          render={
-            <button
-              type="button"
-              className="group inline-flex hover:opacity-80"
-              onClick={() => {
-                setOpen((v) => !v);
-              }}
-            />
-          }
-        >
-          {badge}
-          <span className="sr-only">Role information</span>
-        </TooltipTrigger>
-        <TooltipContent
-          side="top"
-          className="max-w-64 text-wrap flex-col items-start"
-        >
-          {fullRole?.summary && (
-            <p className="font-medium">{fullRole.summary}</p>
-          )}
-          {fullRole?.description && (
-            <p className="mt-1 opacity-90">{fullRole.description}</p>
-          )}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Dialog>
+      <DialogTrigger
+        render={
+          <button
+            type="button"
+            className="group inline-flex hover:opacity-80"
+          />
+        }
+      >
+        {badge}
+        <span className="sr-only">Role information</span>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {role.name} ({teamLabel})
+          </DialogTitle>
+        </DialogHeader>
+        {fullRole?.summary && <p className="font-medium">{fullRole.summary}</p>}
+        {fullRole?.description && (
+          <p className="mt-1 opacity-90">{fullRole.description}</p>
+        )}
+      </DialogContent>
+    </Dialog>
   ) : (
     badge
   );

--- a/app/src/components/lobby/RoleConfigEntry.tsx
+++ b/app/src/components/lobby/RoleConfigEntry.tsx
@@ -73,7 +73,7 @@ export function RoleConfigEntry(props: RoleConfigEntryProps) {
       className={`py-1 ${isAdvanced ? "flex flex-col gap-1" : "flex items-start gap-2"} ${dimmed ? "text-muted-foreground" : ""}`}
     >
       <span className="min-w-40 flex items-center gap-1">
-        <RoleLabel role={role} gameMode={gameMode} />
+        <RoleLabel role={role} gameMode={gameMode} showTeam />
       </span>
       {readOnly ? (
         roleConfigMode === RoleConfigMode.Advanced ? (


### PR DESCRIPTION
## Summary
- Replace `RoleLabel` tooltip with a `Dialog` for reliable mobile tap support
- Add `showTeam` prop to `RoleLabel`; used in `RoleConfigEntry` to always show team in role config panel
- Change default `showRolesInPlay` from `None` → `ConfiguredOnly` in lobby create route
- Add `RoleGlossaryDialog` to Werewolf lobby, visible regardless of `showConfigToPlayers`

Closes #227

## Test plan
- [ ] On mobile, tap a role badge with an info icon — verify a dialog opens with role name, team, summary, and description
- [ ] In role config panel, verify team is always visible next to each role name (no hover required)
- [ ] Create a new Werewolf lobby and verify roles in play shows "Configured Only" by default
- [ ] In a Werewolf lobby, verify a "View Glossary" button appears for all players (owner and non-owner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)