### PR TITLE
Implement narrator cancel trial (#259)

### DIFF
--- a/app/src/components/game/werewolf/OwnerTrialPanel.tsx
+++ b/app/src/components/game/werewolf/OwnerTrialPanel.tsx
@@ -45,6 +45,10 @@ export function OwnerTrialPanel({
     action.mutate({ actionId: WerewolfAction.SkipDefense });
   }, [action]);
 
+  const handleCancelTrial = useCallback(() => {
+    action.mutate({ actionId: WerewolfAction.CancelTrial });
+  }, [action]);
+
   const { trial } = WEREWOLF_COPY;
   const verdictLabel = activeTrial.verdict
     ? activeTrial.verdict === "eliminated"
@@ -82,14 +86,24 @@ export function OwnerTrialPanel({
           <p className="text-sm text-muted-foreground mb-3">
             {trial.defenseSubtext}
           </p>
-          <Button
-            size="sm"
-            className="w-full max-w-xs"
-            onClick={handleSkipDefense}
-            disabled={action.isPending}
-          >
-            {trial.skipDefense}
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              className="flex-1"
+              onClick={handleSkipDefense}
+              disabled={action.isPending}
+            >
+              {trial.skipDefense}
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleCancelTrial}
+              disabled={action.isPending}
+            >
+              {trial.cancelTrial}
+            </Button>
+          </div>
         </>
       ) : (
         <>
@@ -119,14 +133,24 @@ export function OwnerTrialPanel({
               ))}
             </ul>
           )}
-          <Button
-            size="sm"
-            className="w-full max-w-xs"
-            onClick={handleResolve}
-            disabled={action.isPending}
-          >
-            {trial.resolveTrial}
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              className="flex-1"
+              onClick={handleResolve}
+              disabled={action.isPending}
+            >
+              {trial.resolveTrial}
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleCancelTrial}
+              disabled={action.isPending}
+            >
+              {trial.cancelTrial}
+            </Button>
+          </div>
         </>
       )}
     </div>

--- a/app/src/lib/game-modes/werewolf/actions/cancel-trial.test.ts
+++ b/app/src/lib/game-modes/werewolf/actions/cancel-trial.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { WerewolfPhase } from "../types";
+import type { WerewolfTurnState, WerewolfDaytimePhase } from "../types";
+import { WerewolfAction, WEREWOLF_ACTIONS } from "./index";
+import { makePlayingGame } from "./test-helpers";
+
+function makeDayStateWithTrial(
+  phase: "defense" | "voting",
+  verdict?: "eliminated" | "innocent",
+): WerewolfTurnState {
+  return {
+    turn: 1,
+    phase: {
+      type: WerewolfPhase.Daytime,
+      startedAt: 1000,
+      nightActions: {},
+      activeTrial: {
+        defendantId: "p2",
+        startedAt: 2000,
+        phase,
+        votes: [],
+        ...(verdict ? { verdict } : {}),
+      },
+    },
+    deadPlayerIds: [],
+  };
+}
+
+describe("WerewolfAction.CancelTrial", () => {
+  const action = WEREWOLF_ACTIONS[WerewolfAction.CancelTrial];
+
+  describe("isValid", () => {
+    it("returns true during defense phase", () => {
+      const game = makePlayingGame(makeDayStateWithTrial("defense"));
+      expect(action.isValid(game, "owner-1", null)).toBe(true);
+    });
+
+    it("returns true during voting phase", () => {
+      const game = makePlayingGame(makeDayStateWithTrial("voting"));
+      expect(action.isValid(game, "owner-1", null)).toBe(true);
+    });
+
+    it("returns false after verdict", () => {
+      const game = makePlayingGame(
+        makeDayStateWithTrial("voting", "eliminated"),
+      );
+      expect(action.isValid(game, "owner-1", null)).toBe(false);
+    });
+
+    it("returns false when no active trial", () => {
+      const ts: WerewolfTurnState = {
+        turn: 1,
+        phase: {
+          type: WerewolfPhase.Daytime,
+          startedAt: 1000,
+          nightActions: {},
+        },
+        deadPlayerIds: [],
+      };
+      const game = makePlayingGame(ts);
+      expect(action.isValid(game, "owner-1", null)).toBe(false);
+    });
+
+    it("returns false for non-owner", () => {
+      const game = makePlayingGame(makeDayStateWithTrial("defense"));
+      expect(action.isValid(game, "p2", null)).toBe(false);
+    });
+  });
+
+  describe("apply", () => {
+    it("clears activeTrial entirely", () => {
+      const game = makePlayingGame(makeDayStateWithTrial("voting"));
+      action.apply(game, null, "owner-1");
+      const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
+      const phase = ts.phase as WerewolfDaytimePhase;
+      expect(phase.activeTrial).toBeUndefined();
+    });
+
+    it("does not affect deadPlayerIds", () => {
+      const game = makePlayingGame(makeDayStateWithTrial("defense"));
+      action.apply(game, null, "owner-1");
+      const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
+      expect(ts.deadPlayerIds).toEqual([]);
+    });
+  });
+});

