### PR TITLE
Implement Secret Villain policy phase actions (#292)

### DIFF
--- a/app/src/lib/game-modes/secret-villain/actions/chancellor-play.ts
+++ b/app/src/lib/game-modes/secret-villain/actions/chancellor-play.ts
@@ -1,0 +1,81 @@
+import { GameStatus } from "@/lib/types";
+import type { Game, GameAction } from "@/lib/types";
+import { SecretVillainPhase, PolicyCard, CARDS_TO_WIN } from "../types";
+import {
+  currentTurnState,
+  getNextPresidentId,
+  getSpecialAction,
+} from "../utils";
+
+export const chancellorPlayAction: GameAction = {
+  isValid(game: Game, callerId: string, payload: unknown) {
+    const ts = currentTurnState(game);
+    if (!ts) return false;
+    if (ts.phase.type !== SecretVillainPhase.PolicyChancellor) return false;
+    if (ts.phase.chancellorId !== callerId) return false;
+    if (ts.phase.playedCard !== undefined) return false;
+
+    const { cardIndex } = payload as { cardIndex?: unknown };
+    if (typeof cardIndex !== "number") return false;
+    return cardIndex >= 0 && cardIndex < 2;
+  },
+
+  apply(game: Game, payload: unknown, callerId: string) {
+    const ts = currentTurnState(game);
+    if (ts?.phase.type !== SecretVillainPhase.PolicyChancellor) return;
+    if (ts.phase.chancellorId !== callerId) return;
+
+    const { cardIndex } = payload as { cardIndex: number };
+    const remainingCards = [...ts.phase.remainingCards];
+    const [played] = remainingCards.splice(cardIndex, 1);
+    const [discarded] = remainingCards;
+    if (!played || !discarded) return;
+
+    ts.discardPile = [...ts.discardPile, discarded];
+
+    // Update board.
+    if (played === PolicyCard.Good) {
+      ts.goodCardsPlayed++;
+    } else {
+      ts.badCardsPlayed++;
+    }
+
+    // Update previous administration.
+    ts.previousPresidentId = ts.phase.presidentId;
+    ts.previousChancellorId = ts.phase.chancellorId;
+
+    // Check win condition.
+    if (ts.goodCardsPlayed >= CARDS_TO_WIN) {
+      game.status = { type: GameStatus.Finished, winner: "Good" };
+      return;
+    }
+    if (ts.badCardsPlayed >= CARDS_TO_WIN) {
+      game.status = { type: GameStatus.Finished, winner: "Bad" };
+      return;
+    }
+
+    // Check for special action trigger (only on Bad cards).
+    if (played === PolicyCard.Bad) {
+      const action = getSpecialAction(ts.badCardsPlayed, game.players.length);
+      if (action) {
+        ts.phase = {
+          type: SecretVillainPhase.SpecialAction,
+          startedAt: Date.now(),
+          presidentId: ts.phase.presidentId,
+          actionType: action,
+        };
+        return;
+      }
+    }
+
+    // No special action — advance to next election.
+    const { presidentId, nextIndex } = getNextPresidentId(ts);
+    ts.currentPresidentIndex = nextIndex;
+    ts.phase = {
+      type: SecretVillainPhase.ElectionNomination,
+      startedAt: Date.now(),
+      presidentId,
+    };
+    ts.turn++;
+  },
+};

--- a/app/src/lib/game-modes/secret-villain/actions/index.ts
+++ b/app/src/lib/game-modes/secret-villain/actions/index.ts
@@ -2,15 +2,21 @@ import type { GameAction } from "@/lib/types";
 import { nominateChancellorAction } from "./nominate-chancellor";
 import { castElectionVoteAction } from "./cast-election-vote";
 import { resolveElectionAction } from "./resolve-election";
+import { presidentDiscardAction } from "./president-discard";
+import { chancellorPlayAction } from "./chancellor-play";
 
 export enum SecretVillainAction {
-  NominateChancellor = "nominate-chancellor",
   CastElectionVote = "cast-election-vote",
+  ChancellorPlay = "chancellor-play",
+  NominateChancellor = "nominate-chancellor",
+  PresidentDiscard = "president-discard",
   ResolveElection = "resolve-election",
 }
 
 export const SECRET_VILLAIN_ACTIONS: Record<SecretVillainAction, GameAction> = {
-  [SecretVillainAction.NominateChancellor]: nominateChancellorAction,
   [SecretVillainAction.CastElectionVote]: castElectionVoteAction,
+  [SecretVillainAction.ChancellorPlay]: chancellorPlayAction,
+  [SecretVillainAction.NominateChancellor]: nominateChancellorAction,
+  [SecretVillainAction.PresidentDiscard]: presidentDiscardAction,
   [SecretVillainAction.ResolveElection]: resolveElectionAction,
 };

--- a/app/src/lib/game-modes/secret-villain/actions/policy.test.ts
+++ b/app/src/lib/game-modes/secret-villain/actions/policy.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect } from "vitest";
+import {
+  GameMode,
+  GameStatus,
+  DEFAULT_TIMER_CONFIG,
+  ShowRolesInPlay,
+} from "@/lib/types";
+import type { Game } from "@/lib/types";
+import {
+  SecretVillainPhase,
+  PolicyCard,
+  CARDS_TO_WIN,
+  SpecialActionType,
+} from "../types";
+import type { SecretVillainTurnState, PolicyChancellorPhase } from "../types";
+import { SecretVillainRole } from "../roles";
+import { presidentDiscardAction } from "./president-discard";
+import { chancellorPlayAction } from "./chancellor-play";
+
+function makePlayer(id: string) {
+  return {
+    id,
+    name: `Player ${id}`,
+    sessionId: `session-${id}`,
+    visiblePlayers: [],
+  };
+}
+
+function makePolicyGame(
+  overrides: {
+    turnState?: Partial<SecretVillainTurnState>;
+    status?: Game["status"];
+    roleAssignments?: Game["roleAssignments"];
+    playerCount?: number;
+  } = {},
+): Game {
+  const count = overrides.playerCount ?? 5;
+  const playerIds = Array.from({ length: count }, (_, i) => `p${i + 1}`);
+
+  const baseTurnState: SecretVillainTurnState = {
+    presidentOrder: playerIds,
+    currentPresidentIndex: 0,
+    turn: 1,
+    phase: {
+      type: SecretVillainPhase.PolicyPresident,
+      startedAt: 1000,
+      presidentId: "p1",
+      chancellorId: "p3",
+      drawnCards: [PolicyCard.Good, PolicyCard.Bad, PolicyCard.Good],
+    },
+    goodCardsPlayed: 0,
+    badCardsPlayed: 0,
+    deck: [PolicyCard.Bad, PolicyCard.Good, PolicyCard.Bad],
+    discardPile: [],
+    eliminatedPlayerIds: [],
+    failedElectionCount: 0,
+    ...overrides.turnState,
+  };
+
+  return {
+    id: "game-1",
+    lobbyId: "lobby-1",
+    gameMode: GameMode.SecretVillain,
+    status: overrides.status ?? {
+      type: GameStatus.Playing,
+      turnState: baseTurnState,
+    },
+    players: playerIds.map(makePlayer),
+    roleAssignments: overrides.roleAssignments ?? [
+      { playerId: "p1", roleDefinitionId: SecretVillainRole.Good },
+      { playerId: "p2", roleDefinitionId: SecretVillainRole.Good },
+      { playerId: "p3", roleDefinitionId: SecretVillainRole.Good },
+      { playerId: "p4", roleDefinitionId: SecretVillainRole.Bad },
+      { playerId: "p5", roleDefinitionId: SecretVillainRole.SpecialBad },
+    ],
+    configuredRoleSlots: [],
+    showRolesInPlay: ShowRolesInPlay.None,
+    timerConfig: DEFAULT_TIMER_CONFIG,
+    nominationsEnabled: false,
+    singleTrialPerDay: false,
+    revealProtections: false,
+  } satisfies Game;
+}
+
+function getTurnState(game: Game): SecretVillainTurnState {
+  if (game.status.type !== GameStatus.Playing) throw new Error("Not playing");
+  return game.status.turnState as SecretVillainTurnState;
+}
+
+// ─── presidentDiscardAction ─────────────────────────────────────────────────
+
+describe("presidentDiscardAction", () => {
+  describe("isValid", () => {
+    it("president can discard a card by index (0, 1, or 2)", () => {
+      const game = makePolicyGame();
+      expect(presidentDiscardAction.isValid(game, "p1", { cardIndex: 0 })).toBe(
+        true,
+      );
+      expect(presidentDiscardAction.isValid(game, "p1", { cardIndex: 1 })).toBe(
+        true,
+      );
+      expect(presidentDiscardAction.isValid(game, "p1", { cardIndex: 2 })).toBe(
+        true,
+      );
+    });
+
+    it("non-president cannot discard", () => {
+      const game = makePolicyGame();
+      expect(presidentDiscardAction.isValid(game, "p2", { cardIndex: 0 })).toBe(
+        false,
+      );
+    });
+
+    it("cannot discard with invalid index (negative, >=3, non-number)", () => {
+      const game = makePolicyGame();
+      expect(
+        presidentDiscardAction.isValid(game, "p1", { cardIndex: -1 }),
+      ).toBe(false);
+      expect(presidentDiscardAction.isValid(game, "p1", { cardIndex: 3 })).toBe(
+        false,
+      );
+      expect(
+        presidentDiscardAction.isValid(game, "p1", { cardIndex: "zero" }),
+      ).toBe(false);
+    });
+
+    it("cannot discard when already discarded", () => {
+      const game = makePolicyGame({
+        turnState: {
+          phase: {
+            type: SecretVillainPhase.PolicyPresident,
+            startedAt: 1000,
+            presidentId: "p1",
+            chancellorId: "p3",
+            drawnCards: [PolicyCard.Good, PolicyCard.Bad, PolicyCard.Good],
+            discardedCard: PolicyCard.Bad,
+          },
+        },
+      });
+      expect(presidentDiscardAction.isValid(game, "p1", { cardIndex: 0 })).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("apply", () => {
+    it("transitions to PolicyChancellor phase with remaining 2 cards", () => {
+      const game = makePolicyGame();
+      presidentDiscardAction.apply(game, { cardIndex: 1 }, "p1");
+
+      const ts = getTurnState(game);
+      expect(ts.phase.type).toBe(SecretVillainPhase.PolicyChancellor);
+      const phase = ts.phase as PolicyChancellorPhase;
+      expect(phase.presidentId).toBe("p1");
+      expect(phase.chancellorId).toBe("p3");
+      // Discarded index 1 (Bad), remaining are [Good, Good]
+      expect(phase.remainingCards).toEqual([PolicyCard.Good, PolicyCard.Good]);
+      expect(ts.discardPile).toEqual([PolicyCard.Bad]);
+    });
+  });
+});
+
+// ─── chancellorPlayAction ───────────────────────────────────────────────────
+
+describe("chancellorPlayAction", () => {
+  function makeChancellorGame(
+    overrides: Partial<SecretVillainTurnState> = {},
+    playerCount?: number,
+  ) {
+    return makePolicyGame({
+      playerCount,
+      turnState: {
+        phase: {
+          type: SecretVillainPhase.PolicyChancellor,
+          startedAt: 1000,
+          presidentId: "p1",
+          chancellorId: "p3",
+          remainingCards: [PolicyCard.Good, PolicyCard.Bad],
+        },
+        ...overrides,
+      },
+    });
+  }
+
+  describe("isValid", () => {
+    it("chancellor can play a card by index (0 or 1)", () => {
+      const game = makeChancellorGame();
+      expect(chancellorPlayAction.isValid(game, "p3", { cardIndex: 0 })).toBe(
+        true,
+      );
+      expect(chancellorPlayAction.isValid(game, "p3", { cardIndex: 1 })).toBe(
+        true,
+      );
+    });
+
+    it("non-chancellor cannot play", () => {
+      const game = makeChancellorGame();
+      expect(chancellorPlayAction.isValid(game, "p1", { cardIndex: 0 })).toBe(
+        false,
+      );
+    });
+
+    it("cannot play with invalid index", () => {
+      const game = makeChancellorGame();
+      expect(chancellorPlayAction.isValid(game, "p3", { cardIndex: -1 })).toBe(
+        false,
+      );
+      expect(chancellorPlayAction.isValid(game, "p3", { cardIndex: 2 })).toBe(
+        false,
+      );
+      expect(
+        chancellorPlayAction.isValid(game, "p3", { cardIndex: "one" }),
+      ).toBe(false);
+    });
+  });
+
+  describe("apply", () => {
+    it("playing Good card increments goodCardsPlayed", () => {
+      const game = makeChancellorGame();
+      // Index 0 is Good
+      chancellorPlayAction.apply(game, { cardIndex: 0 }, "p3");
+
+      const ts = getTurnState(game);
+      expect(ts.goodCardsPlayed).toBe(1);
+      expect(ts.badCardsPlayed).toBe(0);
+      // The other card (Bad) goes to discard
+      expect(ts.discardPile).toContain(PolicyCard.Bad);
+    });
+
+    it("playing Bad card increments badCardsPlayed", () => {
+      const game = makeChancellorGame();
+      // Index 1 is Bad
+      chancellorPlayAction.apply(game, { cardIndex: 1 }, "p3");
+
+      const ts = getTurnState(game);
+      expect(ts.badCardsPlayed).toBe(1);
+      expect(ts.goodCardsPlayed).toBe(0);
+      // The other card (Good) goes to discard
+      expect(ts.discardPile).toContain(PolicyCard.Good);
+    });
+
+    it("updates previousPresidentId and previousChancellorId", () => {
+      const game = makeChancellorGame();
+      chancellorPlayAction.apply(game, { cardIndex: 0 }, "p3");
+
+      const ts = getTurnState(game);
+      expect(ts.previousPresidentId).toBe("p1");
+      expect(ts.previousChancellorId).toBe("p3");
+    });
+
+    it("5th Good card triggers Good team win", () => {
+      const game = makeChancellorGame({ goodCardsPlayed: CARDS_TO_WIN - 1 });
+      chancellorPlayAction.apply(game, { cardIndex: 0 }, "p3");
+
+      expect(game.status.type).toBe(GameStatus.Finished);
+      if (game.status.type === GameStatus.Finished) {
+        expect(game.status.winner).toBe("Good");
+      }
+    });
+
+    it("5th Bad card triggers Bad team win", () => {
+      const game = makeChancellorGame({
+        badCardsPlayed: CARDS_TO_WIN - 1,
+        phase: {
+          type: SecretVillainPhase.PolicyChancellor,
+          startedAt: 1000,
+          presidentId: "p1",
+          chancellorId: "p3",
+          remainingCards: [PolicyCard.Bad, PolicyCard.Good],
+        },
+      });
+      chancellorPlayAction.apply(game, { cardIndex: 0 }, "p3");
+
+      expect(game.status.type).toBe(GameStatus.Finished);
+      if (game.status.type === GameStatus.Finished) {
+        expect(game.status.winner).toBe("Bad");
+      }
+    });
+
+    it("Bad card triggers special action when applicable", () => {
+      // 7 players: bad card 2 triggers InvestigateTeam
+      const game = makeChancellorGame(
+        {
+          badCardsPlayed: 1,
+          phase: {
+            type: SecretVillainPhase.PolicyChancellor,
+            startedAt: 1000,
+            presidentId: "p1",
+            chancellorId: "p3",
+            remainingCards: [PolicyCard.Bad, PolicyCard.Good],
+          },
+        },
+        7,
+      );
+      chancellorPlayAction.apply(game, { cardIndex: 0 }, "p3");
+
+      const ts = getTurnState(game);
+      expect(ts.phase.type).toBe(SecretVillainPhase.SpecialAction);
+      if (ts.phase.type === SecretVillainPhase.SpecialAction) {
+        expect(ts.phase.actionType).toBe(SpecialActionType.InvestigateTeam);
+        expect(ts.phase.presidentId).toBe("p1");
+      }
+    });
+
+    it("Good card does not trigger special action, advances to next election", () => {
+      const game = makeChancellorGame({ badCardsPlayed: 1 }, 7);
+      // Play Good (index 0)
+      chancellorPlayAction.apply(game, { cardIndex: 0 }, "p3");
+
+      const ts = getTurnState(game);
+      expect(ts.phase.type).toBe(SecretVillainPhase.ElectionNomination);
+      expect(ts.turn).toBe(2);
+    });
+
+    it("Bad card with no special action advances to next election", () => {
+      // 5 players: bad card 1 has no special action
+      const game = makeChancellorGame({
+        badCardsPlayed: 0,
+        phase: {
+          type: SecretVillainPhase.PolicyChancellor,
+          startedAt: 1000,
+          presidentId: "p1",
+          chancellorId: "p3",
+          remainingCards: [PolicyCard.Bad, PolicyCard.Good],
+        },
+      });
+      chancellorPlayAction.apply(game, { cardIndex: 0 }, "p3");
+
+      const ts = getTurnState(game);
+      expect(ts.phase.type).toBe(SecretVillainPhase.ElectionNomination);
+      expect(ts.turn).toBe(2);
+    });
+  });
+});

--- a/app/src/lib/game-modes/secret-villain/actions/president-discard.ts
+++ b/app/src/lib/game-modes/secret-villain/actions/president-discard.ts
@@ -1,0 +1,37 @@
+import type { Game, GameAction } from "@/lib/types";
+import { SecretVillainPhase, PolicyCard } from "../types";
+import { currentTurnState } from "../utils";
+
+export const presidentDiscardAction: GameAction = {
+  isValid(game: Game, callerId: string, payload: unknown) {
+    const ts = currentTurnState(game);
+    if (!ts) return false;
+    if (ts.phase.type !== SecretVillainPhase.PolicyPresident) return false;
+    if (ts.phase.presidentId !== callerId) return false;
+    if (ts.phase.discardedCard !== undefined) return false;
+
+    const { cardIndex } = payload as { cardIndex?: unknown };
+    if (typeof cardIndex !== "number") return false;
+    return cardIndex >= 0 && cardIndex < 3;
+  },
+
+  apply(game: Game, payload: unknown, callerId: string) {
+    const ts = currentTurnState(game);
+    if (ts?.phase.type !== SecretVillainPhase.PolicyPresident) return;
+    if (ts.phase.presidentId !== callerId) return;
+
+    const { cardIndex } = payload as { cardIndex: number };
+    const drawnCards = [...ts.phase.drawnCards];
+    const [discarded] = drawnCards.splice(cardIndex, 1);
+    if (!discarded) return;
+
+    ts.discardPile = [...ts.discardPile, discarded];
+    ts.phase = {
+      type: SecretVillainPhase.PolicyChancellor,
+      startedAt: Date.now(),
+      presidentId: ts.phase.presidentId,
+      chancellorId: ts.phase.chancellorId,
+      remainingCards: drawnCards as [PolicyCard, PolicyCard],
+    };
+  },
+};

--- a/app/src/lib/game-modes/secret-villain/utils/index.ts
+++ b/app/src/lib/game-modes/secret-villain/utils/index.ts
@@ -4,3 +4,4 @@ export {
   getNextPresidentId,
   getEligibleChancellorIds,
 } from "./turn-state";
+export { getSpecialAction } from "./special-actions";

--- a/app/src/lib/game-modes/secret-villain/utils/special-actions.test.ts
+++ b/app/src/lib/game-modes/secret-villain/utils/special-actions.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { SpecialActionType } from "../types";
+import { getSpecialAction } from "./special-actions";
+
+describe("getSpecialAction", () => {
+  describe("5-6 players", () => {
+    it.each([5, 6])("no action at bad card 1 (%i players)", (count) => {
+      expect(getSpecialAction(1, count)).toBeUndefined();
+    });
+
+    it.each([5, 6])("no action at bad card 2 (%i players)", (count) => {
+      expect(getSpecialAction(2, count)).toBeUndefined();
+    });
+
+    it.each([5, 6])("InvestigateTeam at bad card 3 (%i players)", (count) => {
+      expect(getSpecialAction(3, count)).toBe(
+        SpecialActionType.InvestigateTeam,
+      );
+    });
+
+    it.each([5, 6])("Shoot at bad card 4 (%i players)", (count) => {
+      expect(getSpecialAction(4, count)).toBe(SpecialActionType.Shoot);
+    });
+
+    it.each([5, 6])("Shoot at bad card 5 (%i players)", (count) => {
+      expect(getSpecialAction(5, count)).toBe(SpecialActionType.Shoot);
+    });
+  });
+
+  describe("7-8 players", () => {
+    it.each([7, 8])("no action at bad card 1 (%i players)", (count) => {
+      expect(getSpecialAction(1, count)).toBeUndefined();
+    });
+
+    it.each([7, 8])("InvestigateTeam at bad card 2 (%i players)", (count) => {
+      expect(getSpecialAction(2, count)).toBe(
+        SpecialActionType.InvestigateTeam,
+      );
+    });
+
+    it.each([7, 8])("SpecialElection at bad card 3 (%i players)", (count) => {
+      expect(getSpecialAction(3, count)).toBe(
+        SpecialActionType.SpecialElection,
+      );
+    });
+
+    it.each([7, 8])("Shoot at bad card 4 (%i players)", (count) => {
+      expect(getSpecialAction(4, count)).toBe(SpecialActionType.Shoot);
+    });
+
+    it.each([7, 8])("Shoot at bad card 5 (%i players)", (count) => {
+      expect(getSpecialAction(5, count)).toBe(SpecialActionType.Shoot);
+    });
+  });
+
+  describe("9-10 players", () => {
+    it.each([9, 10])("InvestigateTeam at bad card 1 (%i players)", (count) => {
+      expect(getSpecialAction(1, count)).toBe(
+        SpecialActionType.InvestigateTeam,
+      );
+    });
+
+    it.each([9, 10])("InvestigateTeam at bad card 2 (%i players)", (count) => {
+      expect(getSpecialAction(2, count)).toBe(
+        SpecialActionType.InvestigateTeam,
+      );
+    });
+
+    it.each([9, 10])("SpecialElection at bad card 3 (%i players)", (count) => {
+      expect(getSpecialAction(3, count)).toBe(
+        SpecialActionType.SpecialElection,
+      );
+    });
+
+    it.each([9, 10])("Shoot at bad card 4 (%i players)", (count) => {
+      expect(getSpecialAction(4, count)).toBe(SpecialActionType.Shoot);
+    });
+
+    it.each([9, 10])("Shoot at bad card 5 (%i players)", (count) => {
+      expect(getSpecialAction(5, count)).toBe(SpecialActionType.Shoot);
+    });
+  });
+});

--- a/app/src/lib/game-modes/secret-villain/utils/special-actions.ts
+++ b/app/src/lib/game-modes/secret-villain/utils/special-actions.ts
@@ -1,0 +1,46 @@
+import { SpecialActionType } from "../types";
+
+/**
+ * Special action power tables indexed by badCardsPlayed count (1-5).
+ * Each table maps to the action triggered when the Nth Bad card is played.
+ * undefined = no special action for that card.
+ */
+const POWERS_5_6: (SpecialActionType | undefined)[] = [
+  undefined, // 1st Bad card
+  undefined, // 2nd Bad card
+  SpecialActionType.InvestigateTeam, // 3rd
+  SpecialActionType.Shoot, // 4th
+  SpecialActionType.Shoot, // 5th
+];
+
+const POWERS_7_8: (SpecialActionType | undefined)[] = [
+  undefined, // 1st Bad card
+  SpecialActionType.InvestigateTeam, // 2nd
+  SpecialActionType.SpecialElection, // 3rd
+  SpecialActionType.Shoot, // 4th
+  SpecialActionType.Shoot, // 5th
+];
+
+const POWERS_9_10: (SpecialActionType | undefined)[] = [
+  SpecialActionType.InvestigateTeam, // 1st Bad card
+  SpecialActionType.InvestigateTeam, // 2nd
+  SpecialActionType.SpecialElection, // 3rd
+  SpecialActionType.Shoot, // 4th
+  SpecialActionType.Shoot, // 5th
+];
+
+/**
+ * Returns the special action triggered by playing the Nth Bad card,
+ * or undefined if no action is triggered.
+ *
+ * @param badCardsPlayed — the count AFTER the card has been played (1-5)
+ * @param playerCount — total players in the game (including eliminated)
+ */
+export function getSpecialAction(
+  badCardsPlayed: number,
+  playerCount: number,
+): SpecialActionType | undefined {
+  const powers =
+    playerCount <= 6 ? POWERS_5_6 : playerCount <= 8 ? POWERS_7_8 : POWERS_9_10;
+  return powers[badCardsPlayed - 1];
+}


### PR DESCRIPTION
## Summary
- **PresidentDiscard** — president sees 3 drawn cards, discards 1 (goes to discard pile), passes remaining 2 to chancellor
- **ChancellorPlay** — chancellor plays 1 of 2 cards to the board, other goes to discard pile
  - Updates `previousPresidentId` and `previousChancellorId`
  - Checks win conditions (5 Good → Good wins, 5 Bad → Bad wins)
  - If a Bad card triggers a special action, transitions to `SpecialAction` phase
  - Otherwise advances to next election
- **Special action trigger utility** — maps bad card count × player count to presidential powers:
  - 5-6 players: investigate (3rd), shoot (4th, 5th)
  - 7-8 players: investigate (2nd), special election (3rd), shoot (4th, 5th)
  - 9-10 players: investigate (1st, 2nd), special election (3rd), shoot (4th, 5th)

## New files
- `actions/president-discard.ts`, `actions/chancellor-play.ts`
- `utils/special-actions.ts`
- `actions/policy.test.ts` (15 tests), `utils/special-actions.test.ts` (15 tests)

## Test plan
- [x] TypeScript compiles with zero errors
- [x] ESLint passes with zero errors
- [x] 741 tests pass (30 new policy + special action tests)

Part of #288. Closes #292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)