### PR TITLE
Show pending voter names during election vote (#372)

### DIFF
--- a/src/components/game/secret-villain/ElectionVoteView.spec.tsx
+++ b/src/components/game/secret-villain/ElectionVoteView.spec.tsx
@@ -87,4 +87,66 @@ describe("ElectionVoteView", () => {
       }),
     ).toBeNull();
   });
+
+  it("shows pending player names when 3 or fewer are left to vote", () => {
+    const players = [
+      { id: "p1", name: "Alice" },
+      { id: "p2", name: "Bob" },
+      { id: "p3", name: "Charlie" },
+    ];
+    render(
+      <ElectionVoteView
+        {...defaultProps}
+        myVote="aye"
+        players={players}
+        votedPlayerIds={["p1"]}
+      />,
+    );
+    expect(
+      screen.getByText(
+        SECRET_VILLAIN_COPY.election.waitingForPlayers(["Bob", "Charlie"]),
+      ),
+    ).toBeDefined();
+  });
+
+  it("shows generic waiting text when more than 3 are left to vote", () => {
+    const players = [
+      { id: "p1", name: "Alice" },
+      { id: "p2", name: "Bob" },
+      { id: "p3", name: "Charlie" },
+      { id: "p4", name: "Diana" },
+      { id: "p5", name: "Eve" },
+    ];
+    render(
+      <ElectionVoteView
+        {...defaultProps}
+        myVote="aye"
+        players={players}
+        votedPlayerIds={["p1"]}
+      />,
+    );
+    expect(
+      screen.getByText(SECRET_VILLAIN_COPY.election.alreadyVoted),
+    ).toBeDefined();
+  });
+
+  it("excludes eliminated players from pending voter count", () => {
+    const players = [
+      { id: "p1", name: "Alice" },
+      { id: "p2", name: "Bob" },
+      { id: "p3", name: "Charlie" },
+    ];
+    render(
+      <ElectionVoteView
+        {...defaultProps}
+        myVote="aye"
+        players={players}
+        votedPlayerIds={["p1"]}
+        eliminatedPlayerIds={["p3"]}
+      />,
+    );
+    expect(
+      screen.getByText(SECRET_VILLAIN_COPY.election.waitingForPlayers(["Bob"])),
+    ).toBeDefined();
+  });
 });

--- a/src/components/game/secret-villain/ElectionVoteView.tsx
+++ b/src/components/game/secret-villain/ElectionVoteView.tsx
@@ -19,9 +19,18 @@ interface ElectionVoteViewProps {
   timerDurationSeconds?: number;
   /** When the vote phase started (for timer). */
   voteStartedAt?: Date;
+  /** All players in the game (for voter status display). */
+  players?: { id: string; name: string }[];
+  /** Player IDs who have already voted. */
+  votedPlayerIds?: string[];
+  /** Player IDs who are eliminated (cannot vote). */
+  eliminatedPlayerIds?: string[];
   isPending?: boolean;
   isEliminated?: boolean;
 }
