### PR TITLE
Update werewolf docs for all implemented roles and features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,8 @@ pnpm tsc --noEmit     # Type check (from app/)
 
 - All user-facing strings must be stored in a co-located copy file (e.g., `ComponentName.copy.ts` or `copy.ts`) for internationalization (i18n) readiness.
 - Do not hardcode display strings inline in components.
+
+## Documentation
+
+- When adding or modifying roles, actions, game settings, or data flow in a game mode, update the corresponding docs in `docs/<game-mode>/` (`roles.md`, `actions.md`, `data-flow.md`).
+- Keep documentation in sync with the code — outdated docs are worse than no docs.

--- a/docs/werewolf/actions.md
+++ b/docs/werewolf/actions.md
@@ -67,8 +67,8 @@ Actions are the mechanism by which the Narrator and players mutate game state. E
 ### `reveal-investigation-result`
 
 **Who:** Narrator only
-**When:** During Nighttime, active phase is an Investigate role (Seer), action is confirmed
-**Effect:** Sets `resultRevealed: true` on the night action. This causes `GameSerializationService` to include the `investigationResult` in the Seer's `PlayerGameState`.
+**When:** During Nighttime, active phase is an Investigate role (Seer, Wizard, One-Eyed Seer, Mystic Seer, Mentalist), action is confirmed
+**Effect:** Sets `resultRevealed: true` on the night action. This causes `GameSerializationService` to include the `investigationResult` in the investigating player's `PlayerGameState`.
 
 ---
 
@@ -88,6 +88,98 @@ Actions are the mechanism by which the Narrator and players mutate game state. E
 
 ---
 
+### `start-trial`
+
+**Who:** Narrator only
+**When:** During Daytime
+**Effect:** Starts a trial against a defendant. Pre-populates forced votes (Village Idiot = guilty, Pacifist = innocent). Clears nominations. Blocked by `singleTrialPerDay` if a trial has already concluded this day.
+
+**Payload:** `{ defendantId: string }`
+
+---
+
+### `cast-vote`
+
+**Who:** Player
+**When:** During Daytime (voting phase of an active trial)
+**Effect:** Casts a guilty or innocent vote. Silenced and dead players cannot vote. Hypnotized players' votes mirror the Mummy's vote.
+
+**Payload:** `{ vote: "guilty" | "innocent" }`
+
+---
+
+### `resolve-trial`
+
+**Who:** Narrator only
+**When:** During Daytime (after voting completes)
+**Effect:** Resolves the trial verdict — guilty votes exceeding innocent votes results in elimination. The Mayor's vote counts double. Clears One-Eyed Seer lock and Priest wards for a killed player.
+
+---
+
+### `end-game`
+
+**Who:** Narrator only
+**When:** Any
+**Effect:** Ends the game immediately.
+
+---
+
+### `smite-player`
+
+**Who:** Narrator only
+**When:** During Nighttime
+**Effect:** Marks a player for death by mysterious forces. Smite bypasses all protections (Bodyguard, Doctor, Priest ward, Witch).
+
+**Payload:** `{ playerId: string }`
+
+---
+
+### `unsmite-player`
+
+**Who:** Narrator only
+**When:** During Nighttime
+**Effect:** Removes a pending smite from a player.
+
+**Payload:** `{ playerId: string }`
+
+---
+
+### `nominate-player`
+
+**Who:** Player
+**When:** During Daytime
+**Effect:** Nominates a defendant for trial. When the nomination count reaches the threshold, a trial is automatically started. Blocked by `singleTrialPerDay` if a trial has already concluded this day.
+
+**Payload:** `{ defendantId: string }`
+
+---
+
+### `withdraw-nomination`
+
+**Who:** Player
+**When:** During Daytime
+**Effect:** Withdraws the player's own nomination.
+
+---
+
+### `skip-defense`
+
+**Who:** Narrator only
+**When:** During Daytime (defense phase of an active trial)
+**Effect:** Skips the defense phase and moves the trial directly to voting.
+
+---
+
+### `kill-player`
+
+**Who:** Narrator only
+**When:** During Daytime
+**Effect:** Immediately kills a player (for in-person trials). Checks win condition. Clears One-Eyed Seer lock and Priest wards for the killed player.
+
+**Payload:** `{ playerId: string }`
+
+---
+
 ## Action Payload Summary
 
 | Action                        | Caller                    | Payload                                                |
