### PR TITLE
Implement Secret Villain game initialization and player state (#295)

### DIFF
--- a/app/src/lib/game-modes/secret-villain/services.test.ts
+++ b/app/src/lib/game-modes/secret-villain/services.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect } from "vitest";
+import {
+  GameMode,
+  GameStatus,
+  DEFAULT_TIMER_CONFIG,
+  ShowRolesInPlay,
+  Team,
+} from "@/lib/types";
+import type { Game } from "@/lib/types";
+import {
+  SecretVillainPhase,
+  PolicyCard,
+  SpecialActionType,
+  DECK_GOOD_CARDS,
+  DECK_BAD_CARDS,
+} from "./types";
+import type { SecretVillainTurnState } from "./types";
+import { SecretVillainRole } from "./roles";
+import { secretVillainServices } from "./services";
+
+const assignments = [
+  { playerId: "p1", roleDefinitionId: SecretVillainRole.Good },
+  { playerId: "p2", roleDefinitionId: SecretVillainRole.Good },
+  { playerId: "p3", roleDefinitionId: SecretVillainRole.Bad },
+  { playerId: "p4", roleDefinitionId: SecretVillainRole.SpecialBad },
+  { playerId: "p5", roleDefinitionId: SecretVillainRole.Good },
+];
+
+const playerIds = assignments.map((a) => a.playerId);
+
+function makePlayers() {
+  return playerIds.map((id) => ({
+    id,
+    name: `Player ${id}`,
+    sessionId: `session-${id}`,
+    visiblePlayers: [],
+  }));
+}
+
+const baseTurnState: SecretVillainTurnState = {
+  turn: 1,
+  phase: {
+    type: SecretVillainPhase.ElectionNomination,
+    startedAt: 1000,
+    presidentId: "p1",
+  },
+  presidentOrder: playerIds,
+  currentPresidentIndex: 1,
+  goodCardsPlayed: 0,
+  badCardsPlayed: 0,
+  deck: [],
+  discardPile: [],
+  eliminatedPlayerIds: [],
+  failedElectionCount: 0,
+};
+
+function makeGame(turnState: SecretVillainTurnState): Game {
+  return {
+    id: "game-1",
+    lobbyId: "lobby-1",
+    gameMode: GameMode.SecretVillain,
+    status: { type: GameStatus.Playing, turnState },
+    players: makePlayers(),
+    roleAssignments: assignments,
+    configuredRoleSlots: [],
+    showRolesInPlay: ShowRolesInPlay.None,
+    timerConfig: DEFAULT_TIMER_CONFIG,
+    nominationsEnabled: false,
+    singleTrialPerDay: false,
+    revealProtections: false,
+  } satisfies Game;
+}
+
+const goodRole = {
+  id: SecretVillainRole.Good,
+  name: "Good Role",
+  team: Team.Good,
+};
+
+describe("buildInitialTurnState", () => {
+  it("returns a turn state with turn 1", () => {
+    const ts = secretVillainServices.buildInitialTurnState(
+      assignments,
+    ) as SecretVillainTurnState;
+    expect(ts.turn).toBe(1);
+  });
+
+  it("starts in ElectionNomination phase with the first president", () => {
+    const ts = secretVillainServices.buildInitialTurnState(
+      assignments,
+    ) as SecretVillainTurnState;
+    expect(ts.phase.type).toBe(SecretVillainPhase.ElectionNomination);
+    expect(ts.phase.presidentId).toBe(ts.presidentOrder[0]);
+  });
+
+  it("sets currentPresidentIndex to 1", () => {
+    const ts = secretVillainServices.buildInitialTurnState(
+      assignments,
+    ) as SecretVillainTurnState;
+    expect(ts.currentPresidentIndex).toBe(1);
+  });
+
+  it("starts with 0 good and bad cards played", () => {
+    const ts = secretVillainServices.buildInitialTurnState(
+      assignments,
+    ) as SecretVillainTurnState;
+    expect(ts.goodCardsPlayed).toBe(0);
+    expect(ts.badCardsPlayed).toBe(0);
+  });
+
+  it("creates a deck with 17 cards (6 Good + 11 Bad)", () => {
+    const ts = secretVillainServices.buildInitialTurnState(
+      assignments,
+    ) as SecretVillainTurnState;
+    expect(ts.deck).toHaveLength(DECK_GOOD_CARDS + DECK_BAD_CARDS);
+    const goodCount = ts.deck.filter((c) => c === PolicyCard.Good).length;
+    const badCount = ts.deck.filter((c) => c === PolicyCard.Bad).length;
+    expect(goodCount).toBe(DECK_GOOD_CARDS);
+    expect(badCount).toBe(DECK_BAD_CARDS);
+  });
+
+  it("starts with empty discardPile, eliminatedPlayerIds, and 0 failedElectionCount", () => {
+    const ts = secretVillainServices.buildInitialTurnState(
+      assignments,
+    ) as SecretVillainTurnState;
+    expect(ts.discardPile).toEqual([]);
+    expect(ts.eliminatedPlayerIds).toEqual([]);
+    expect(ts.failedElectionCount).toBe(0);
+  });
+
+  it("includes all player IDs in presidentOrder", () => {
+    const ts = secretVillainServices.buildInitialTurnState(
+      assignments,
+    ) as SecretVillainTurnState;
+    expect(ts.presidentOrder).toHaveLength(playerIds.length);
+    for (const id of playerIds) {
+      expect(ts.presidentOrder).toContain(id);
+    }
+  });
+});
+
+describe("extractPlayerState", () => {
+  it("returns empty object when game is not playing", () => {
+    const game = {
+      ...makeGame(baseTurnState),
+      status: { type: GameStatus.Starting as const },
+    } satisfies Game;
+    expect(
+      secretVillainServices.extractPlayerState(game, "p1", goodRole),
+    ).toEqual({});
+  });
+
+  it("president sees drawn cards during PolicyPresident phase", () => {
+    const ts: SecretVillainTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: SecretVillainPhase.PolicyPresident,
+        startedAt: 1000,
+        presidentId: "p1",
+        chancellorId: "p2",
+        drawnCards: [PolicyCard.Good, PolicyCard.Bad, PolicyCard.Bad],
+      },
+    };
+    const result = secretVillainServices.extractPlayerState(
+      makeGame(ts),
+      "p1",
+      goodRole,
+    );
+    expect(result["policyCards"]).toEqual({
+      drawnCards: [PolicyCard.Good, PolicyCard.Bad, PolicyCard.Bad],
+    });
+  });
+
+  it("non-president does NOT see drawn cards during PolicyPresident phase", () => {
+    const ts: SecretVillainTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: SecretVillainPhase.PolicyPresident,
+        startedAt: 1000,
+        presidentId: "p1",
+        chancellorId: "p2",
+        drawnCards: [PolicyCard.Good, PolicyCard.Bad, PolicyCard.Bad],
+      },
+    };
+    const result = secretVillainServices.extractPlayerState(
+      makeGame(ts),
+      "p2",
+      goodRole,
+    );
+    expect(result["policyCards"]).toBeUndefined();
+  });
+
+  it("chancellor sees remaining cards during PolicyChancellor phase", () => {
+    const ts: SecretVillainTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: SecretVillainPhase.PolicyChancellor,
+        startedAt: 1000,
+        presidentId: "p1",
+        chancellorId: "p2",
+        remainingCards: [PolicyCard.Good, PolicyCard.Bad],
+      },
+    };
+    const result = secretVillainServices.extractPlayerState(
+      makeGame(ts),
+      "p2",
+      goodRole,
+    );
+    expect(result["policyCards"]).toEqual({
+      remainingCards: [PolicyCard.Good, PolicyCard.Bad],
+      vetoProposed: undefined,
+      vetoResponse: undefined,
+    });
+  });
+
+  it("non-chancellor does NOT see remaining cards during PolicyChancellor phase", () => {
+    const ts: SecretVillainTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: SecretVillainPhase.PolicyChancellor,
+        startedAt: 1000,
+        presidentId: "p1",
+        chancellorId: "p2",
+        remainingCards: [PolicyCard.Good, PolicyCard.Bad],
+      },
+    };
+    const result = secretVillainServices.extractPlayerState(
+      makeGame(ts),
+      "p3",
+      goodRole,
+    );
+    expect(result["policyCards"]).toBeUndefined();
+  });
+
+  it("president sees veto proposal when vetoProposed is true", () => {
+    const ts: SecretVillainTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: SecretVillainPhase.PolicyChancellor,
+        startedAt: 1000,
+        presidentId: "p1",
+        chancellorId: "p2",
+        remainingCards: [PolicyCard.Good, PolicyCard.Bad],
+        vetoProposed: true,
+      },
+    };
+    const result = secretVillainServices.extractPlayerState(
+      makeGame(ts),
+      "p1",
+      goodRole,
+    );
+    expect(result["vetoProposal"]).toEqual({
+      vetoProposed: true,
+      vetoResponse: undefined,
+    });
+  });
+
+  it("president sees peeked cards during PolicyPeek special action", () => {
+    const ts: SecretVillainTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: SecretVillainPhase.SpecialAction,
+        startedAt: 1000,
+        presidentId: "p1",
+        actionType: SpecialActionType.PolicyPeek,
+        peekedCards: [PolicyCard.Bad, PolicyCard.Good, PolicyCard.Bad],
+      },
+    };
+    const result = secretVillainServices.extractPlayerState(
+      makeGame(ts),
+      "p1",
+      goodRole,
+    );
+    expect(result["policyCards"]).toEqual({
+      peekedCards: [PolicyCard.Bad, PolicyCard.Good, PolicyCard.Bad],
+    });
+  });
+
+  it("president sees investigation result when revealedTeam is set", () => {
+    const ts: SecretVillainTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: SecretVillainPhase.SpecialAction,
+        startedAt: 1000,
+        presidentId: "p1",
+        actionType: SpecialActionType.InvestigateTeam,
+        targetPlayerId: "p3",
+        revealedTeam: "Bad",
+      },
+    };
+    const result = secretVillainServices.extractPlayerState(
+      makeGame(ts),
+      "p1",
+      goodRole,
+    );
+    expect(result["investigationResult"]).toEqual({
+      targetPlayerId: "p3",
+      team: "Bad",
+    });
+  });
+
+  it("player sees their own election vote during ElectionVote phase", () => {
+    const ts: SecretVillainTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: SecretVillainPhase.ElectionVote,
+        startedAt: 1000,
+        presidentId: "p1",
+        chancellorNomineeId: "p2",
+        votes: [{ playerId: "p3", vote: "aye" }],
+      },
+    };
+    const result = secretVillainServices.extractPlayerState(
+      makeGame(ts),
+      "p3",
+      goodRole,
+    );
+    expect(result["myElectionVote"]).toBe("aye");
+  });
+
+  it("president sees eligible chancellor IDs during ElectionNomination phase", () => {
+    const result = secretVillainServices.extractPlayerState(
+      makeGame(baseTurnState),
+      "p1",
+      goodRole,
+    );
+    expect(result["eligibleChancellorIds"]).toBeDefined();
+    expect(Array.isArray(result["eligibleChancellorIds"])).toBe(true);
+    expect(result["eligibleChancellorIds"]).not.toContain("p1");
+  });
+
+  it("eliminated player has amDead set to true", () => {
+    const ts: SecretVillainTurnState = {
+      ...baseTurnState,
+      eliminatedPlayerIds: ["p3"],
+    };
+    const result = secretVillainServices.extractPlayerState(
+      makeGame(ts),
+      "p3",
+      goodRole,
+    );
+    expect(result["amDead"]).toBe(true);
+  });
+
+  it("deadPlayerIds is set when any players are eliminated", () => {
+    const ts: SecretVillainTurnState = {
+      ...baseTurnState,
+      eliminatedPlayerIds: ["p3", "p5"],
+    };
+    const result = secretVillainServices.extractPlayerState(
+      makeGame(ts),
+      "p1",
+      goodRole,
+    );
+    expect(result["deadPlayerIds"]).toEqual(["p3", "p5"]);
+  });
+});

