### PR TITLE
Define Secret Villain turn state types and game phases (#289)

### DIFF
--- a/app/src/lib/game-modes/secret-villain/index.ts
+++ b/app/src/lib/game-modes/secret-villain/index.ts
@@ -1,2 +1,3 @@
+export * from "./types";
 export * from "./roles";
 export * from "./config";

--- a/app/src/lib/game-modes/secret-villain/types.ts
+++ b/app/src/lib/game-modes/secret-villain/types.ts
@@ -1,0 +1,158 @@
+// ---------------------------------------------------------------------------
+// Phase enum
+// ---------------------------------------------------------------------------
+
+export enum SecretVillainPhase {
+  ElectionNomination = "election-nomination",
+  ElectionVote = "election-vote",
+  PolicyPresident = "policy-president",
+  PolicyChancellor = "policy-chancellor",
+  SpecialAction = "special-action",
+}
+
+// ---------------------------------------------------------------------------
+// Policy cards
+// ---------------------------------------------------------------------------
+
+export enum PolicyCard {
+  Good = "good",
+  Bad = "bad",
+}
+
+/** Number of Good and Bad cards in a fresh deck. */
+export const DECK_GOOD_CARDS = 6;
+export const DECK_BAD_CARDS = 11;
+
+/** Consecutive failed elections before auto-play triggers. */
+export const FAILED_ELECTION_THRESHOLD = 4;
+
+/** Number of Bad cards that must be played before the Special Bad chancellor win condition activates. */
+export const BAD_CARDS_FOR_SPECIAL_BAD_WIN = 3;
+
+/** Number of cards to win for each team. */
+export const CARDS_TO_WIN = 5;
+
+// ---------------------------------------------------------------------------
+// Special action types
+// ---------------------------------------------------------------------------
+
+export enum SpecialActionType {
+  InvestigateTeam = "investigate-team",
+  SpecialElection = "special-election",
+  Shoot = "shoot",
+}
+
+// ---------------------------------------------------------------------------
+// Election types
+// ---------------------------------------------------------------------------
+
+export type ElectionVote = "aye" | "no";
+
+// ---------------------------------------------------------------------------
+// Phase types (discriminated union members)
+// ---------------------------------------------------------------------------
+
+/** President selects a chancellor nominee. */
+export interface ElectionNominationPhase {
+  type: SecretVillainPhase.ElectionNomination;
+  startedAt: number;
+  presidentId: string;
+}
+
+/** All players vote on the president/chancellor pairing. */
+export interface ElectionVotePhase {
+  type: SecretVillainPhase.ElectionVote;
+  startedAt: number;
+  presidentId: string;
+  chancellorNomineeId: string;
+  votes: { playerId: string; vote: ElectionVote }[];
+  /** Set once all votes are cast. True if ayes strictly exceed nos. */
+  passed?: boolean;
+}
+
+/** President draws 3 cards, discards 1, passes 2 to chancellor. */
+export interface PolicyPresidentPhase {
+  type: SecretVillainPhase.PolicyPresident;
+  startedAt: number;
+  presidentId: string;
+  chancellorId: string;
+  /** The 3 cards drawn from the deck. Only visible to the president. */
+  drawnCards: [PolicyCard, PolicyCard, PolicyCard];
+  /** The card discarded by the president. Set once the president decides. */
+  discardedCard?: PolicyCard;
+}
+
+/** Chancellor chooses 1 of 2 cards to play. */
+export interface PolicyChancellorPhase {
+  type: SecretVillainPhase.PolicyChancellor;
+  startedAt: number;
+  presidentId: string;
+  chancellorId: string;
+  /** The 2 cards passed from the president. Only visible to the chancellor. */
+  remainingCards: [PolicyCard, PolicyCard];
+  /** The card played by the chancellor. Set once the chancellor decides. */
+  playedCard?: PolicyCard;
+}
+
+/** A special action triggered by a Bad card being played. */
+export interface SpecialActionPhase {
+  type: SecretVillainPhase.SpecialAction;
+  startedAt: number;
+  presidentId: string;
+  actionType: SpecialActionType;
+  /** The player targeted by the action (investigate, shoot, or special election). */
+  targetPlayerId?: string;
+  /** For InvestigateTeam: whether the target has consented to reveal. */
+  targetConsented?: boolean;
+  /** For InvestigateTeam: the revealed team, visible only to the president. */
+  revealedTeam?: "Good" | "Bad";
+  /** True once the action has been fully resolved. */
+  resolved?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Turn phase union
+// ---------------------------------------------------------------------------
+
+export type SecretVillainTurnPhase =
+  | ElectionNominationPhase
+  | ElectionVotePhase
+  | PolicyPresidentPhase
+  | PolicyChancellorPhase
+  | SpecialActionPhase;
+
+// ---------------------------------------------------------------------------
+// Turn state
+// ---------------------------------------------------------------------------
+
+export interface SecretVillainTurnState {
+  /** Current turn number (increments each time a new president takes the chair). */
+  turn: number;
+  /** Current game phase. */
+  phase: SecretVillainTurnPhase;
+  /** Fixed player rotation order for the presidency (player IDs). */
+  presidentOrder: string[];
+  /** Index into presidentOrder for the current (or next) president. */
+  currentPresidentIndex: number;
+  /** Number of Good policy cards played on the board (0–5). */
+  goodCardsPlayed: number;
+  /** Number of Bad policy cards played on the board (0–5). */
+  badCardsPlayed: number;
+  /** The draw pile (face-down). Reshuffled from discards when exhausted. */
+  deck: PolicyCard[];
+  /** Cards that have been discarded (by president or chancellor). */
+  discardPile: PolicyCard[];
+  /** Player IDs removed from the game by the Shoot power. */
+  eliminatedPlayerIds: string[];
+  /** Player ID of the previous turn's president (ineligible for chancellor). */
+  previousPresidentId?: string;
+  /** Player ID of the previous turn's chancellor (ineligible for chancellor). */
+  previousChancellorId?: string;
+  /** Number of consecutive failed elections (resets on a successful election). */
+  failedElectionCount: number;
+  /**
+   * One-time president override: if set, this player becomes president for the
+   * next turn, after which the normal rotation resumes.
+   */
+  specialPresidentId?: string;
+}


### PR DESCRIPTION
## Summary
- Adds `SecretVillainTurnState` with board state tracking (good/bad cards played), deck/discard management, president rotation, and election failure counter
- Defines 5 phase types as a discriminated union: `ElectionNomination`, `ElectionVote`, `PolicyPresident`, `PolicyChancellor`, `SpecialAction`
- Adds enums for `SecretVillainPhase`, `PolicyCard`, `SpecialActionType`, and `ElectionVote`
- Includes game constants: deck composition (6 Good / 11 Bad), failed election threshold (4), Special Bad win condition (3 Bad cards), cards to win (5)

## Test plan
- [x] TypeScript compiles with zero errors
- [x] All 650 existing tests pass
- [x] Review types against #288 game rules for completeness

Part of #288. Closes #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)