### PR TITLE
Add auto-format CI workflow for Claude-authored commits

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,48 @@
+name: Auto-format
+
+on:
+  push:
+    branches-ignore: ["main"]
+
+jobs:
+  auto-format:
+    name: Auto-format
+    runs-on: ubuntu-latest
+    # Only run on commits co-authored by Claude to avoid unnecessary runs
+    # and prevent loops (this workflow's own commits have no co-author)
+    if: "contains(github.event.head_commit.message, 'Co-Authored-By: Claude')"
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run Prettier
+        run: pnpm prettier --write .
+
+      - name: Check for changes
+        id: diff
+        run: |
+          git diff --quiet && echo "changed=false" >> "$GITHUB_OUTPUT" || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push formatting fixes
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "style: auto-format"
+          git push


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically fixes Prettier formatting issues on non-main branches when the commit was co-authored by Claude.

## How it works

1. Triggers on push to any branch except `main`
2. Checks if the commit message contains `Co-Authored-By: Claude`
3. If yes, runs `pnpm prettier --write .`
4. If any files changed, commits and pushes the fix

## Loop prevention

- **Trigger filter**: Only runs on commits co-authored by Claude
- **Auto-commit has no co-author**: The `style: auto-format` commit won't match the filter, so it can't re-trigger itself
- **Main excluded**: Never runs on pushes to main

## Why

Worktree agents, cherry-picks, and rebases can bypass the local pre-commit hook, causing CI format checks to fail. This catches those cases automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)