@@ -100,16 +192,27 @@ Actions are the mechanism by which the Narrator and players mutate game state. E
 | `reveal-investigation-result` | Narrator                  | none                                                   |
 | `mark-player-dead`            | Narrator                  | `{ playerId: string }`                                 |
 | `mark-player-alive`           | Narrator                  | `{ playerId: string }`                                 |
+| `start-trial`                 | Narrator                  | `{ defendantId: string }`                              |
+| `cast-vote`                   | Player                    | `{ vote: "guilty" \| "innocent" }`                     |
+| `resolve-trial`               | Narrator                  | none                                                   |
+| `end-game`                    | Narrator                  | none                                                   |
+| `smite-player`                | Narrator                  | `{ playerId: string }`                                 |
+| `unsmite-player`              | Narrator                  | `{ playerId: string }`                                 |
+| `nominate-player`             | Player                    | `{ defendantId: string }`                              |
+| `withdraw-nomination`         | Player                    | none                                                   |
+| `skip-defense`                | Narrator                  | none                                                   |
+| `kill-player`                 | Narrator                  | `{ playerId: string }`                                 |
 
 ## Night Action Types
 
 ```typescript
-// Solo role action (Seer, Bodyguard, Witch, Spellcaster, Chupacabra)
+// Solo role action (Seer, Bodyguard, Witch, Spellcaster, Chupacabra, Doctor, Priest, Mummy, Wizard, One-Eyed Seer, Exposer, Mystic Seer, Altruist)
 interface NightAction {
   targetPlayerId?: string; // absent when skipped
   skipped?: true; // set when the player intentionally chose "Skip"
   confirmed?: boolean;
-  resultRevealed?: boolean; // Seer only
+  resultRevealed?: boolean; // Seer, Wizard, One-Eyed Seer, Mystic Seer
+  secondTargetPlayerId?: string; // Mentalist dual-target
 }
 
 // Individual vote within a group phase
@@ -131,26 +234,54 @@ interface TeamNightAction {
 
 `resolveNightActions()` runs when `start-day` is called:
 
-1. Collects base attacks and protections from all roles except Witch and Spellcaster.
-2. Applies Witch action: if target is already under attack → protect; otherwise → attack.
-3. Applies Spellcaster action: emits a `silenced` event.
-4. Returns `NightResolutionEvent[]`:
+1. Collects base attacks and protections from all roles except Witch, Altruist, Spellcaster, and Mummy.
+2. Applies Priest ward protection: any player with an active ward has the ward consume the attack (ward is removed, player survives).
+3. Applies Witch action: if target is already under attack → protect; otherwise → attack.
+4. Applies Altruist action (last): if the Altruist's target is under attack, the attack is redirected onto the Altruist (the Altruist dies instead).
+5. Applies Tough Guy absorption: if a Tough Guy is attacked for the first time, the attack is absorbed (survives this night, dies on the next attack).
+6. Applies Smite: any smited player is killed regardless of protections.
+7. Applies Spellcaster action: emits a `silenced` event.
+8. Applies Mummy action: emits a `hypnotized` event for the target.
+9. Returns `NightResolutionEvent[]`:
    - `{ type: "killed", targetPlayerId, attackedBy, protectedBy, died }`
    - `{ type: "silenced", targetPlayerId }`
+   - `{ type: "hypnotized", targetPlayerId }`
+   - `{ type: "tough-guy-absorbed", targetPlayerId }`
+   - `{ type: "altruist-intercepted", targetPlayerId }`
 
 ```mermaid
 flowchart TD
-    Start([start-day called]) --> Collect[Collect attacks and protections\nfrom Werewolves, Bodyguard, Chupacabra]
-    Collect --> Witch{Witch used ability?}
+    Start([start-day called]) --> Collect[Collect attacks and protections\nfrom Werewolves, Bodyguard, Doctor, Chupacabra]
+    Collect --> Priest{Priest ward active\non target?}
+    Priest -->|yes| WardAbsorb[Ward absorbs attack\nremove ward]
+    Priest -->|no| Witch
+    WardAbsorb --> Witch
+    Witch{Witch used ability?}
     Witch -->|protect target| Protect[Remove pending attack on target]
     Witch -->|attack target| NewAttack[Add new attack on target]
