### PR TITLE
Allow werewolves to target hidden allies (#250)

### DIFF
--- a/app/src/lib/game-modes/werewolf/utils/targeting.test.ts
+++ b/app/src/lib/game-modes/werewolf/utils/targeting.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Team } from "@/lib/types";
 import { WerewolfRole } from "../roles";
-import { getTargetablePlayers } from "./targeting";
+import { getTargetablePlayers, getGroupPhaseMemberIds } from "./targeting";
 
 const players = [
   { id: "owner", name: "Owner" },
@@ -326,5 +326,45 @@ describe("getTargetablePlayers — group phase (suffixed key)", () => {
       p1Assignments,
     );
     expect(result.map((p) => p.id)).toContain("p3");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getGroupPhaseMemberIds — hidden allies are targetable
+// ---------------------------------------------------------------------------
+
+describe("getGroupPhaseMemberIds", () => {
+  it("includes Werewolves and Wolf Cubs (wake-phase participants)", () => {
+    const assignments = [
+      { playerId: "w1", roleDefinitionId: WerewolfRole.Werewolf },
+      { playerId: "wc1", roleDefinitionId: WerewolfRole.WolfCub },
+      { playerId: "p1", roleDefinitionId: WerewolfRole.Villager },
+    ];
+    const result = getGroupPhaseMemberIds(assignments, WerewolfRole.Werewolf);
+    expect(result).toContain("w1");
+    expect(result).toContain("wc1");
+    expect(result).not.toContain("p1");
+  });
+
+  it("does NOT include Wizard (Team.Bad but no wakesWith)", () => {
+    const assignments = [
+      { playerId: "w1", roleDefinitionId: WerewolfRole.Werewolf },
+      { playerId: "wiz1", roleDefinitionId: WerewolfRole.Wizard },
+      { playerId: "p1", roleDefinitionId: WerewolfRole.Villager },
+    ];
+    const result = getGroupPhaseMemberIds(assignments, WerewolfRole.Werewolf);
+    expect(result).toContain("w1");
+    expect(result).not.toContain("wiz1");
+  });
+
+  it("does NOT include Minion (Team.Bad but no wakesWith Werewolf)", () => {
+    const assignments = [
+      { playerId: "w1", roleDefinitionId: WerewolfRole.Werewolf },
+      { playerId: "min1", roleDefinitionId: WerewolfRole.Minion },
+      { playerId: "p1", roleDefinitionId: WerewolfRole.Villager },
+    ];
+    const result = getGroupPhaseMemberIds(assignments, WerewolfRole.Werewolf);
+    expect(result).toContain("w1");
+    expect(result).not.toContain("min1");
   });
 });

--- a/app/src/lib/game-modes/werewolf/utils/targeting.ts
+++ b/app/src/lib/game-modes/werewolf/utils/targeting.ts
@@ -94,23 +94,23 @@ export function getGroupPhasePlayerIds(
 }
 
 /**
- * Returns all player IDs on the same team as the group phase primary role
- * (alive or dead) so they can be excluded from targeting.
+ * Returns all player IDs who participate in the group phase (alive or dead),
+ * based on matching the primary role ID or wakesWith. Hidden allies (e.g.
+ * Wizard, Minion) who share the team but don't wake with the group are NOT
+ * included — they can be targeted by the group.
  */
 export function getGroupPhaseMemberIds(
   roleAssignments: PlayerRoleAssignment[],
   phaseKey: string,
 ): string[] {
-  const primaryRole = (
-    WEREWOLF_ROLES as Record<string, WerewolfRoleDefinition>
-  )[baseGroupPhaseKey(phaseKey)];
-  if (!primaryRole) return [];
+  const baseKey = baseGroupPhaseKey(phaseKey);
   return roleAssignments
     .filter((a) => {
+      if (a.roleDefinitionId === baseKey) return true;
       const role = (WEREWOLF_ROLES as Record<string, WerewolfRoleDefinition>)[
         a.roleDefinitionId
       ];
-      return role?.team === primaryRole.team;
+      return (role?.wakesWith as string | undefined) === baseKey;
     })
     .map((a) => a.playerId);
 }


### PR DESCRIPTION
## Summary

Fixes #250 — Werewolves can now target hidden allies like the Wizard and Minion during the night attack phase.

## Root cause

`getGroupPhaseMemberIds` was using **team membership** (`role.team === primaryRole.team`) to determine which players the narrator couldn't target during a group phase. This incorrectly excluded the Wizard and Minion — they share `Team.Bad` but don't actually participate in the Werewolf wake phase.

## Fix

Changed `getGroupPhaseMemberIds` to check **actual group phase participation** (matching `roleDefinitionId` or `wakesWith`) instead of team membership. Now only players who wake with the group (Werewolves, Wolf Cubs, Lone Wolves) are excluded from targeting. Hidden allies (Wizard, Minion) are targetable.

The player-side check (`getGroupPhasePlayerIds`) already used the correct logic — this aligns the narrator-side check to match.

## Test plan

- [x] Werewolves and Wolf Cubs correctly excluded from targeting
- [x] Wizard (Team.Bad, no wakesWith) NOT excluded — can be targeted
- [x] Minion (Team.Bad, no wakesWith Werewolf) NOT excluded — can be targeted

🤖 Generated with [Claude Code](https://claude.com/claude-code)