### PR TITLE
Implement Secret Villain deck and card management (#290)

### DIFF
--- a/app/src/lib/game-modes/secret-villain/index.ts
+++ b/app/src/lib/game-modes/secret-villain/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
 export * from "./roles";
 export * from "./config";
+export * from "./utils";

--- a/app/src/lib/game-modes/secret-villain/utils/deck.test.ts
+++ b/app/src/lib/game-modes/secret-villain/utils/deck.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { PolicyCard, DECK_GOOD_CARDS, DECK_BAD_CARDS } from "../types";
+import { createDeck, drawCards, reshuffleIfNeeded } from "./deck";
+
+describe("createDeck", () => {
+  it("creates a deck with the correct total card count", () => {
+    const deck = createDeck();
+    expect(deck).toHaveLength(DECK_GOOD_CARDS + DECK_BAD_CARDS);
+  });
+
+  it("contains the correct number of Good cards", () => {
+    const deck = createDeck();
+    const goodCount = deck.filter((c) => c === PolicyCard.Good).length;
+    expect(goodCount).toBe(DECK_GOOD_CARDS);
+  });
+
+  it("contains the correct number of Bad cards", () => {
+    const deck = createDeck();
+    const badCount = deck.filter((c) => c === PolicyCard.Bad).length;
+    expect(badCount).toBe(DECK_BAD_CARDS);
+  });
+});
+
+describe("drawCards", () => {
+  it("returns the requested number of drawn cards", () => {
+    const deck = [PolicyCard.Good, PolicyCard.Bad, PolicyCard.Good];
+    const { drawn } = drawCards(deck, 2);
+    expect(drawn).toEqual([PolicyCard.Good, PolicyCard.Bad]);
+  });
+
+  it("returns the remaining deck after drawing", () => {
+    const deck = [PolicyCard.Good, PolicyCard.Bad, PolicyCard.Good];
+    const { remaining } = drawCards(deck, 2);
+    expect(remaining).toEqual([PolicyCard.Good]);
+  });
+
+  it("draws from the top of the deck", () => {
+    const deck = [PolicyCard.Bad, PolicyCard.Good, PolicyCard.Bad];
+    const { drawn } = drawCards(deck, 1);
+    expect(drawn).toEqual([PolicyCard.Bad]);
+  });
+
+  it("does not mutate the original deck", () => {
+    const deck = [PolicyCard.Good, PolicyCard.Bad, PolicyCard.Good];
+    const original = [...deck];
+    drawCards(deck, 2);
+    expect(deck).toEqual(original);
+  });
+
+  it("throws when drawing more cards than available", () => {
+    const deck = [PolicyCard.Good];
+    expect(() => drawCards(deck, 2)).toThrow(
+      "Cannot draw 2 cards from a deck of 1",
+    );
+  });
+
+  it("returns empty remaining when drawing all cards", () => {
+    const deck = [PolicyCard.Good, PolicyCard.Bad];
+    const { drawn, remaining } = drawCards(deck, 2);
+    expect(drawn).toHaveLength(2);
+    expect(remaining).toHaveLength(0);
+  });
+});
+
+describe("reshuffleIfNeeded", () => {
+  it("does not reshuffle when deck has 3 or more cards", () => {
+    const deck = [PolicyCard.Good, PolicyCard.Bad, PolicyCard.Good];
+    const discardPile = [PolicyCard.Bad, PolicyCard.Bad];
+    const result = reshuffleIfNeeded(deck, discardPile);
+    expect(result.deck).toEqual(deck);
+    expect(result.discardPile).toEqual(discardPile);
+  });
+
+  it("reshuffles when deck has fewer than 3 cards", () => {
+    const deck = [PolicyCard.Good, PolicyCard.Bad];
+    const discardPile = [PolicyCard.Bad, PolicyCard.Good, PolicyCard.Bad];
+    const result = reshuffleIfNeeded(deck, discardPile);
+    expect(result.deck).toHaveLength(5);
+    expect(result.discardPile).toEqual([]);
+  });
+
+  it("reshuffles when deck is empty", () => {
+    const deck: PolicyCard[] = [];
+    const discardPile = [PolicyCard.Good, PolicyCard.Bad];
+    const result = reshuffleIfNeeded(deck, discardPile);
+    expect(result.deck).toHaveLength(2);
+    expect(result.discardPile).toEqual([]);
+  });
+
+  it("preserves total card count across reshuffle", () => {
+    const deck = [PolicyCard.Good];
+    const discardPile = [
+      PolicyCard.Bad,
+      PolicyCard.Bad,
+      PolicyCard.Good,
+      PolicyCard.Good,
+    ];
+    const result = reshuffleIfNeeded(deck, discardPile);
+    expect(result.deck).toHaveLength(5);
+    const goodCount = result.deck.filter((c) => c === PolicyCard.Good).length;
+    const badCount = result.deck.filter((c) => c === PolicyCard.Bad).length;
+    expect(goodCount).toBe(3);
+    expect(badCount).toBe(2);
+  });
+
+  it("handles reshuffle with empty discard pile", () => {
+    const deck = [PolicyCard.Good];
+    const discardPile: PolicyCard[] = [];
+    const result = reshuffleIfNeeded(deck, discardPile);
+    expect(result.deck).toHaveLength(1);
+    expect(result.discardPile).toEqual([]);
+  });
+});

--- a/app/src/lib/game-modes/secret-villain/utils/deck.ts
+++ b/app/src/lib/game-modes/secret-villain/utils/deck.ts
@@ -1,0 +1,63 @@
+import { PolicyCard, DECK_GOOD_CARDS, DECK_BAD_CARDS } from "../types";
+
+/** Minimum cards required in the deck before a draw. Below this, reshuffle. */
+const MIN_DECK_SIZE = 3;
+
+/** Fisher-Yates shuffle (in-place, returns the same array). */
+function shuffle<T>(array: T[]): T[] {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const temp = array[i] as T;
+    array[i] = array[j] as T;
+    array[j] = temp;
+  }
+  return array;
+}
+
+/** Creates a fresh shuffled deck with the standard card distribution. */
+export function createDeck(): PolicyCard[] {
+  const cards: PolicyCard[] = [
+    ...Array.from<PolicyCard>({ length: DECK_GOOD_CARDS }).fill(
+      PolicyCard.Good,
+    ),
+    ...Array.from<PolicyCard>({ length: DECK_BAD_CARDS }).fill(PolicyCard.Bad),
+  ];
+  return shuffle(cards);
+}
+
+/**
+ * Draws `count` cards from the top of the deck.
+ * Returns the drawn cards and the remaining deck.
+ * Throws if the deck has fewer cards than requested.
+ */
+export function drawCards(
+  deck: PolicyCard[],
+  count: number,
+): { drawn: PolicyCard[]; remaining: PolicyCard[] } {
+  if (deck.length < count) {
+    throw new Error(
+      `Cannot draw ${String(count)} cards from a deck of ${String(deck.length)}`,
+    );
+  }
+  return {
+    drawn: deck.slice(0, count),
+    remaining: deck.slice(count),
+  };
+}
+
+/**
+ * If the deck has fewer than 3 cards, combines it with the discard pile
+ * and reshuffles. Otherwise returns the deck and discard pile unchanged.
+ */
+export function reshuffleIfNeeded(
+  deck: PolicyCard[],
+  discardPile: PolicyCard[],
+): { deck: PolicyCard[]; discardPile: PolicyCard[] } {
+  if (deck.length >= MIN_DECK_SIZE) {
+    return { deck, discardPile };
+  }
+  return {
+    deck: shuffle([...deck, ...discardPile]),
+    discardPile: [],
+  };
+}

--- a/app/src/lib/game-modes/secret-villain/utils/index.ts
+++ b/app/src/lib/game-modes/secret-villain/utils/index.ts
@@ -1,0 +1,1 @@
+export { createDeck, drawCards, reshuffleIfNeeded } from "./deck";


### PR DESCRIPTION
## Summary
- Adds `createDeck()` — creates a shuffled 17-card deck (6 Good + 11 Bad)
- Adds `drawCards(deck, count)` — draws from the top, returns drawn cards and remaining deck
- Adds `reshuffleIfNeeded(deck, discardPile)` — auto-reshuffles when fewer than 3 cards remain in the deck

## Test plan
- [x] TypeScript compiles with zero errors
- [x] 664 tests pass (14 new deck tests)
- [x] Deck has correct card counts (6 Good, 11 Bad)
- [x] Draw removes cards from top of deck without mutation
- [x] Reshuffle triggers at correct threshold (< 3 cards)
- [x] Card distribution preserved across reshuffles

Part of #288. Closes #290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)