-    Witch -->|skipped| Spellcaster
-    Protect --> Spellcaster
-    NewAttack --> Spellcaster
+    Witch -->|skipped| Altruist
+    Protect --> Altruist
+    NewAttack --> Altruist
+    Altruist{Altruist target\nunder attack?}
+    Altruist -->|yes| Intercept[Redirect attack onto Altruist\nemit altruist-intercepted]
+    Altruist -->|no| ToughGuy
+    Intercept --> ToughGuy
+    ToughGuy{Tough Guy attacked\nfor first time?}
+    ToughGuy -->|yes| Absorb[Absorb attack\nemit tough-guy-absorbed]
+    ToughGuy -->|no| Smite
+    Absorb --> Smite
+    Smite{Player smited?}
+    Smite -->|yes| ForceDeath[Force death regardless\nof protections]
+    Smite -->|no| Spellcaster
+    ForceDeath --> Spellcaster
     Spellcaster{Spellcaster acted?}
     Spellcaster -->|yes| Silence[Emit silenced event for target]
-    Spellcaster -->|no| Resolve
-    Silence --> Resolve
+    Spellcaster -->|no| Mummy
+    Silence --> Mummy
+    Mummy{Mummy acted?}
+    Mummy -->|yes| Hypnotize[Emit hypnotized event for target]
+    Mummy -->|no| Resolve
+    Hypnotize --> Resolve
     Resolve[For each collected attack:\nif protected → died = false\nelse → died = true\nemit killed event]
     Resolve --> Return([Return NightResolutionEvent array])
 ```

--- a/docs/werewolf/data-flow.md
+++ b/docs/werewolf/data-flow.md
@@ -30,6 +30,8 @@ The Narrator's session is stored separately and receives a different (fuller) `P
 | `rolesInPlay`            | ✓               | ✓                               |
 | `deadPlayerIds`          | ✓               | ✓                               |
 | `timerConfig`            | ✓ (if set)      | ✓ (if set)                      |
+| `nominationsEnabled`     | ✓               | ✓                               |
+| `singleTrialPerDay`      | ✓               | ✓                               |
 
 ### Narrator-Only (Nighttime)
 
@@ -41,23 +43,34 @@ The Narrator's session is stored separately and receives a different (fuller) `P
 
 These fields are only populated when the active phase matches the player's role.
 
-| Field                    | Roles                                           | Description                                                                                                                                                                               |
-| ------------------------ | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `myNightTarget`          | All night-waking roles                          | Selected target player ID (`string`), intentional skip (`null`), or undecided (`undefined`)                                                                                               |
-| `myNightTargetConfirmed` | All night-waking roles                          | Whether the selection is locked in                                                                                                                                                        |
-| `teamVotes`              | Werewolf (group phase)                          | `({ playerName, targetPlayerId } \| { playerName, skipped: true })[]` — all alive group members' current votes                                                                            |
-| `suggestedTargetId`      | Werewolf (group phase)                          | The plurality vote target (undefined if tie or all skipped)                                                                                                                               |
-| `allAgreed`              | Werewolf (group phase)                          | `true` when all alive members have voted for the same target or all have skipped                                                                                                          |
-| `investigationResult`    | Seer                                            | `{ targetPlayerId, isWerewolfTeam }` — only after Narrator calls `reveal-investigation-result`                                                                                            |
-| `witchAbilityUsed`       | Witch                                           | `false` when ability is available; `true` once used                                                                                                                                       |
-| `nightStatus`            | Witch (ability available)                       | `{ targetPlayerId, effect: "attacked" }[]` — players currently under attack this night                                                                                                    |
-| `previousNightTargetId`  | Bodyguard, Spellcaster; Werewolf (second phase) | Player ID unavailable this turn: previous night's target for `preventRepeatTarget` roles; first phase's `suggestedTargetId` for the second Werewolf attack phase (within-night exclusion) |
+| Field                       | Roles                                               | Description                                                                                                                                                                               |
+| --------------------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `myNightTarget`             | All night-waking roles                              | Selected target player ID (`string`), intentional skip (`null`), or undecided (`undefined`)                                                                                               |
+| `myNightTargetConfirmed`    | All night-waking roles                              | Whether the selection is locked in                                                                                                                                                        |
+| `teamVotes`                 | Werewolf (group phase)                              | `({ playerName, targetPlayerId } \| { playerName, skipped: true })[]` — all alive group members' current votes                                                                            |
+| `suggestedTargetId`         | Werewolf (group phase)                              | The plurality vote target (undefined if tie or all skipped)                                                                                                                               |
+| `allAgreed`                 | Werewolf (group phase)                              | `true` when all alive members have voted for the same target or all have skipped                                                                                                          |
+| `investigationResult`       | Seer, Wizard, One-Eyed Seer, Mystic Seer, Mentalist | `{ targetPlayerId, isWerewolfTeam }` (or exact role for Mystic Seer, or same-team result for Mentalist) — only after Narrator calls `reveal-investigation-result`                         |
+| `witchAbilityUsed`          | Witch                                               | `false` when ability is available; `true` once used                                                                                                                                       |
+| `nightStatus`               | Witch (ability available)                           | `{ targetPlayerId, effect: "attacked" }[]` — players currently under attack this night                                                                                                    |
+| `previousNightTargetId`     | Bodyguard, Spellcaster; Werewolf (second phase)     | Player ID unavailable this turn: previous night's target for `preventRepeatTarget` roles; first phase's `suggestedTargetId` for the second Werewolf attack phase (within-night exclusion) |
+| `priestWardActive`          | Priest                                              | Whether the Priest's ward is currently active on a player                                                                                                                                 |
+| `mySecondNightTarget`       | Mentalist                                           | The Mentalist's second target for dual-target investigation                                                                                                                               |
+| `elusiveSeerVillagerIds`    | Elusive Seer                                        | List of player IDs who have the Villager role (shown on first night only)                                                                                                                 |
+| `oneEyedSeerLockedTargetId` | One-Eyed Seer                                       | Player ID the One-Eyed Seer is locked onto after detecting a werewolf                                                                                                                     |
 
 ### Player Fields — Daytime (day start)
 