--- a/app/src/lib/game-modes/werewolf/actions/cancel-trial.ts
+++ b/app/src/lib/game-modes/werewolf/actions/cancel-trial.ts
@@ -1,0 +1,22 @@
+import type { Game, GameAction } from "@/lib/types";
+import { WerewolfPhase } from "../types";
+import { currentTurnState, isOwnerPlaying } from "../utils";
+
+export const cancelTrialAction: GameAction = {
+  isValid(game: Game, callerId: string) {
+    if (!isOwnerPlaying(game, callerId)) return false;
+    const ts = currentTurnState(game);
+    if (!ts) return false;
+    if (ts.phase.type !== WerewolfPhase.Daytime) return false;
+    const { activeTrial } = ts.phase;
+    if (!activeTrial) return false;
+    // Can only cancel before a verdict is reached
+    return !activeTrial.verdict;
+  },
+  apply(game: Game) {
+    const ts = currentTurnState(game);
+    if (ts?.phase.type !== WerewolfPhase.Daytime) return;
+    // Remove the trial entirely — as if it never happened
+    ts.phase.activeTrial = undefined;
+  },
+};

--- a/app/src/lib/game-modes/werewolf/actions/index.ts
+++ b/app/src/lib/game-modes/werewolf/actions/index.ts
@@ -19,6 +19,7 @@ import { withdrawNominationAction } from "./withdraw-nomination";
 import { skipDefenseAction } from "./skip-defense";
 import { killPlayerAction } from "./kill-player";
 import { resolveHunterRevengeAction } from "./resolve-hunter-revenge";
+import { cancelTrialAction } from "./cancel-trial";
 
 export const WEREWOLF_ACTIONS: Record<WerewolfAction, GameAction> = {
   [WerewolfAction.StartNight]: startNightAction,
@@ -40,4 +41,5 @@ export const WEREWOLF_ACTIONS: Record<WerewolfAction, GameAction> = {
   [WerewolfAction.SkipDefense]: skipDefenseAction,
   [WerewolfAction.KillPlayer]: killPlayerAction,
   [WerewolfAction.ResolveHunterRevenge]: resolveHunterRevengeAction,
+  [WerewolfAction.CancelTrial]: cancelTrialAction,
 };

--- a/app/src/lib/game-modes/werewolf/actions/types.ts
+++ b/app/src/lib/game-modes/werewolf/actions/types.ts
@@ -18,4 +18,5 @@ export enum WerewolfAction {
   SkipDefense = "skip-defense",
   KillPlayer = "kill-player",
   ResolveHunterRevenge = "resolve-hunter-revenge",
+  CancelTrial = "cancel-trial",
 }

--- a/app/src/lib/game-modes/werewolf/copy.ts
+++ b/app/src/lib/game-modes/werewolf/copy.ts
@@ -95,6 +95,7 @@ export const WEREWOLF_COPY = {
       "Uh, maybe try puppy dog eyes?",
     ],
     skipDefense: "Skip Defense",
+    cancelTrial: "Cancel Trial",
     putToVote: "Put to Vote",
     mustVoteGuiltyNote:
       "As the Village Idiot, your vote was automatically cast as Guilty.",


### PR DESCRIPTION
## Summary

Fixes #259 — The narrator can cancel a trial as if it never happened.

## Behavior

- **Cancel Trial** button appears next to "Skip Defense" (during defense) and "Resolve Trial" (during voting)
- Cancelling clears `activeTrial` entirely — no verdict is recorded
- A new trial can be started after cancellation, even with `singleTrialPerDay` enabled (since `activeTrial.verdict` is cleared, not set)
- The button is only available before a verdict is reached

## Implementation

- `CancelTrial` action: narrator-only, daytime, requires active trial with no verdict. Sets `activeTrial = undefined`.
- `OwnerTrialPanel`: Cancel Trial button in both defense and voting views
- Copy string in `WEREWOLF_COPY.trial.cancelTrial`

## Test plan

- [x] isValid: true during defense phase
- [x] isValid: true during voting phase
- [x] isValid: false after verdict
- [x] isValid: false when no active trial
- [x] isValid: false for non-owner
- [x] apply: clears activeTrial entirely
- [x] apply: does not affect deadPlayerIds

🤖 Generated with [Claude Code](https://claude.com/claude-code)