### PR TITLE
Remove game state polling — rely on Firebase real-time push

### DIFF
--- a/src/app/[gameMode]/game/[gameId]/page.tsx
+++ b/src/app/[gameMode]/game/[gameId]/page.tsx
@@ -1,16 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { GameMode, GameStatus } from "@/lib/types";
+import { GameMode } from "@/lib/types";
 import { useGameStateQuery, GameModeContext } from "@/hooks";
 import { WerewolfGameScreen } from "@/components/game";
 import type { WerewolfPlayerGameState } from "@/lib/game-modes/werewolf/player-state";
 import { parseGameMode } from "@/lib/game-modes";
 import { GAME_PAGE_COPY } from "./page.copy";
 import { UnsupportedGameMode } from "../UnsupportedGameMode";
-
-const POLL_INTERVAL_MS = 2000;
 
 export default function GameModePage() {
   const { gameId, gameMode: gameModeParam } = useParams<{
@@ -19,19 +17,14 @@ export default function GameModePage() {
   }>();
   const router = useRouter();
 
-  const [refetchInterval, setRefetchInterval] = useState<number | undefined>(
-    POLL_INTERVAL_MS,
-  );
-
   const validatedGameMode = parseGameMode(gameModeParam);
 
   const {
     data: gameState,
     isLoading,
     error,
-  } = useGameStateQuery(gameId, validatedGameMode, refetchInterval);
+  } = useGameStateQuery(gameId, validatedGameMode);
 
-  const gameStatus = gameState?.status.type;
   const actualGameMode = gameState?.gameMode;
 
   useEffect(() => {
@@ -39,12 +32,6 @@ export default function GameModePage() {
       router.push("/");
     }
   }, [validatedGameMode, router]);
-
-  useEffect(() => {
-    if (gameStatus && gameStatus !== GameStatus.Starting) {
-      setRefetchInterval(undefined);
-    }
-  }, [gameStatus]);
 
   useEffect(() => {
     if (error?.message === "401" || error?.message === "403") {

--- a/src/app/debug/GameScreenForPlayer.tsx
+++ b/src/app/debug/GameScreenForPlayer.tsx
@@ -1,13 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { GameStatus } from "@/lib/types";
 import type { GameMode } from "@/lib/types";
 import { useGameStateQuery, GameModeContext } from "@/hooks";
 import { WerewolfGameScreen } from "@/components/game";
 import type { WerewolfPlayerGameState } from "@/lib/game-modes/werewolf/player-state";
-
-const POLL_INTERVAL_MS = 2000;
 
 export function GameScreenForPlayer({
   gameId,
@@ -16,23 +12,11 @@ export function GameScreenForPlayer({
   gameId: string;
   gameMode: GameMode;
 }) {
-  const [refetchInterval, setRefetchInterval] = useState<number | undefined>(
-    POLL_INTERVAL_MS,
-  );
-
   const {
     data: gameState,
     isLoading,
     error,
-  } = useGameStateQuery(gameId, gameMode, refetchInterval);
-
-  const gameStatus = gameState?.status.type;
-
-  useEffect(() => {
-    if (gameStatus !== undefined && gameStatus !== GameStatus.Starting) {
-      setRefetchInterval(undefined);
-    }
-  }, [gameStatus]);
+  } = useGameStateQuery(gameId, gameMode);
 
   if (!gameState) {
     return (

--- a/src/components/game/werewolf/PlayerGameScreen.tsx
+++ b/src/components/game/werewolf/PlayerGameScreen.tsx
@@ -4,11 +4,8 @@ import { GameStatus } from "@/lib/types";
 import { WerewolfPhase } from "@/lib/game-modes/werewolf";
 import type { WerewolfTurnState } from "@/lib/game-modes/werewolf";
 import type { WerewolfPlayerGameState } from "@/lib/game-modes/werewolf/player-state";
-import { useGameStateQuery } from "@/hooks";
 import { PlayerGameNightScreen } from "./PlayerGameNightScreen";
 import { PlayerGameDayScreen } from "./PlayerGameDayScreen";
-
-const POLL_INTERVAL_MS = 2000;
 
 interface PlayerGameScreenProps {
   gameId: string;
@@ -22,15 +19,6 @@ export function PlayerGameScreen({ gameId, gameState }: PlayerGameScreenProps) {
     status.type === GameStatus.Playing
       ? (status.turnState as WerewolfTurnState | undefined)
       : undefined;
-
-  const isNighttime = turnState?.phase.type === WerewolfPhase.Nighttime;
-
-  // Poll throughout nighttime to detect when this player's turn starts or ends.
-  useGameStateQuery(
-    gameId,
-    gameState.gameMode,
-    isNighttime ? POLL_INTERVAL_MS : undefined,
-  );
 
   if (status.type !== GameStatus.Playing || !turnState) return null;
 

--- a/src/hooks/game.ts
+++ b/src/hooks/game.ts
@@ -46,7 +46,6 @@ export function useStartGame(lobbyId: string) {
 export function useGameStateQuery(
   gameId: string,
   gameMode: GameMode | undefined,
-  refetchInterval?: number,
 ) {
   const queryClient = useQueryClient();
   const { isReady } = useFirebaseAuth();
@@ -90,7 +89,6 @@ export function useGameStateQuery(
     },
     enabled: !!gameMode,
     retry: false,
-    refetchInterval,
   });
 }
 


### PR DESCRIPTION
## Summary

Removes redundant HTTP polling from game state queries. Firebase `onValue` subscription in `useGameStateQuery` already provides real-time push updates for all state transitions — the `refetchInterval` parameter was a legacy from before Firebase real-time was implemented.

### Changes
- Remove `refetchInterval` parameter from `useGameStateQuery`
- Remove polling state (`useState`, `setRefetchInterval`) and interval effect from game page
- Remove polling state from debug `GameScreenForPlayer`
- Remove nighttime polling from `PlayerGameScreen` (Firebase push already delivers state changes when the player's turn starts/ends)

### Net effect
- 4 files changed, 4 insertions, 47 deletions
- Simpler component code — no polling state management
- No behavior change — Firebase real-time was already handling all updates

## Test plan
- [x] TypeScript compiles with zero errors
- [x] ESLint passes with zero errors
- [x] 843 tests pass
- [x] Verify Werewolf gameplay: player night screen updates when turn starts/ends
- [x] Verify game transitions (Starting → Playing → Finished) update in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)