-| Field         | Description                                                                            |
-| ------------- | -------------------------------------------------------------------------------------- |
-| `nightStatus` | `{ targetPlayerId, effect: "killed" \| "silenced" }[]` — outcome of the previous night |
+| Field                    | Description                                                                                                                                 |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `nightStatus`            | `{ targetPlayerId, effect }[]` — outcome of the previous night. Effects: `"killed"`, `"silenced"`, `"hypnotized"`, `"smited"`, `"survived"` |
+| `nominations`            | Current nominations for trial defendants                                                                                                    |
+| `myNominatedDefendantId` | The defendant this player has nominated (if any)                                                                                            |
+| `activeTrial`            | Active trial state (defendant, phase, votes) if a trial is in progress                                                                      |
+| `isSilenced`             | Whether this player is silenced (cannot vote or nominate)                                                                                   |
+| `isHypnotized`           | Whether this player is hypnotized (vote mirrors the Mummy)                                                                                  |
+| `exposerReveal`          | Publicly revealed role from the Exposer's ability (if any)                                                                                  |
+| `altruistSave`           | Information about an Altruist intercept that saved a player                                                                                 |
 
 ## Game Phase State Machine
 
@@ -124,10 +137,18 @@ Player confirms (confirm-night-target)
 
 Narrator reveals investigation (reveal-investigation-result)
   → nightActions[phaseKey].resultRevealed = true
-  → Seer's PlayerGameState gains investigationResult
+  → Investigator's PlayerGameState gains investigationResult (Seer, Wizard, One-Eyed Seer, Mystic Seer, Mentalist)
 
 Narrator starts day (start-day)
-  → resolveNightActions() runs
+  → resolveNightActions() runs:
+    1. Collect attacks/protections (Werewolves, Bodyguard, Doctor, Chupacabra)
+    2. Apply Priest wards (ward absorbs attack, ward is consumed)
+    3. Apply Witch action (protect or attack)
+    4. Apply Altruist intercept (redirects attack onto self)
+    5. Apply Tough Guy absorption (survives first attack)
+    6. Apply Smite (forced death regardless of protections)
+    7. Apply Spellcaster silence and Mummy hypnotize
+    8. Resolve remaining attacks (protected → survived, else → killed)
   → Killed players added to deadPlayerIds
   → nightResolution stored in daytime phase
   → PlayerGameState rebuilt: nightStatus and myLastNightAction populated
