### PR TITLE
Add component test specs for Werewolf and shared UI components (#334)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,4 +77,13 @@ pnpm build-storybook  # Build static Storybook
 - Story files are co-located with their component: `ComponentName.stories.tsx`.
 - When adding or modifying a UI component, add or update its Storybook story to cover key visual states.
 - Stories should use mock data fixtures — never import from Firebase or depend on runtime providers (QueryClient, Redux store, Next.js router).
-- Components that are too hook-dependent to render in isolation should be noted but not storied until a decorator or presentational extraction is in place.
+- Components that are too hook-dependent to render in isolation should use a presentational split: extract rendering into a `ComponentNameView` that accepts callbacks, and keep the original as a thin wrapper that wires up hooks.
+
+## Component Tests
+
+- Test files are co-located with their component: `ComponentName.test.tsx`.
+- When adding or modifying a UI component, add or update its test to verify rendering behavior and key prop-driven states.
+- Use `@testing-library/react` with `vitest`. Always call `afterEach(cleanup)`.
+- Do not use `.toBeInTheDocument()` — use `.toBeDefined()` or check `.textContent` instead.
+- Assert against copy constants (e.g., `WEREWOLF_COPY`) rather than hardcoded strings.
+- Test presentational view components directly; avoid mocking hooks in tests where possible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,9 +126,23 @@ Every component or module directory should have an `index.ts` that re-exports it
 
 Stories are co-located with their component as `ComponentName.stories.tsx`. When adding or modifying a UI component, update its story to cover key visual states (default, empty, error, role-specific variants).
 
-Stories must render in isolation — use mock data fixtures, not Firebase or runtime providers. If a component is too tightly coupled to hooks (e.g., `useGameAction`, `useRouter`), note it as a gap rather than adding a fragile story.
+Stories must render in isolation — use mock data fixtures, not Firebase or runtime providers. If a component is too tightly coupled to hooks (e.g., `useGameAction`, `useRouter`), use a **presentational split**: extract rendering into a `ComponentNameView` that accepts callbacks, and keep the original as a thin wrapper that wires up hooks. Story and test the view component directly.
 
 ```bash
 pnpm storybook        # Dev server at http://localhost:6006
 pnpm build-storybook  # Static build to storybook-static/
 ```
+
+---
+
+## Component Tests
+
+Component tests are co-located as `ComponentName.test.tsx`. When adding or modifying a UI component, add tests that verify:
+
+- Correct rendering for key prop combinations
+- Conditional rendering (shows/hides sections based on props)
+- Text content matches copy constants (assert against `WEREWOLF_COPY` etc., not hardcoded strings)
+
+Use `@testing-library/react` with `vitest`. Always call `afterEach(cleanup)` — the component test project does not auto-cleanup. Do not use `.toBeInTheDocument()` (no jest-dom); use `.toBeDefined()` or check `.textContent` instead.
+
+Test presentational view components directly rather than mocking hooks. This keeps tests fast and focused on rendering behavior.

--- a/src/components/game/GameRolesList.test.tsx
+++ b/src/components/game/GameRolesList.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { GameRolesList } from "./GameRolesList";
+import type { RoleInPlay } from "@/server/types";
+import { Team } from "@/lib/types";
+
+afterEach(cleanup);
+
+const mockRoles: RoleInPlay[] = [
+  { id: "seer", name: "Seer", team: Team.Good, min: 1, max: 1, count: 1 },
+  {
+    id: "werewolf",
+    name: "Werewolf",
+    team: Team.Bad,
+    min: 1,
+    max: 3,
+    count: 2,
+  },
+  {
+    id: "villager",
+    name: "Villager",
+    team: Team.Good,
+    min: 2,
+    max: 4,
+  },
+];
+
+describe("GameRolesList", () => {
+  it("renders role names when rolesInPlay is provided", () => {
+    render(<GameRolesList roles={mockRoles} />);
+
+    expect(screen.getByText("Roles In Play")).toBeDefined();
+    expect(screen.getByText(/Seer/)).toBeDefined();
+    expect(screen.getByText(/Werewolf/)).toBeDefined();
+    expect(screen.getByText(/Villager/)).toBeDefined();
+  });
+
+  it("renders nothing when rolesInPlay is an empty array", () => {
+    const { container } = render(<GameRolesList roles={[]} />);
+
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/src/components/game/werewolf/ConfirmTargetButtonView.test.tsx
+++ b/src/components/game/werewolf/ConfirmTargetButtonView.test.tsx
@@ -1,0 +1,76 @@
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { ConfirmTargetButtonView } from "./ConfirmTargetButtonView";
+import { WEREWOLF_COPY } from "@/lib/game-modes/werewolf/copy";
+
+afterEach(cleanup);
+
+const defaultProps = {
+  hasTarget: false,
+  hasDecided: false,
+  isConfirmed: false,
+  onConfirm: vi.fn(),
+};
+
+describe("ConfirmTargetButtonView", () => {
+  it("shows 'Action confirmed!' text when isConfirmed is true", () => {
+    render(<ConfirmTargetButtonView {...defaultProps} isConfirmed={true} />);
+    expect(
+      screen.getByText(WEREWOLF_COPY.confirmButton.actionConfirmed),
+    ).toBeDefined();
+  });
+
+  it("shows 'Skip' label when hasDecided is true but hasTarget is false", () => {
+    render(
+      <ConfirmTargetButtonView
+        {...defaultProps}
+        hasDecided={true}
+        hasTarget={false}
+      />,
+    );
+    expect(
+      screen.getByRole("button", {
+        name: WEREWOLF_COPY.confirmButton.skip,
+      }),
+    ).toBeDefined();
+  });
+
+  it("button is disabled when hasDecided is false", () => {
+    render(<ConfirmTargetButtonView {...defaultProps} hasDecided={false} />);
+    const button = screen.getByRole("button", {
+      name: WEREWOLF_COPY.confirmButton.confirm,
+    });
+    expect(button.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("button is disabled when isPending is true", () => {
+    render(
+      <ConfirmTargetButtonView
+        {...defaultProps}
+        hasDecided={true}
+        isPending={true}
+      />,
+    );
+    const button = screen.getByRole("button", {
+      name: WEREWOLF_COPY.confirmButton.skip,
+    });
+    expect(button.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("button is disabled when group needs consensus", () => {
+    render(
+      <ConfirmTargetButtonView
+        {...defaultProps}
+        hasDecided={true}
+        hasTarget={true}
+        isGroupPhase={true}
+        hasGroupMembers={true}
+        allAgreed={false}
+      />,
+    );
+    const button = screen.getByRole("button", {
+      name: WEREWOLF_COPY.confirmButton.confirm,
+    });
+    expect(button.hasAttribute("disabled")).toBe(true);
+  });
+});

--- a/src/components/game/werewolf/GameOverScreenView.test.tsx
+++ b/src/components/game/werewolf/GameOverScreenView.test.tsx
@@ -1,0 +1,111 @@
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { GameOverScreenView } from "./GameOverScreenView";
+import { WerewolfWinner } from "@/lib/game-modes/werewolf/utils/win-condition";
+import { GameStatus, GameMode, Team, DEFAULT_TIMER_CONFIG } from "@/lib/types";
+import { WEREWOLF_COPY } from "@/lib/game-modes/werewolf/copy";
+import type { PlayerGameState } from "@/server/types";
+
+afterEach(cleanup);
+
+function makeGameState(
+  overrides: Partial<PlayerGameState> = {},
+): PlayerGameState {
+  return {
+    status: { type: GameStatus.Finished, winner: WerewolfWinner.Village },
+    gameMode: GameMode.Werewolf,
+    lobbyId: "lobby-1",
+    players: [
+      { id: "p1", name: "Alice" },
+      { id: "p2", name: "Bob" },
+    ],
+    visibleRoleAssignments: [
+      {
+        player: { id: "p1", name: "Alice" },
+        reason: "revealed" as const,
+        role: { id: "villager", name: "Villager", team: Team.Good },
+      },
+      {
+        player: { id: "p2", name: "Bob" },
+        reason: "revealed" as const,
+        role: { id: "werewolf", name: "Werewolf", team: Team.Bad },
+      },
+    ],
+    timerConfig: DEFAULT_TIMER_CONFIG,
+    nominationsEnabled: false,
+    singleTrialPerDay: false,
+    revealProtections: false,
+    ...overrides,
+  };
+}
+
+const defaultProps = {
+  onReturnToLobby: vi.fn(),
+};
+
+describe("GameOverScreenView", () => {
+  it("shows victory heading for Good team player when Village wins", () => {
+    const gameState = makeGameState({
+      myRole: { id: "villager", name: "Villager", team: Team.Good },
+      myPlayerId: "p1",
+    });
+    render(<GameOverScreenView {...defaultProps} gameState={gameState} />);
+    expect(screen.getByText(WEREWOLF_COPY.gameOver.victory)).toBeDefined();
+  });
+
+  it("shows defeat heading for Good team player when Werewolves win", () => {
+    const gameState = makeGameState({
+      status: { type: GameStatus.Finished, winner: WerewolfWinner.Werewolves },
+      myRole: { id: "villager", name: "Villager", team: Team.Good },
+      myPlayerId: "p1",
+    });
+    render(<GameOverScreenView {...defaultProps} gameState={gameState} />);
+    expect(screen.getByText(WEREWOLF_COPY.gameOver.defeat)).toBeDefined();
+  });
+
+  it("shows winner label for narrator (no myRole)", () => {
+    const gameState = makeGameState({
+      myRole: undefined,
+      myPlayerId: undefined,
+    });
+    render(<GameOverScreenView {...defaultProps} gameState={gameState} />);
+    expect(
+      screen.getByText(
+        WEREWOLF_COPY.gameOver.winnerLabel(WerewolfWinner.Village),
+      ),
+    ).toBeDefined();
+  });
+
+  it("shows draw heading when winner is Draw", () => {
+    const gameState = makeGameState({
+      status: { type: GameStatus.Finished, winner: WerewolfWinner.Draw },
+      myRole: { id: "villager", name: "Villager", team: Team.Good },
+      myPlayerId: "p1",
+    });
+    render(<GameOverScreenView {...defaultProps} gameState={gameState} />);
+    expect(screen.getByText(WEREWOLF_COPY.gameOver.draw)).toBeDefined();
+  });
+
+  it("shows return-to-lobby error message when returnError is true", () => {
+    const gameState = makeGameState();
+    render(
+      <GameOverScreenView
+        {...defaultProps}
+        gameState={gameState}
+        returnError={true}
+      />,
+    );
+    expect(
+      screen.getByText(WEREWOLF_COPY.gameOver.returnToLobbyError),
+    ).toBeDefined();
+  });
+
+  it("renders role assignment list with player names", () => {
+    const gameState = makeGameState();
+    render(<GameOverScreenView {...defaultProps} gameState={gameState} />);
+    expect(screen.getByText("Alice")).toBeDefined();
+    expect(screen.getByText("Bob")).toBeDefined();
+    expect(screen.getByText("Villager")).toBeDefined();
+    expect(screen.getByText("Werewolf")).toBeDefined();
+  });
+});

--- a/src/components/game/werewolf/PlayerNightSummary.test.tsx
+++ b/src/components/game/werewolf/PlayerNightSummary.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { PlayerNightSummary } from "./PlayerNightSummary";
+import type { DaytimeNightStatusEntry } from "@/server/types";
+import type { PublicLobbyPlayer } from "@/server/types/lobby";
+import { WEREWOLF_COPY } from "@/lib/game-modes/werewolf/copy";
+
+afterEach(cleanup);
+
+const players: PublicLobbyPlayer[] = [
+  { id: "p1", name: "Alice" },
+  { id: "p2", name: "Bob" },
+  { id: "p3", name: "Charlie" },
+];
+
+describe("PlayerNightSummary", () => {
+  it("renders killed player text", () => {
+    const nightStatus: DaytimeNightStatusEntry[] = [
+      { targetPlayerId: "p1", effect: "killed" },
+    ];
+
+    render(<PlayerNightSummary players={players} nightStatus={nightStatus} />);
+
+    expect(screen.getByText("Last Night")).toBeDefined();
+    expect(screen.getByText("Alice was eliminated.")).toBeDefined();
+  });
+
+  it("renders protected player text", () => {
+    const nightStatus: DaytimeNightStatusEntry[] = [
+      { targetPlayerId: "p2", effect: "protected" },
+    ];
+
+    render(<PlayerNightSummary players={players} nightStatus={nightStatus} />);
+
+    const expectedText = WEREWOLF_COPY.day.protected("Bob");
+    expect(screen.getByText(expectedText)).toBeDefined();
+  });
+
+  it("renders nothing when nightStatus is empty", () => {
+    const { container } = render(
+      <PlayerNightSummary players={players} nightStatus={[]} />,
+    );
+
+    expect(container.querySelector("h2")).toBeNull();
+  });
+
+  it("renders nothing when nightStatus is undefined", () => {
+    const { container } = render(<PlayerNightSummary players={players} />);
+
+    expect(container.querySelector("h2")).toBeNull();
+  });
+
+  it("renders multiple effects", () => {
+    const nightStatus: DaytimeNightStatusEntry[] = [
+      { targetPlayerId: "p1", effect: "killed" },
+      { targetPlayerId: "p2", effect: "protected" },
+      { targetPlayerId: "p3", effect: "peaceful" },
+    ];
+
+    render(<PlayerNightSummary players={players} nightStatus={nightStatus} />);
+
+    expect(screen.getByText("Alice was eliminated.")).toBeDefined();
+    expect(screen.getByText(WEREWOLF_COPY.day.protected("Bob"))).toBeDefined();
+    expect(
+      screen.getByText(WEREWOLF_COPY.oldMan.peacefulDeath("Charlie")),
+    ).toBeDefined();
+  });
+});

--- a/src/components/game/werewolf/PlayerRoleDisplay.test.tsx
+++ b/src/components/game/werewolf/PlayerRoleDisplay.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  act,
+} from "@testing-library/react";
+import { PlayerRoleDisplay } from "./PlayerRoleDisplay";
+import type { PublicRoleInfo } from "@/server/types";
+import { GameMode, Team } from "@/lib/types";
+import { WEREWOLF_COPY } from "@/lib/game-modes/werewolf/copy";
+
+afterEach(cleanup);
+
+const mockRole: PublicRoleInfo = {
+  id: "seer",
+  name: "Seer",
+  team: Team.Good,
+};
+
+describe("PlayerRoleDisplay", () => {
+  it("renders the show role button by default", () => {
+    render(<PlayerRoleDisplay role={mockRole} gameMode={GameMode.Werewolf} />);
+
+    expect(screen.getByText(WEREWOLF_COPY.roleDisplay.showRole)).toBeDefined();
+  });
+
+  it("renders role name and team label when revealed", () => {
+    render(<PlayerRoleDisplay role={mockRole} gameMode={GameMode.Werewolf} />);
+
+    act(() => {
+      fireEvent.click(screen.getByText(WEREWOLF_COPY.roleDisplay.showRole));
+    });
+
+    const expectedText = WEREWOLF_COPY.roleDisplay.roleRevealed(
+      "Seer",
+      "Villagers",
+    );
+    expect(screen.getByText(expectedText)).toBeDefined();
+  });
+
+  it("renders role name with raw team when no gameMode is provided", () => {
+    render(<PlayerRoleDisplay role={mockRole} />);
+
+    act(() => {
+      fireEvent.click(screen.getByText(WEREWOLF_COPY.roleDisplay.showRole));
+    });
+
+    const expectedText = WEREWOLF_COPY.roleDisplay.roleRevealed("Seer", "Good");
+    expect(screen.getByText(expectedText)).toBeDefined();
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -22,6 +22,14 @@ export default defineConfig({
         },
         resolve: { alias: { "@": path.resolve(import.meta.dirname, "./src") } },
       },
+      {
+        test: {
+          name: "components",
+          environment: "happy-dom",
+          include: ["src/**/*.test.tsx"],
+        },
+        resolve: { alias: { "@": path.resolve(import.meta.dirname, "./src") } },
+      },
     ],
   },
 });


### PR DESCRIPTION
## Summary
- Adds a `components` vitest project with `happy-dom` environment for `.test.tsx` files
- Creates 5 component test files with 21 tests covering key UI components
- Updates AGENTS.md and CONTRIBUTING.md with component testing conventions

### Tests added

**Presentational view components:**
- `ConfirmTargetButtonView` (5 tests) — confirmed state, skip label, disabled states (undecided, pending, group consensus)
- `GameOverScreenView` (6 tests) — victory/defeat/draw headings, narrator view, error message, role assignment list

**Shared game components:**
- `GameRolesList` (2 tests) — renders role names, handles empty state
- `PlayerNightSummary` (5 tests) — killed/protected/peaceful text, multiple effects, empty/undefined nightStatus
- `PlayerRoleDisplay` (3 tests) — hidden state, role reveal on click, team label rendering

### Documentation updates
- **AGENTS.md**: Added Component Tests section with co-location, testing library patterns, copy constant assertions, presentational split guidance
- **CONTRIBUTING.md**: Added Component Tests section with same conventions in expanded form

## Test plan
- [x] TypeScript compiles with zero errors
- [x] ESLint passes with zero errors
- [x] 834 tests pass across 89 test files (21 new component tests)

Closes #334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)