### PR TITLE
Extract WerewolfTimerConfig from base TimerConfig (#374)

### DIFF
--- a/src/components/game/werewolf/GameOverScreenView.spec.tsx
+++ b/src/components/game/werewolf/GameOverScreenView.spec.tsx
@@ -2,7 +2,8 @@ import { afterEach, describe, it, expect, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import { GameOverScreenView } from "./GameOverScreenView";
 import { WerewolfWinner } from "@/lib/game-modes/werewolf/utils/win-condition";
-import { GameStatus, GameMode, Team, DEFAULT_TIMER_CONFIG } from "@/lib/types";
+import { GameStatus, GameMode, Team } from "@/lib/types";
+import { DEFAULT_WEREWOLF_TIMER_CONFIG } from "@/lib/game-modes/werewolf/timer-config";
 import { WEREWOLF_COPY } from "@/lib/game-modes/werewolf/copy";
 import type { WerewolfPlayerGameState } from "@/lib/game-modes/werewolf/player-state";
 
@@ -31,7 +32,7 @@ function makeGameState(
         role: { id: "werewolf", name: "Werewolf", team: Team.Bad },
       },
     ],
-    timerConfig: DEFAULT_TIMER_CONFIG,
+    timerConfig: DEFAULT_WEREWOLF_TIMER_CONFIG,
     nominationsEnabled: false,
     singleTrialPerDay: false,
     revealProtections: false,

--- a/src/components/game/werewolf/GameOverScreenView.stories.tsx
+++ b/src/components/game/werewolf/GameOverScreenView.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { GameOverScreenView } from "./GameOverScreenView";
-import { GameMode, GameStatus, Team, DEFAULT_TIMER_CONFIG } from "@/lib/types";
+import { GameMode, GameStatus, Team } from "@/lib/types";
+import { DEFAULT_WEREWOLF_TIMER_CONFIG } from "@/lib/game-modes/werewolf/timer-config";
 import { WerewolfWinner } from "@/lib/game-modes/werewolf/utils/win-condition";
 import type { WerewolfPlayerGameState } from "@/lib/game-modes/werewolf/player-state";
 import { fn } from "storybook/test";
@@ -50,7 +51,7 @@ const baseGameState: WerewolfPlayerGameState = {
   nominationsEnabled: false,
   singleTrialPerDay: true,
   revealProtections: true,
-  timerConfig: DEFAULT_TIMER_CONFIG,
+  timerConfig: DEFAULT_WEREWOLF_TIMER_CONFIG,
 };
 
 export const GoodTeamVictory: Story = {

--- a/src/components/lobby/GameConfigurationPanel.tsx
+++ b/src/components/lobby/GameConfigurationPanel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 import { GAME_MODES, getRoleSlotsRequired } from "@/lib/game-modes";
 import type { GameConfig } from "@/server/types";
 import { GameMode } from "@/lib/types";
+import type { WerewolfTimerConfig } from "@/lib/game-modes/werewolf/timer-config";
 import {
   WEREWOLF_ROLE_CATEGORY_LABELS,
   WEREWOLF_ROLE_CATEGORY_ORDER,
@@ -99,7 +100,7 @@ export function GameConfigurationPanel(props: GameConfigurationPanelProps) {
         revealProtections: config.revealProtections,
         onShowRolesInPlayChange: undefined,
         onShowConfigToPlayersChange: undefined,
-        onTimerConfigChange: undefined,
+        onWerewolfTimerConfigChange: undefined,
         onNominationEnabledChange: undefined,
         onSingleTrialPerDayChange: undefined,
         onRevealProtectionsChange: undefined,
@@ -115,7 +116,7 @@ export function GameConfigurationPanel(props: GameConfigurationPanelProps) {
           dispatch(setShowRolesInPlay(value)),
         onShowConfigToPlayersChange: (value: boolean) =>
           dispatch(setShowConfigToPlayers(value)),
-        onTimerConfigChange: (value: typeof timerConfig) =>
+        onWerewolfTimerConfigChange: (value: typeof timerConfig) =>
           dispatch(setTimerConfig(value)),
         onNominationEnabledChange: (value: boolean) =>
           dispatch(setNominationEnabled(value)),
@@ -133,12 +134,12 @@ export function GameConfigurationPanel(props: GameConfigurationPanelProps) {
 
   const werewolfConfig = isWerewolf ? (
     <WerewolfConfigPanel
-      timerConfig={resolved.timerConfig}
+      timerConfig={resolved.timerConfig as WerewolfTimerConfig}
       nominationEnabled={resolved.nominationEnabled}
       singleTrialPerDay={resolved.singleTrialPerDay}
       revealProtections={resolved.revealProtections}
       disabled={disabled}
-      onTimerConfigChange={resolved.onTimerConfigChange}
+      onWerewolfTimerConfigChange={resolved.onWerewolfTimerConfigChange}
       onNominationEnabledChange={resolved.onNominationEnabledChange}
       onSingleTrialPerDayChange={resolved.onSingleTrialPerDayChange}
       onRevealProtectionsChange={resolved.onRevealProtectionsChange}

--- a/src/components/lobby/TimerConfigPanel.tsx
+++ b/src/components/lobby/TimerConfigPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { TimerConfig } from "@/lib/types";
+import type { WerewolfTimerConfig } from "@/lib/game-modes/werewolf/timer-config";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { TIMER_CONFIG_COPY } from "./TimerConfigPanel.copy";
@@ -8,9 +8,9 @@ import { TimerConfigPanelRow, TIMER_ROWS } from "./TimerConfigPanelRow";
 import type { TimerRow } from "./TimerConfigPanelRow";
 
 interface TimerConfigPanelProps {
-  timerConfig: TimerConfig;
+  timerConfig: WerewolfTimerConfig;
   disabled?: boolean;
-  onChange?: (config: TimerConfig) => void;
+  onChange?: (config: WerewolfTimerConfig) => void;
 }
 
 export function TimerConfigPanel({

--- a/src/components/lobby/TimerConfigPanelRow.tsx
+++ b/src/components/lobby/TimerConfigPanelRow.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import type { TimerConfig } from "@/lib/types";
+import type { WerewolfTimerConfig } from "@/lib/game-modes/werewolf/timer-config";
 import { Incrementer } from "./Incrementer";
 import { TIMER_CONFIG_COPY } from "./TimerConfigPanel.copy";
 
 export interface TimerRow {
   label: string;
-  field: keyof Omit<TimerConfig, "autoAdvance">;
+  field: keyof Omit<WerewolfTimerConfig, "autoAdvance">;
   min: number;
   max: number;
   step: number;

--- a/src/components/lobby/WerewolfConfigPanel.tsx
+++ b/src/components/lobby/WerewolfConfigPanel.tsx
@@ -1,18 +1,18 @@
 "use client";
 
-import type { TimerConfig } from "@/lib/types";
+import type { WerewolfTimerConfig } from "@/lib/game-modes/werewolf/timer-config";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { WEREWOLF_CONFIG_PANEL_COPY } from "./WerewolfConfigPanel.copy";
 import { TimerConfigPanel } from "./TimerConfigPanel";
 
 interface WerewolfConfigPanelProps {
-  timerConfig: TimerConfig;
+  timerConfig: WerewolfTimerConfig;
   nominationEnabled: boolean;
   singleTrialPerDay: boolean;
   revealProtections: boolean;
   disabled?: boolean;
-  onTimerConfigChange?: (config: TimerConfig) => void;
+  onWerewolfTimerConfigChange?: (config: WerewolfTimerConfig) => void;
   onNominationEnabledChange?: (value: boolean) => void;
   onSingleTrialPerDayChange?: (value: boolean) => void;
   onRevealProtectionsChange?: (value: boolean) => void;
@@ -24,7 +24,7 @@ export function WerewolfConfigPanel({
   singleTrialPerDay,
   revealProtections,
   disabled,
-  onTimerConfigChange,
+  onWerewolfTimerConfigChange,
   onNominationEnabledChange,
   onSingleTrialPerDayChange,
   onRevealProtectionsChange,
@@ -67,7 +67,7 @@ export function WerewolfConfigPanel({
       <TimerConfigPanel
         timerConfig={timerConfig}
         disabled={disabled}
-        onChange={onTimerConfigChange}
+        onChange={onWerewolfTimerConfigChange}
       />
     </div>
   );

--- a/src/hooks/game.spec.ts
+++ b/src/hooks/game.spec.ts
@@ -6,8 +6,8 @@ import {
   RoleConfigMode,
   ShowRolesInPlay,
   Team,
-  DEFAULT_TIMER_CONFIG,
 } from "@/lib/types";
+import { DEFAULT_WEREWOLF_TIMER_CONFIG } from "@/lib/game-modes/werewolf/timer-config";
 import { ServerResponseStatus } from "@/server/types";
 import type { PlayerGameState, PublicLobby } from "@/server/types";
 import type { WerewolfPlayerGameState } from "@/lib/game-modes/werewolf/player-state";
@@ -49,7 +49,7 @@ const mockGameState: WerewolfPlayerGameState = {
   nominationsEnabled: false,
   singleTrialPerDay: true,
   revealProtections: true,
-  timerConfig: DEFAULT_TIMER_CONFIG,
+  timerConfig: DEFAULT_WEREWOLF_TIMER_CONFIG,
 };
 
 const mockOwnerGameState: PlayerGameState = {
@@ -86,7 +86,7 @@ describe("useStartGame", () => {
             nominationsEnabled: false,
             singleTrialPerDay: true,
             revealProtections: true,
-            timerConfig: DEFAULT_TIMER_CONFIG,
+            timerConfig: DEFAULT_WEREWOLF_TIMER_CONFIG,
           },
           gameId: "game-1",
           readyPlayerIds: [],

--- a/src/lib/firebase/schema/lobby.ts
+++ b/src/lib/firebase/schema/lobby.ts
@@ -6,6 +6,8 @@ import type {
   TimerConfig,
 } from "@/lib/types";
 import { DEFAULT_TIMER_CONFIG } from "@/lib/types";
+import type { WerewolfTimerConfig } from "@/lib/game-modes/werewolf/timer-config";
+import { DEFAULT_WEREWOLF_TIMER_CONFIG } from "@/lib/game-modes/werewolf/timer-config";
 import type { PublicLobby } from "@/server/types";
 
 export interface FirebaseLobbyPublic {
@@ -145,8 +147,14 @@ export function firebaseToRoleSlot(s: FirebaseRoleSlot): RoleSlot {
   return { roleId: s.roleId, min: s.min, max: s.max };
 }
 
-/** Parses a raw Firebase TimerConfig, filling missing fields with defaults. */
-export function parseTimerConfig(raw: Record<string, unknown>): TimerConfig {
+/**
+ * Parses a raw Firebase TimerConfig, filling missing fields with defaults.
+ * Returns a WerewolfTimerConfig since DEFAULT_TIMER_CONFIG includes all fields.
+ * Non-Werewolf game modes ignore the Werewolf-specific fields.
+ */
+export function parseTimerConfig(
+  raw: Record<string, unknown>,
+): WerewolfTimerConfig {
   return {
     autoAdvance:
       typeof raw["autoAdvance"] === "boolean"
@@ -159,19 +167,19 @@ export function parseTimerConfig(raw: Record<string, unknown>): TimerConfig {
     nightPhaseSeconds:
       typeof raw["nightPhaseSeconds"] === "number"
         ? raw["nightPhaseSeconds"]
-        : DEFAULT_TIMER_CONFIG.nightPhaseSeconds,
+        : DEFAULT_WEREWOLF_TIMER_CONFIG.nightPhaseSeconds,
     dayPhaseSeconds:
       typeof raw["dayPhaseSeconds"] === "number"
         ? raw["dayPhaseSeconds"]
-        : DEFAULT_TIMER_CONFIG.dayPhaseSeconds,
+        : DEFAULT_WEREWOLF_TIMER_CONFIG.dayPhaseSeconds,
     votePhaseSeconds:
       typeof raw["votePhaseSeconds"] === "number"
         ? raw["votePhaseSeconds"]
-        : DEFAULT_TIMER_CONFIG.votePhaseSeconds,
+        : DEFAULT_WEREWOLF_TIMER_CONFIG.votePhaseSeconds,
     defensePhaseSeconds:
       typeof raw["defensePhaseSeconds"] === "number"
         ? raw["defensePhaseSeconds"]
-        : DEFAULT_TIMER_CONFIG.defensePhaseSeconds,
+        : DEFAULT_WEREWOLF_TIMER_CONFIG.defensePhaseSeconds,
   };
 }
 

--- a/src/lib/firebase/schema/player-state.ts
+++ b/src/lib/firebase/schema/player-state.ts
@@ -71,7 +71,8 @@ export interface FirebasePlayerState {
 }
 
 export function playerStateToFirebase(
-  state: PlayerGameState & Partial<WerewolfPlayerGameState>,
+  state: PlayerGameState &
+    Partial<Omit<WerewolfPlayerGameState, keyof PlayerGameState>>,
 ): FirebasePlayerState {
   return {
     statusJson: JSON.stringify(state.status),

--- a/src/lib/game-modes/werewolf/index.ts
+++ b/src/lib/game-modes/werewolf/index.ts
@@ -1,4 +1,5 @@
 export * from "./types";
+export * from "./timer-config";
 export * from "./player-state";
 export * from "./roles";
 export * from "./actions";

--- a/src/lib/game-modes/werewolf/player-state.ts
+++ b/src/lib/game-modes/werewolf/player-state.ts
@@ -1,4 +1,5 @@
 import type { Team } from "@/lib/types";
+import type { WerewolfTimerConfig } from "./timer-config";
 import type { PlayerGameState, NightStatusEntry } from "@/server/types/game";
 import type { AnyNightAction, DaytimeVote } from "./types";
 
@@ -8,6 +9,8 @@ import type { AnyNightAction, DaytimeVote } from "./types";
  * should type their props as WerewolfPlayerGameState.
  */
 export interface WerewolfPlayerGameState extends PlayerGameState {
+  /** Override base timerConfig with Werewolf-specific timer fields. */
+  timerConfig: WerewolfTimerConfig;
   /** Whether player nominations for trial are enabled in this game. */
   nominationsEnabled: boolean;
   /** When true, only one trial is allowed per day phase. */

--- a/src/lib/game-modes/werewolf/timer-config.ts
+++ b/src/lib/game-modes/werewolf/timer-config.ts
@@ -1,0 +1,22 @@
+import type { TimerConfig } from "@/lib/types";
+
+/** Werewolf-specific timer configuration. */
+export interface WerewolfTimerConfig extends TimerConfig {
+  /** Seconds per night role phase. */
+  nightPhaseSeconds: number;
+  /** Seconds for day discussion. */
+  dayPhaseSeconds: number;
+  /** Seconds for a daytime elimination vote. */
+  votePhaseSeconds: number;
+  /** Seconds for the defense speech before an elimination vote. */
+  defensePhaseSeconds: number;
+}
+
+export const DEFAULT_WEREWOLF_TIMER_CONFIG: WerewolfTimerConfig = {
+  autoAdvance: false,
+  startCountdownSeconds: 10,
+  nightPhaseSeconds: 30,
+  dayPhaseSeconds: 300,
+  votePhaseSeconds: 20,
+  defensePhaseSeconds: 10,
+};

--- a/src/lib/types/game.ts
+++ b/src/lib/types/game.ts
@@ -233,28 +233,17 @@ export interface GameAction {
 
 // --- Phase Timer Configuration ---
 
+/** Base timer configuration shared across all game modes. */
 export interface TimerConfig {
   /** When true, each phase automatically advances when its timer expires. */
   autoAdvance: boolean;
   /** Seconds for game-start countdown. */
   startCountdownSeconds: number;
-  /** Seconds per night role phase. */
-  nightPhaseSeconds: number;
-  /** Seconds for day discussion. */
-  dayPhaseSeconds: number;
-  /** Seconds for a daytime elimination vote. */
-  votePhaseSeconds: number;
-  /** Seconds for the defense speech before an elimination vote. */
-  defensePhaseSeconds: number;
 }
 
 export const DEFAULT_TIMER_CONFIG: TimerConfig = {
   autoAdvance: false,
   startCountdownSeconds: 10,
-  nightPhaseSeconds: 30,
-  dayPhaseSeconds: 300,
-  votePhaseSeconds: 20,
-  defensePhaseSeconds: 10,
 };
 
 // --- Lobby (top-level entity; game is absent until started) ---

--- a/src/store/game-config-slice.ts
+++ b/src/store/game-config-slice.ts
@@ -2,8 +2,9 @@ import { createSlice, createSelector } from "@reduxjs/toolkit";
 import type { PayloadAction } from "@reduxjs/toolkit";
 import { sum } from "lodash";
 import { GameMode, RoleConfigMode, ShowRolesInPlay } from "@/lib/types";
-import type { RoleSlot, TimerConfig } from "@/lib/types";
-import { DEFAULT_TIMER_CONFIG } from "@/lib/types";
+import type { RoleSlot } from "@/lib/types";
+import type { WerewolfTimerConfig } from "@/lib/game-modes/werewolf/timer-config";
+import { DEFAULT_WEREWOLF_TIMER_CONFIG } from "@/lib/game-modes/werewolf/timer-config";
 import type { GameConfig } from "@/server/types";
 import { GAME_MODES } from "@/lib/game-modes";
 
@@ -55,7 +56,7 @@ export interface GameConfigState {
   roleMaxes: Record<string, number>;
   showConfigToPlayers: boolean;
   showRolesInPlay: ShowRolesInPlay;
-  timerConfig: TimerConfig;
+  timerConfig: WerewolfTimerConfig;
   nominationEnabled: boolean;
   singleTrialPerDay: boolean;
   revealProtections: boolean;
@@ -73,7 +74,7 @@ const initialState: GameConfigState = {
   roleMaxes: {},
   showConfigToPlayers: false,
   showRolesInPlay: ShowRolesInPlay.None,
-  timerConfig: DEFAULT_TIMER_CONFIG,
+  timerConfig: DEFAULT_WEREWOLF_TIMER_CONFIG,
   nominationEnabled: true,
   singleTrialPerDay: true,
   revealProtections: true,
@@ -114,7 +115,7 @@ const gameConfigSlice = createSlice({
       state.roleMaxes = roleMaxesFromSlots(slots);
       state.showConfigToPlayers = config.showConfigToPlayers;
       state.showRolesInPlay = config.showRolesInPlay;
-      state.timerConfig = config.timerConfig;
+      state.timerConfig = config.timerConfig as WerewolfTimerConfig;
       state.nominationEnabled = config.nominationsEnabled;
       state.singleTrialPerDay = config.singleTrialPerDay;
       state.revealProtections = config.revealProtections;
@@ -246,7 +247,7 @@ const gameConfigSlice = createSlice({
       state.syncVersion++;
     },
 
-    setTimerConfig(state, action: PayloadAction<TimerConfig>) {
+    setTimerConfig(state, action: PayloadAction<WerewolfTimerConfig>) {
       state.timerConfig = action.payload;
       state.syncVersion++;
     },


### PR DESCRIPTION
## Summary

Split `TimerConfig` into a base type (shared) and game-mode-specific extensions, following the same pattern as `PlayerGameState` → `WerewolfPlayerGameState`.

### Base TimerConfig (`lib/types/game.ts`)
```typescript
interface TimerConfig {
  autoAdvance: boolean;
  startCountdownSeconds: number;
}
```

### WerewolfTimerConfig (`lib/game-modes/werewolf/timer-config.ts`)
```typescript
interface WerewolfTimerConfig extends TimerConfig {
  nightPhaseSeconds: number;
  dayPhaseSeconds: number;
  votePhaseSeconds: number;
  defensePhaseSeconds: number;
}
```

### Changes
- `TimerConfig` is now game-mode-agnostic (2 fields)
- `WerewolfTimerConfig` lives in the Werewolf game mode (not core types)
- `DEFAULT_TIMER_CONFIG` is a base config; `DEFAULT_WEREWOLF_TIMER_CONFIG` has Werewolf defaults
- `WerewolfPlayerGameState` overrides `timerConfig` to `WerewolfTimerConfig`
- Timer config panel, Redux slice, and lobby components updated to use `WerewolfTimerConfig`
- Firebase `parseTimerConfig` returns `WerewolfTimerConfig` (fills all fields from defaults)

### Future
Secret Villain can define `SecretVillainTimerConfig extends TimerConfig` with election/policy timers (#373) without touching the base type.

## Test plan
- [x] TypeScript compiles with zero errors
- [x] ESLint passes
- [x] 909 tests pass

Closes #374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)