@@ -136,10 +157,27 @@ Narrator starts day (start-day)
 ### Day Phase
 
 ```
-Players discuss and vote (outside the app)
-Narrator marks players dead (mark-player-dead / mark-player-alive)
-  → deadPlayerIds updated
-  → Dead player's role revealed in visibleRoleAssignments for all
+Players discuss and may nominate defendants (nominate-player / withdraw-nomination)
+  → nominations updated for all players
+  → When nomination threshold is reached, trial starts automatically
+
+Trial flow (if nominations are enabled):
+  1. Nominations → threshold reached or Narrator calls start-trial
+  2. Defense phase → defendant speaks (Narrator may skip-defense)
+  3. Voting phase → players cast-vote (guilty/innocent)
+     - Village Idiot votes are forced guilty
+     - Pacifist votes are forced innocent
+     - Hypnotized votes mirror the Mummy
+     - Silenced/dead players cannot vote
+     - Mayor's vote counts double
+  4. Narrator calls resolve-trial → guilty > innocent = eliminated
+     - Clears OES lock and Priest wards for killed player
+
+Narrator may also:
+  - kill-player → immediately kills a player (for in-person trials)
+  - mark-player-dead / mark-player-alive → manual dead state management
+    → deadPlayerIds updated
+    → Dead player's role revealed in visibleRoleAssignments for all
 
 Narrator starts next night (start-night)
   → New turn begins; nightPhaseOrder rebuilt

--- a/docs/werewolf/roles.md
+++ b/docs/werewolf/roles.md
@@ -6,18 +6,32 @@ Each player is secretly assigned one role. The Narrator has no role and runs the
 
 ## Role Table
 
-| Role          | ID                       | Team    | Wakes at Night     | Night Action         | Notes                                                                                                       |
-| ------------- | ------------------------ | ------- | ------------------ | -------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Villager      | `werewolf-villager`      | Good    | Never              | —                    | Baseline good-team role                                                                                     |
-| Werewolf      | `werewolf-werewolf`      | Bad     | Every Night        | Attack (group vote)  | Sees all Bad-team players; votes jointly with other Werewolves and Wolf Cubs                                |
-| Wolf Cub      | `werewolf-wolf-cub`      | Bad     | Every Night        | Attack (group vote)  | Wakes with Werewolves (`wakesWith`); when killed, Werewolves receive two attack phases the following night  |
-| Seer          | `werewolf-seer`          | Good    | Every Night        | Investigate          | Learns whether the target is on Team Bad; Narrator reveals result                                           |
-| Bodyguard     | `werewolf-bodyguard`     | Good    | Every Night        | Protect              | Chosen target survives any attack that night; cannot protect the same player on consecutive nights          |
-| Witch         | `werewolf-witch`         | Good    | Every Night (last) | Special (once)       | After all other roles act, may protect the attacked player **or** attack any other player; one-time ability |
-| Spellcaster   | `werewolf-spellcaster`   | Good    | Every Night        | Silence              | Target is silenced the following day; cannot silence the same player on consecutive nights                  |
-| Mason         | `werewolf-mason`         | Good    | First Night Only   | —                    | Masons see each other's identities; no action after night 1                                                 |
-| Chupacabra    | `werewolf-chupacabra`    | Neutral | Every Night        | Attack (conditional) | Attack lands only if target is on Team Bad, **or** if all Team Bad players are already dead                 |
-| Village Idiot | `werewolf-village-idiot` | Good    | Never              | —                    | Baseline good-team role                                                                                     |
+| Role          | ID                       | Team    | Wakes at Night            | Night Action         | Notes                                                                                                                         |
+| ------------- | ------------------------ | ------- | ------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Villager      | `werewolf-villager`      | Good    | Never                     | —                    | Baseline good-team role                                                                                                       |
+| Werewolf      | `werewolf-werewolf`      | Bad     | Every Night               | Attack (group vote)  | Sees all Bad-team players; votes jointly with other Werewolves and Wolf Cubs; `teamTargeting`, `isWerewolf`                   |
+| Wolf Cub      | `werewolf-wolf-cub`      | Bad     | Every Night               | Attack (group vote)  | Wakes with Werewolves (`wakesWith`); when killed, Werewolves receive two attack phases the following night; `isWerewolf`      |
+| Seer          | `werewolf-seer`          | Good    | Every Night               | Investigate          | Learns whether the target is on Team Bad; Narrator reveals result                                                             |
+| Witch         | `werewolf-witch`         | Good    | Every Night (2nd-to-last) | Special (once)       | After all other roles act (except Altruist), may protect the attacked player **or** attack any other player; one-time ability |
+| Spellcaster   | `werewolf-spellcaster`   | Good    | Every Night               | Special (silence)    | Target is silenced the following day; cannot silence the same player on consecutive nights (`preventRepeatTarget`)            |
+| Mason         | `werewolf-mason`         | Good    | First Night Only          | —                    | Masons see each other's identities (`awareOf: Masons`); no action after night 1                                               |
+| Chupacabra    | `werewolf-chupacabra`    | Neutral | Every Night               | Attack (conditional) | Attack lands only if target is on Team Bad, **or** if all Team Bad players are already dead                                   |
+| Village Idiot | `werewolf-village-idiot` | Good    | Never                     | —                    | Vote is forced to guilty during trials (`alwaysVotesGuilty`)                                                                  |
+| Bodyguard     | `werewolf-bodyguard`     | Good    | Every Night               | Protect              | Chosen target survives any attack that night; cannot protect the same player on consecutive nights (`preventRepeatTarget`)    |
+| Doctor        | `werewolf-doctor`        | Good    | Every Night               | Protect              | Chosen target survives any attack that night; cannot protect self (`preventSelfTarget`)                                       |
+| Priest        | `werewolf-priest`        | Good    | Every Night               | Protect              | Places a persistent ward on the target; ward absorbs the next attack on that player                                           |
+| Tough Guy     | `werewolf-tough-guy`     | Good    | Never                     | —                    | Survives the first attack; dies to a subsequent attack                                                                        |
+| Minion        | `werewolf-minion`        | Bad     | First Night Only          | —                    | Sees all werewolf players (`awareOf: werewolves`); werewolves do not know the Minion's identity                               |
+| Pacifist      | `werewolf-pacifist`      | Good    | Never                     | —                    | Vote is forced to innocent during trials (`alwaysVotesInnocent`)                                                              |
+| Mayor         | `werewolf-mayor`         | Good    | Never                     | —                    | Vote counts double during trials (secret — not revealed to other players)                                                     |
+| Mummy         | `werewolf-mummy`         | Good    | Every Night               | Special (hypnotize)  | Hypnotizes target's vote the following day — their vote mirrors the Mummy's vote                                              |
+| Wizard        | `werewolf-wizard`        | Bad     | Every Night               | Investigate          | Checks whether the target is the Seer (`checksForSeer`)                                                                       |
+| One-Eyed Seer | `werewolf-one-eyed-seer` | Good    | Every Night               | Investigate          | Learns whether target is on Team Bad; if a werewolf is detected, locks onto that player for future nights                     |
+| Exposer       | `werewolf-exposer`       | Good    | Every Night               | Special (reveal)     | Reveals target's role publicly; one-time ability (`oncePerGame`)                                                              |
+| Elusive Seer  | `werewolf-elusive-seer`  | Good    | First Night Only          | —                    | Sees all Villager-role players on the first night                                                                             |
+| Mentalist     | `werewolf-mentalist`     | Good    | Every Night               | Investigate (dual)   | Selects two players and learns whether they are on the same team (`dualTargetInvestigate`)                                    |
+| Mystic Seer   | `werewolf-mystic-seer`   | Good    | Every Night               | Investigate          | Learns the target's exact role, not just their team (`revealsExactRole`)                                                      |
+| Altruist      | `werewolf-altruist`      | Good    | Every Night (last)        | Special (intercept)  | Acts after the Witch (last in night order); intercepts an attack on the target and dies in their place                        |
 
 ## Role Properties
 
@@ -28,11 +42,20 @@ interface WerewolfRoleDefinition {
   team: Team; // Good | Bad | Neutral
   wakesAtNight: WakesAtNight; // Never | FirstNightOnly | EveryNight
   targetCategory: TargetCategory; // None | Attack | Protect | Investigate | Special
+  category?: string; // Display category for role selection UI
   canSeeTeam?: Team[]; // Teams whose members this role can see
   canSeeRole?: WerewolfRole[]; // Specific roles this role can identify
   teamTargeting?: boolean; // True = primary role for a group phase (Werewolves vote together)
   preventRepeatTarget?: boolean; // True = cannot target the same player on consecutive nights (Bodyguard, Spellcaster)
+  preventSelfTarget?: boolean; // True = cannot target self (Doctor)
   wakesWith?: WerewolfRole; // Secondary role that silently joins the referenced role's group phase
+  isWerewolf?: boolean; // True = counts as a werewolf for investigation and win-condition purposes (Werewolf, Wolf Cub)
+  alwaysVotesGuilty?: boolean; // True = vote is forced to guilty during trials (Village Idiot)
+  alwaysVotesInnocent?: boolean; // True = vote is forced to innocent during trials (Pacifist)
+  checksForSeer?: boolean; // True = investigates whether target is the Seer (Wizard)
+  revealsExactRole?: boolean; // True = investigation reveals the exact role, not just team (Mystic Seer)
+  dualTargetInvestigate?: boolean; // True = selects two targets and learns if they share a team (Mentalist)
+  oncePerGame?: boolean; // True = ability can only be used once (Exposer)
 }
 ```
 
