### PR TITLE
Show personalized defense speech text for defendant (#278)

### DIFF
--- a/app/src/components/game/werewolf/TrialVotePanel.tsx
+++ b/app/src/components/game/werewolf/TrialVotePanel.tsx
@@ -108,10 +108,12 @@ export function TrialVotePanel({
   ) : activeTrial.phase === "defense" ? (
     <>
       <p className="font-semibold mb-1">
-        {trial.defenseHeading(defendantName)}
+        {isDefendant
+          ? trial.defenseHeadingSelf
+          : trial.defenseHeading(defendantName)}
       </p>
       <p className="text-sm text-muted-foreground mb-2">
-        {trial.defenseSubtext}
+        {isDefendant ? trial.defenseSubtextSelf : trial.defenseSubtext}
       </p>
       {isDefendant && isSilenced && (
         <p className="text-sm italic text-muted-foreground mb-2">

--- a/app/src/lib/game-modes/werewolf/copy.ts
+++ b/app/src/lib/game-modes/werewolf/copy.ts
@@ -89,6 +89,8 @@ export const WEREWOLF_COPY = {
     resolveTrial: "Resolve Trial",
     defenseHeading: (name: string) => `${name} has the floor`,
     defenseSubtext: "The accused may speak in their defense.",
+    defenseHeadingSelf: "You have the floor",
+    defenseSubtextSelf: "Speak now in your own defense.",
     defenseSilenced: [
       "Bad time to lose your voice.",
       "Cat got your tongue?",


### PR DESCRIPTION
## Summary

Fixes #278 — The defendant now sees personalized text during the defense phase instead of the same third-person message everyone else sees.

### Before
Everyone (including the defendant) sees:
> **Player 4 has the floor**
> The accused may speak in their defense.

### After
The defendant sees:
> **You have the floor**
> Speak now in your own defense.

Other players still see the original third-person text.

## Changes

- `copy.ts`: Added `defenseHeadingSelf` and `defenseSubtextSelf` strings
- `TrialVotePanel.tsx`: Uses `isDefendant` (already computed) to switch between self/other text

🤖 Generated with [Claude Code](https://claude.com/claude-code)