### PR TITLE
Fix Mortician ability not ending after killing a Werewolf (#344)

### DIFF
--- a/src/lib/game-modes/werewolf/actions/start-night.test.ts
+++ b/src/lib/game-modes/werewolf/actions/start-night.test.ts
@@ -249,4 +249,23 @@ describe("StartNight — Mirrorcaster charge persistence", () => {
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
     expect(ts.mirrorcasterCharged).toBeUndefined();
   });
+
+  it("carries morticianAbilityEnded forward to next night", () => {
+    const game = makePlayingGame({
+      ...dayTurnState,
+      morticianAbilityEnded: true,
+    });
+    startNightAction.apply(game, null, "owner-1");
+
+    const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
+    expect(ts.morticianAbilityEnded).toBe(true);
+  });
+
+  it("does not carry morticianAbilityEnded when it is false/undefined", () => {
+    const game = makePlayingGame(dayTurnState);
+    startNightAction.apply(game, null, "owner-1");
+
+    const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
+    expect(ts.morticianAbilityEnded).toBeUndefined();
+  });
 });

--- a/src/lib/game-modes/werewolf/actions/start-night.ts
+++ b/src/lib/game-modes/werewolf/actions/start-night.ts
@@ -57,6 +57,7 @@ export const startNightAction: GameAction = {
           ? { oneEyedSeerLockedTargetId: ts.oneEyedSeerLockedTargetId }
           : {}),
         ...(ts.exposerAbilityUsed ? { exposerAbilityUsed: true } : {}),
+        ...(ts.morticianAbilityEnded ? { morticianAbilityEnded: true } : {}),
         ...(ts.exposerReveal ? { exposerReveal: ts.exposerReveal } : {}),
         ...(ts.executionerTargetId
           ? { executionerTargetId: ts.executionerTargetId }


### PR DESCRIPTION
## Summary

The `morticianAbilityEnded` flag was set correctly in `start-day` when the Mortician killed a Werewolf, but `start-night` did not carry it forward when building the next turn's state. The flag was silently dropped on every day→night transition, allowing the Mortician to continue targeting on subsequent nights.

### Root cause

`start-night.ts` builds a fresh turn state and explicitly carries forward persistent flags (`witchAbilityUsed`, `exposerAbilityUsed`, `mirrorcasterCharged`, etc.) but `morticianAbilityEnded` was missing from the list.

### Fix

Add `morticianAbilityEnded` to the `start-night` carry-forward list, matching the existing pattern for other once-per-game ability flags.

## Test plan
- [x] TypeScript compiles with zero errors
- [x] 845 tests pass (2 new regression tests)
- [x] New test: `morticianAbilityEnded` carries forward to next night
- [x] New test: flag is not present when ability hasn't been used

Closes #344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)