@@ -44,7 +67,8 @@ Roles wake in the order they are defined in `WEREWOLF_ROLES`, subject to these r
 2. Roles with `wakesAtNight: FirstNightOnly` are skipped on turn 2+.
 3. A role is skipped if all players assigned to it are dead.
 4. Roles with `wakesWith` do not get their own phase — they participate in the primary role's phase.
-5. The Witch always acts **last**, after all other roles, so she can see current attacks before deciding.
+5. The Witch acts **second-to-last**, after all other roles except the Altruist, so she can see current attacks before deciding.
+6. The Altruist always acts **last**, after the Witch, so it can intercept attacks (including Witch attacks) on its target.
 
 ## Default Role Distribution
 
@@ -60,8 +84,9 @@ Additional roles (Bodyguard, Witch, etc.) are configured per game in the lobby.
 
 ## Visibility Rules
 
-- **Werewolves** see all other Team Bad players (`canSeeTeam: [Team.Bad]`), including Wolf Cubs.
+- **Werewolves** see all other Team Bad players (`canSeeTeam: [Team.Bad]`), including Wolf Cubs and Minion.
 - **Wolf Cubs** see all other Team Bad players (`canSeeTeam: [Team.Bad]`), including Werewolves.
+- **Minion** sees all werewolf players (`awareOf: werewolves`) on the first night. Werewolves do **not** see the Minion (the Minion is Team Bad but awareness is one-directional).
 - **Masons** see all other Masons (`canSeeRole: [Mason]`).
 - **Dead players** have their roles revealed to all living players automatically.
 - All other roles see only their own identity.
