### PR TITLE
Fix return-to-lobby reliability (#252)

### DIFF
--- a/app/src/app/[gameMode]/lobby/[lobbyId]/page.tsx
+++ b/app/src/app/[gameMode]/lobby/[lobbyId]/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
-import { getPlayerId, getLobbyId, getSessionId } from "@/lib/api";
+import { getPlayerId, getLobbyId, getSessionId, saveGameId } from "@/lib/api";
 import { GameMode } from "@/lib/types";
 import { parseGameMode } from "@/lib/game-modes";
 import {
@@ -83,9 +83,16 @@ export default function LobbyPage() {
   }, [actualGameMode, validatedGameMode, lobbyId, router]);
 
   // Once the game starts, redirect all players to the game mode page.
+  // Only redirect when gameId transitions from absent to present (game just
+  // started), not when the page loads with gameId already set (e.g. returning
+  // from a finished game before clearGameId propagates).
+  const prevGameIdRef = useRef<string | undefined>(undefined);
   useEffect(() => {
-    if (gameId && actualGameMode)
+    if (gameId && !prevGameIdRef.current && actualGameMode) {
+      saveGameId(gameId);
       router.push(`/${actualGameMode}/game/${gameId}`);
+    }
+    prevGameIdRef.current = gameId;
   }, [gameId, actualGameMode, router]);
 
   // If the lobby doesn't exist or the session is invalid, return to the home page.

--- a/app/src/components/game/werewolf/GameOverScreen.tsx
+++ b/app/src/components/game/werewolf/GameOverScreen.tsx
@@ -95,6 +95,11 @@ export function GameOverScreen({ gameState }: GameOverScreenProps) {
       >
         {WEREWOLF_COPY.gameOver.returnToLobby}
       </Button>
+      {returnToLobbyMutation.isError && (
+        <p className="text-destructive text-sm mt-2 text-center">
+          {WEREWOLF_COPY.gameOver.returnToLobbyError}
+        </p>
+      )}
     </div>
   );
 }

--- a/app/src/hooks/lobby.ts
+++ b/app/src/hooks/lobby.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import {
+  clearGameId,
   createLobby,
   joinLobby,
   removePlayer,
@@ -78,6 +79,7 @@ export function useReturnToLobby(lobbyId: string) {
     mutationFn: () => returnToLobby(lobbyId),
     onSuccess: (response) => {
       if (response.status === ServerResponseStatus.Error) return;
+      clearGameId();
       router.push(`/${response.data.lobby.config.gameMode}/lobby/${lobbyId}`);
     },
   });

--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -11,6 +11,7 @@ import { ServerResponseStatus } from "@/server/types";
 const SESSION_KEY = "x-session-id";
 const PLAYER_ID_KEY = "player-id";
 const LOBBY_ID_KEY = "lobby-id";
+const GAME_ID_KEY = "game-id";
 
 export function getSessionId(): string | undefined {
   if (typeof window === "undefined") return undefined;
@@ -39,10 +40,24 @@ function saveLobbyId(lobbyId: string): void {
   localStorage.setItem(LOBBY_ID_KEY, lobbyId);
 }
 
+export function getGameId(): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  return localStorage.getItem(GAME_ID_KEY) ?? undefined;
+}
+
+export function saveGameId(gameId: string): void {
+  localStorage.setItem(GAME_ID_KEY, gameId);
+}
+
+export function clearGameId(): void {
+  localStorage.removeItem(GAME_ID_KEY);
+}
+
 export function clearSession(): void {
   localStorage.removeItem(SESSION_KEY);
   localStorage.removeItem(PLAYER_ID_KEY);
   localStorage.removeItem(LOBBY_ID_KEY);
+  localStorage.removeItem(GAME_ID_KEY);
 }
 
 function saveJoinData(

--- a/app/src/lib/game-modes/werewolf/copy.ts
+++ b/app/src/lib/game-modes/werewolf/copy.ts
@@ -126,6 +126,7 @@ export const WEREWOLF_COPY = {
     endGame: "End Game",
     rolesRevealHeading: "Final Roles",
     returnToLobby: "Return to Lobby",
+    returnToLobbyError: "Failed to return to lobby. Please try again.",
   },
   nomination: {
     heading: "Nominate for Trial",


### PR DESCRIPTION
## Summary

Fixes #252 — "Return to lobby" button not working reliably on slow connections.

## Root causes and fixes

### 1. Lobby page redirects to finished games
The lobby page unconditionally redirected to the game when `gameId` was set, even if the game was finished. On slow connections, the `clearGameId` API call hadn't propagated yet, causing the user to bounce right back to the game.

**Fix:** The redirect now only fires when `gameId` transitions from absent to present (game just started), tracked via a ref. If the page loads with `gameId` already set (returning from a finished game), the redirect is suppressed.

### 2. No error feedback on return-to-lobby failure
When the `returnToLobby` mutation failed (slow connection, timeout), the button re-enabled silently with no indication that anything went wrong.

**Fix:** `GameOverScreen` now displays an error message when the mutation fails: "Failed to return to lobby. Please try again."

### 3. No gameId in localStorage
Session recovery was limited because `gameId` was not stored locally. Only `sessionId`, `playerId`, and `lobbyId` were persisted.

**Fix:** `gameId` is now saved to localStorage when the game starts and cleared on successful return-to-lobby. This enables future session recovery features.

## Test plan

- [ ] Click "Return to Lobby" on game over screen — should navigate to lobby
- [ ] Return to lobby on slow connection — should show error if mutation fails
- [ ] Lobby page should not redirect back to a finished game
- [ ] Starting a new game should redirect to the game page normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)