### PR TITLE
Remove deprecated eslint config from next.config.ts

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -1,12 +1,7 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 
-const nextConfig: NextConfig = {
-  eslint: {
-    // Linting is handled at the workspace level via `pnpm lint`
-    ignoreDuringBuilds: true,
-  },
-};
+const nextConfig: NextConfig = {};
 
 export default withSentryConfig(nextConfig, {
   org: process.env["SENTRY_ORG"],


### PR DESCRIPTION
## Summary

Removes the `eslint.ignoreDuringBuilds` key from `next.config.ts`. This key is no longer supported as of Next.js 15.5+ and causes build warnings:

```
⚠ `eslint` configuration in next.config.ts is no longer supported.
⚠ Invalid next.config.ts options detected:
⚠     Unrecognized key(s) in object: 'eslint'
```

Linting is already handled at the workspace level via `pnpm lint`, so this setting was redundant.

Unblocks Dependabot PR #269 (dev-dependencies bump including Next.js).

🤖 Generated with [Claude Code](https://claude.com/claude-code)