--- a/app/src/lib/game-modes/secret-villain/services.ts
+++ b/app/src/lib/game-modes/secret-villain/services.ts
@@ -1,16 +1,142 @@
-import type { GameModeServices } from "@/lib/types";
+import { GameStatus } from "@/lib/types";
+import type { Game, GameModeServices, PlayerRoleAssignment } from "@/lib/types";
+import { SecretVillainPhase } from "./types";
+import type { SecretVillainTurnState } from "./types";
+import { createDeck, getEligibleChancellorIds } from "./utils";
 
-/** Stub services for Secret Villain — to be implemented with gameplay. */
+function shuffle<T>(array: T[]): T[] {
+  const result = [...array];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const temp = result[i] as T;
+    result[i] = result[j] as T;
+    result[j] = temp;
+  }
+  return result;
+}
+
 export const secretVillainServices: GameModeServices = {
-  buildInitialTurnState() {
-    return undefined;
+  buildInitialTurnState(
+    roleAssignments: PlayerRoleAssignment[],
+  ): SecretVillainTurnState {
+    const playerIds = shuffle(roleAssignments.map((a) => a.playerId));
+    const firstPresidentId = playerIds[0];
+    if (!firstPresidentId) {
+      throw new Error("No players to initialize Secret Villain game");
+    }
+
+    return {
+      turn: 1,
+      phase: {
+        type: SecretVillainPhase.ElectionNomination,
+        startedAt: Date.now(),
+        presidentId: firstPresidentId,
+      },
+      presidentOrder: playerIds,
+      currentPresidentIndex: 1,
+      goodCardsPlayed: 0,
+      badCardsPlayed: 0,
+      deck: createDeck(),
+      discardPile: [],
+      eliminatedPlayerIds: [],
+      failedElectionCount: 0,
+    };
   },
 
   selectSpecialTargets() {
     return {};
   },
 
-  extractPlayerState() {
-    return {};
+  extractPlayerState(game: Game, callerId: string): Record<string, unknown> {
+    if (game.status.type !== GameStatus.Playing) return {};
+    const ts = game.status.turnState as SecretVillainTurnState | undefined;
+    if (!ts) return {};
+
+    const result: Record<string, unknown> = {};
+    const { phase } = ts;
+
+    // President sees drawn cards during policy president phase.
+    if (
+      phase.type === SecretVillainPhase.PolicyPresident &&
+      phase.presidentId === callerId
+    ) {
+      result["policyCards"] = {
+        drawnCards: phase.drawnCards,
+        ...(phase.discardedCard !== undefined
+          ? { discardedCard: phase.discardedCard }
+          : {}),
+      };
+    }
+
+    // Chancellor sees remaining cards during policy chancellor phase.
+    if (
+      phase.type === SecretVillainPhase.PolicyChancellor &&
+      phase.chancellorId === callerId
+    ) {
+      result["policyCards"] = {
+        remainingCards: phase.remainingCards,
+        vetoProposed: phase.vetoProposed,
+        vetoResponse: phase.vetoResponse,
+      };
+    }
+
+    // President sees veto proposal during chancellor phase.
+    if (
+      phase.type === SecretVillainPhase.PolicyChancellor &&
+      phase.presidentId === callerId &&
+      phase.vetoProposed
+    ) {
+      result["vetoProposal"] = {
+        vetoProposed: true,
+        vetoResponse: phase.vetoResponse,
+      };
+    }
+
+    // President sees peeked cards during policy peek.
+    if (
+      phase.type === SecretVillainPhase.SpecialAction &&
+      phase.presidentId === callerId &&
+      phase.peekedCards
+    ) {
+      result["policyCards"] = { peekedCards: phase.peekedCards };
+    }
+
+    // President sees investigation result.
+    if (
+      phase.type === SecretVillainPhase.SpecialAction &&
+      phase.presidentId === callerId &&
+      phase.revealedTeam
+    ) {
+      result["investigationResult"] = {
+        targetPlayerId: phase.targetPlayerId ?? "",
+        team: phase.revealedTeam,
+      };
+    }
+
+    // Election vote phase: include the player's own vote.
+    if (phase.type === SecretVillainPhase.ElectionVote) {
+      const myVote = phase.votes.find((v) => v.playerId === callerId);
+      if (myVote) {
+        result["myElectionVote"] = myVote.vote;
+      }
+    }
+
+    // Eligible chancellors for nomination phase (president only).
+    if (
+      phase.type === SecretVillainPhase.ElectionNomination &&
+      phase.presidentId === callerId
+    ) {
+      result["eligibleChancellorIds"] = getEligibleChancellorIds(ts, callerId);
+    }
+
+    // Eliminated state.
+    if (ts.eliminatedPlayerIds.includes(callerId)) {
+      result["amDead"] = true;
+    }
+    if (ts.eliminatedPlayerIds.length > 0) {
+      result["deadPlayerIds"] = ts.eliminatedPlayerIds;
+    }
+
+    return result;
   },
 };


### PR DESCRIPTION
## Summary
- Implements `buildInitialTurnState` for Secret Villain: creates shuffled 17-card deck, randomized president rotation order, starts in ElectionNomination phase
- Implements `extractPlayerState` with per-player visibility:
  - **President**: drawn cards (PolicyPresident), peeked cards (PolicyPeek), investigation results, veto proposals, eligible chancellor IDs (ElectionNomination)
  - **Chancellor**: remaining cards and veto state (PolicyChancellor)
  - **All players**: own election vote, eliminated status
- Uses Secret Villain-specific field names (`policyCards`, `myElectionVote`, `eligibleChancellorIds`, `vetoProposal`, `investigationResult`) to avoid collision with Werewolf-specific `PlayerGameState` fields

## Related
- Filed #322 to refactor Werewolf-specific fields out of the generic `PlayerGameState` interface

## Test plan
- [x] TypeScript compiles with zero errors
- [x] ESLint passes with zero errors
- [x] 796 tests pass (18 new service tests)

Part of #288. Closes #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)