### PR TITLE
Remove redundant .npmrc to fix npm warning (#330)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-node-linker=isolated


### PR DESCRIPTION
## Summary
Removes `.npmrc` which contained only `node-linker=isolated` — this is pnpm's default since v7, making the file redundant. npm reads `.npmrc` and warns about the unknown key, producing:

```
npm warn Unknown project config "node-linker". This will stop working in the next major version of npm.
```

The project already uses `pnpm exec` everywhere (pre-commit hook, CI). No `npx` usage found in any scripts or workflows.

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds without `.npmrc`
- [x] 843 tests pass
- [x] Pre-commit hook (`pnpm exec lint-staged`) still works

Closes #330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)