### PR TITLE
Extract shared CI setup into composite action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,21 @@
+name: "Setup"
+description: "Install pnpm, Node.js, and project dependencies"
+
+inputs:
+  frozen-lockfile:
+    description: "Use --frozen-lockfile for pnpm install"
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: pnpm/action-setup@v5
+      with:
+        version: 10
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 24.x
+        cache: "pnpm"
+    - run: pnpm install ${{ inputs.frozen-lockfile == 'true' && '--frozen-lockfile' || '--no-frozen-lockfile' }}
+      shell: bash

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -21,16 +21,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch }}
           token: ${{ secrets.CI_PAT_TOKEN }}
 
-      - uses: pnpm/action-setup@v5
-        with:
-          version: 10
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-          cache: "pnpm"
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
 
       - name: Run Prettier
         run: pnpm prettier --write .

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -12,14 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-        with:
-          version: 10
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-          cache: "pnpm"
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: pnpm -r test
 
   lint:
@@ -27,14 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-        with:
-          version: 10
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-          cache: "pnpm"
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: pnpm -r run lint
 
   format:
@@ -42,14 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-        with:
-          version: 10
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-          cache: "pnpm"
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: pnpm run format:check
 
   build:
@@ -57,12 +36,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
-        with:
-          version: 10
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-          cache: "pnpm"
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
       - run: pnpm -r run build

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -14,14 +14,9 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.CI_PAT_TOKEN }}
-      - uses: pnpm/action-setup@v5
+      - uses: ./.github/actions/setup
         with:
-          version: 10
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-          cache: "pnpm"
-      - run: pnpm install --no-frozen-lockfile
+          frozen-lockfile: "false"
       - name: Commit updated lockfile
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
- Creates `.github/actions/setup/action.yml` composite action that handles pnpm, Node.js, and dependency installation
- Replaces the duplicated 3-step setup block (pnpm/action-setup, setup-node, pnpm install) across all 3 CI workflows (6 occurrences)
- Accepts a `frozen-lockfile` input (defaults to `true`) so the Dependabot lockfile workflow can pass `false`

## Test plan
- [x] CI workflows run successfully on this PR
- [x] Verify auto-format workflow still triggers on CI failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)