### PR TITLE
Fix game mode select showing ID instead of label (#346)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -139,7 +139,7 @@ export default function Home() {
               }}
             >
               <SelectTrigger id="game-mode">
-                <SelectValue />
+                <SelectValue>{GAME_MODES[selectedGameMode].name}</SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {GAME_MODE_OPTIONS.map((opt) => (


### PR DESCRIPTION
## Summary

The game mode dropdown on the home page showed the raw enum value (e.g., `werewolf`) instead of the display name (e.g., `Werewolf`) after selection. The base-ui `SelectValue` component renders the `value` prop directly rather than auto-matching the `SelectItem` children like Radix does.

Fix: pass the game mode's display name as children to `SelectValue`.

## Test plan
- [x] TypeScript compiles
- [x] ESLint passes
- [x] Verify dropdown shows "Werewolf" not "werewolf" after selection

Closes #346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)