### PR TITLE
Remove stale /app directory from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,7 @@
 version: 2
 updates:
-  # Root workspace dependencies
   - package-ecosystem: npm
     directory: /
-    schedule:
-      interval: weekly
-    groups:
-      dev-dependencies:
-        patterns:
-          - "*"
-
-  # Next.js app dependencies
-  - package-ecosystem: npm
-    directory: /app
     schedule:
       interval: weekly
     groups:
@@ -25,7 +14,6 @@ updates:
         patterns:
           - "*"
 
-  # GitHub Actions
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## Summary
The monorepo was flattened in #327 but the Dependabot config still had separate npm entries for `/` (root workspace) and `/app` (Next.js app). Merges them into a single entry with proper dev/production dependency grouping.

## Test plan
- [x] Config-only change — no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)