### PR TITLE
Add missing coding conventions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ pnpm build-storybook  # Build static Storybook
 
 - All user-facing strings must be stored in a co-located copy file (e.g., `ComponentName.copy.ts` or `copy.ts`) for internationalization (i18n) readiness.
 - Do not hardcode display strings inline in components.
+- Copy files export a single `as const` object named `{SCOPE}_COPY` (e.g., `WEREWOLF_COPY`, `HOME_PAGE_COPY`, `GAME_TIMER_COPY`).
 
 ## Documentation
 
@@ -71,6 +72,24 @@ pnpm build-storybook  # Build static Storybook
 ### Component Structure
 
 - Components should have a single JSX return statement. Invalid states should be prevented by the type system or guarded against by the calling component. An early `return null` can be acceptable if the invalid state is infeasible for the parent component to detect, but the component itself should be returned as a single JSX block.
+
+## Naming Conventions
+
+- **Game actions**: Export as `{actionName}Action` with type `GameAction` (e.g., `castVoteAction`, `startNightAction`).
+- **Firebase schema conversions**: `{domain}ToFirebase()` / `firebaseTo{Domain}()` (e.g., `gameToFirebase()`, `firebaseToGame()`).
+- **Redux slices**: File suffix `-slice.ts` (e.g., `game-config-slice.ts`).
+- **Presentational views**: Components extracted for testability use the `{Component}View` suffix (e.g., `GameOverScreenView`, `ConfirmTargetButtonView`).
+
+## Testing Conventions
+
+- Use `describe`/`it` from Vitest (not `test`).
+- Test fixture generators use `make{DomainName}()` (e.g., `makePlayingGame()`, `makeGameState()`).
+- When splitting large test files, organize into `{module}-tests/` directories (e.g., `resolution-tests/altruist.test.ts`).
+
+## Git Conventions
+
+- Branch names: lowercase with hyphens, prefixed by type: `feature/`, `chore/`, `refactor/`, `docs/`, with issue number suffix (e.g., `feature/secret-villain-deck-290`).
+- Commit messages: imperative verbs (Add, Implement, Fix, Update, Extract, Remove). No `feat:`/`fix:` prefixes.
 
 ## Storybook
 


### PR DESCRIPTION
## Summary
- Documents coding conventions that are consistently followed but not previously captured in AGENTS.md
- Removes stale `/app` directory from Dependabot config (leftover from monorepo flattening in #327)

### AGENTS.md additions
- **Copy file naming**: `{SCOPE}_COPY` export with `as const`
- **Game action naming**: `{actionName}Action` with `GameAction` type
- **Firebase schema naming**: `{domain}ToFirebase()` / `firebaseTo{Domain}()`
- **Redux slice naming**: `-slice.ts` suffix
- **Presentational view naming**: `{Component}View` suffix for hook-extracted components
- **Test conventions**: `describe`/`it` (not `test`), `make{Domain}()` fixture generators
- **Git conventions**: branch naming pattern (`feature/`, `chore/`, etc. with issue number), imperative commit verbs

### Dependabot fix
Merged the two npm update entries (root + `/app`) into one with dev/production dependency grouping, since all deps now live in the root `package.json`.

## Test plan
- [x] No code changes — documentation and config only
- [x] Lint and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)