+
+/** Max number of pending players to show by name. */
+const PENDING_NAME_THRESHOLD = 3;
 
 export function ElectionVoteView({
   presidentName,
@@ -32,6 +41,9 @@ export function ElectionVoteView({
   allVoted,
   timerDurationSeconds,
   voteStartedAt,
+  players,
+  votedPlayerIds,
+  eliminatedPlayerIds,
   isPending,
   isEliminated,
 }: ElectionVoteViewProps) {
@@ -45,6 +57,18 @@ export function ElectionVoteView({
     timerDurationSeconds > 0 &&
     voteStartedAt !== undefined;
   const canResolve = allVoted === true || timerExpired;
+
+  const votedSet = new Set(votedPlayerIds ?? []);
+  const eliminatedSet = new Set(eliminatedPlayerIds ?? []);
+  const pendingPlayers = (players ?? []).filter(
+    (p) => !votedSet.has(p.id) && !eliminatedSet.has(p.id),
+  );
+  const waitingText =
+    pendingPlayers.length > 0 && pendingPlayers.length <= PENDING_NAME_THRESHOLD
+      ? SECRET_VILLAIN_COPY.election.waitingForPlayers(
+          pendingPlayers.map((p) => p.name),
+        )
+      : SECRET_VILLAIN_COPY.election.alreadyVoted;
 
   return (
     <Card>
@@ -73,9 +97,7 @@ export function ElectionVoteView({
             {SECRET_VILLAIN_COPY.eliminated}
           </p>
         ) : hasVoted ? (
-          <p className="text-sm text-muted-foreground">
-            {SECRET_VILLAIN_COPY.election.alreadyVoted}
-          </p>
+          <p className="text-sm text-muted-foreground">{waitingText}</p>
         ) : (
           <div className="space-y-2">
             <p className="text-sm font-medium">

--- a/src/components/game/secret-villain/SecretVillainGameScreenView.tsx
+++ b/src/components/game/secret-villain/SecretVillainGameScreenView.tsx
@@ -203,6 +203,9 @@ export function SecretVillainGameScreenView({
             voteStartedAt={
               phase.startedAt ? new Date(phase.startedAt) : undefined
             }
+            players={players}
+            votedPlayerIds={gameState.votedPlayerIds}
+            eliminatedPlayerIds={gameState.deadPlayerIds}
             isPending={isPending}
             isEliminated={isEliminated}
           />

--- a/src/lib/game-modes/secret-villain/copy.ts
+++ b/src/lib/game-modes/secret-villain/copy.ts
@@ -19,6 +19,8 @@ export const SECRET_VILLAIN_COPY = {
     no: "No",
     waitingForVotes: "Waiting for all players to vote\u2026",
     alreadyVoted: "Vote cast. Waiting for others\u2026",
+    waitingForPlayers: (names: string[]) =>
+      `Waiting for ${names.join(", ")}\u2026`,
     resolveVote: "Reveal Results",
     resultPassed: "Election Passed",
     resultFailed: "Election Failed",

--- a/src/lib/game-modes/secret-villain/player-state.ts
+++ b/src/lib/game-modes/secret-villain/player-state.ts
@@ -74,8 +74,10 @@ export interface SecretVillainPlayerGameState extends PlayerGameState {
   myElectionVote?: ElectionVote;
   /** All election votes (after resolution). */
   electionVotes?: SvElectionVoteEntry[];
-  /** Number of votes cast so far (not who voted — votes are secret until tally). */
+  /** Number of votes cast so far. */
   electionVoteCount?: number;
+  /** Player IDs who have voted (not how they voted — votes are secret until tally). */
+  votedPlayerIds?: string[];
   /** Whether the election passed. */
   electionPassed?: boolean;
   /** Whether veto power is unlocked (4+ Bad cards). */

--- a/src/lib/game-modes/secret-villain/services.ts
+++ b/src/lib/game-modes/secret-villain/services.ts
@@ -186,8 +186,9 @@ export const secretVillainServices: GameModeServices = {
       if (myVote) {
         result["myElectionVote"] = myVote.vote;
       }
-      // Vote count (not who voted) — used to determine if all players have voted.
+      // Who has voted (not how) — used for voter status display.
       result["electionVoteCount"] = phase.votes.length;
+      result["votedPlayerIds"] = phase.votes.map((v) => v.playerId);
       // After tally, share full results.
       if (phase.passed !== undefined) {
         result["electionVotes"] = phase.votes;


### PR DESCRIPTION
## Summary

During the election vote phase, show the names of players who haven't voted yet when 3 or fewer are pending. When more than 3 are pending, keep the generic "Vote cast. Waiting for others…" text.

### Behavior
| Pending voters | Display |
|---|---|
| 1 | "Waiting for Bob…" |
| 2 | "Waiting for Bob, Charlie…" |
| 3 | "Waiting for Alice, Bob, Charlie…" |
| 4+ | "Vote cast. Waiting for others…" |

Eliminated players are excluded from the pending count.

### Changes
- `extractPlayerState` now exposes `votedPlayerIds` (who voted, not how)
- `SecretVillainPlayerGameState` gains `votedPlayerIds` field
- `ElectionVoteView` computes pending players and selects the appropriate message
- New copy: `waitingForPlayers(names)` function

## Test plan
- [x] 921 tests pass (3 new)
- [x] Pending names shown when ≤3 left
- [x] Generic text shown when >3 left
- [x] Eliminated players excluded from count

Closes #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)