### PR TITLE
Exclude pnpm-lock.yaml from Prettier formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 dist
 .next
 app/src/components/ui
+pnpm-lock.yaml


### PR DESCRIPTION
## Summary

- Adds `pnpm-lock.yaml` to `.prettierignore`
- Fixes CI format check failures on dependabot PRs (e.g. #251) where Prettier reformats the lockfile generated by dependabot

🤖 Generated with [Claude Code](https://claude.com/claude-code)