@@ -69,6 +94,7 @@ Additional roles (Bodyguard, Witch, etc.) are configured per game in the lobby.
 ```mermaid
 graph LR
     WW[Werewolf] -->|sees all| Bad[Team Bad players]
+    Minion -->|sees all| WWs[Werewolf players]
     Mason -->|sees all| Masons[Other Masons]
     All[All players] -->|see roles of| Dead[Dead players]
     Narrator -->|sees all| Assignments[All role assignments]
@@ -88,9 +114,12 @@ flowchart TD
     Alive -->|No| Skip
     Alive -->|Yes| Add[Add phase key to order]
     Add --> IsWitch{Is Witch?}
-    IsWitch -->|Yes| MoveLast[Move to end of order]
-    IsWitch -->|No| Next
-    MoveLast --> Next[Next role]
+    IsWitch -->|Yes| MoveSecondLast[Move to second-to-last]
+    IsWitch -->|No| IsAltruist{Is Altruist?}
+    IsAltruist -->|Yes| MoveLast[Move to end of order]
+    IsAltruist -->|No| Next
+    MoveSecondLast --> Next[Next role]
+    MoveLast --> Next
     Skip --> Next
     SkipOwn --> Next
     Next --> Done([nightPhaseOrder complete])


### PR DESCRIPTION
## Summary

Comprehensive documentation update for `docs/werewolf/` to reflect the current codebase state — the docs were 15 roles and 10 actions behind.

### roles.md
- Role table expanded from 10 to all 25 implemented roles
- Role Properties interface updated with all current fields
- Night phase ordering updated (Witch second-to-last, Altruist last)
- Visibility rules updated (Minion awareness of werewolves)

### actions.md
- Added 10 missing actions (trial flow, nominations, smite, kill-player)
- Night resolution rewritten with full 8-step pipeline
- All 5 NightResolutionEvent types documented

### data-flow.md
- PlayerGameState tables updated with all current fields
- Day phase section rewritten with full trial flow
- Night resolution pipeline expanded

### AGENTS.md
- Added documentation maintenance directive: update docs when changing roles, actions, settings, or data flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)