### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/rmartz/hidden-role-game/security/code-scanning/1](https://github.com/rmartz/hidden-role-game/security/code-scanning/1)

In general, fix this by adding an explicit `permissions` block to the workflow (or to individual jobs) that grants only the minimum scopes needed. For a typical CI workflow that only checks out code and runs tests/builds, `contents: read` is sufficient, and you usually do not need any write access or other scopes.

For this specific file `.github/workflows/ci-actions.yml`, the simplest, non-functional-change fix is to add a root-level `permissions:` block after the `name: CI` line (before `on:`), setting `contents: read`. This will apply to all jobs (`tests`, `lint`, `format`, `build`) because none of them define their own `permissions` section. No additional imports or methods are needed, as this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
