### PR TITLE
Replace function-style imports with module-level imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,8 @@ pnpm build-storybook  # Build static Storybook
 ## Code Conventions
 
 - **No spurious variables.** Do not assign a value to a variable only to immediately return it on the next line — return the expression directly instead.
+- **No IIFEs.** Do not use immediately-invoked function expressions. Extract the logic into a named helper function or compute the value with a plain expression instead.
+- **No function-style imports.** Do not use inline `import("…").Type` syntax in type annotations. Use module-level `import type { … } from "…"` statements at the top of the file. Dynamic `await import("…")` for services that require conditional loading (e.g., Sentry instrumentation) is acceptable.
 - **Role enums and definitions** in game mode files (e.g., `WerewolfRole` enum and `WEREWOLF_ROLES` object) must be kept in alphabetical order to minimize merge conflicts.
 
 ## User-Facing Text

--- a/src/lib/firebase/schema/game.ts
+++ b/src/lib/firebase/schema/game.ts
@@ -1,5 +1,6 @@
 import type {
   Game,
+  GamePlayer,
   GameStatusState,
   PlayerRoleAssignment,
   TimerConfig,
@@ -77,7 +78,7 @@ export function gameToFirebase(game: Game): FirebaseGamePublic {
 export function firebaseToGame(
   gameId: string,
   pub: FirebaseGamePublic,
-  gamePlayers: import("@/lib/types").GamePlayer[],
+  gamePlayers: GamePlayer[],
 ): Game {
   const roleAssignments: PlayerRoleAssignment[] = Object.entries(
     pub.roleAssignments ?? {},

--- a/src/lib/firebase/schema/lobby.ts
+++ b/src/lib/firebase/schema/lobby.ts
@@ -2,6 +2,7 @@ import type {
   Lobby,
   LobbyConfig,
   LobbyPlayer,
+  ModeConfig,
   RoleSlot,
   TimerConfig,
 } from "@/lib/types";
@@ -85,7 +86,7 @@ export function lobbyToFirebase(lobby: Lobby): {
 
 /** Strip the `gameMode` discriminant before writing to Firebase. */
 export function modeConfigToFirebase(
-  modeConfig: import("@/lib/types").ModeConfig,
+  modeConfig: ModeConfig,
 ): Record<string, unknown> {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { gameMode: _discriminant, ...rest } = modeConfig;

--- a/src/lib/game-modes/werewolf/actions/set-night-target-tests/bodyguard-witch.spec.ts
+++ b/src/lib/game-modes/werewolf/actions/set-night-target-tests/bodyguard-witch.spec.ts
@@ -177,10 +177,7 @@ describe("SetNightTarget — Witch cannot self-attack", () => {
         startedAt: 1000,
         nightPhaseOrder: [WerewolfRole.Werewolf, WerewolfRole.Witch],
         currentPhaseIndex: 1,
-        nightActions: nightActions as Record<
-          string,
-          import("../../types").AnyNightAction
-        >,
+        nightActions: nightActions as Record<string, AnyNightAction>,
       },
       deadPlayerIds: [],
     };

--- a/src/lib/game-modes/werewolf/actions/start-day.mirrorcaster.spec.ts
+++ b/src/lib/game-modes/werewolf/actions/start-day.mirrorcaster.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import type { Game } from "@/lib/types";
 import type { WerewolfTurnState } from "../types";
 import { WerewolfRole } from "../roles";
 import { WerewolfAction, WEREWOLF_ACTIONS } from "./index";
@@ -14,7 +15,7 @@ const mcRoleAssignments = [
   { playerId: "p5", roleDefinitionId: WerewolfRole.Villager },
 ];
 
-function getTurnState(game: import("@/lib/types").Game): WerewolfTurnState {
+function getTurnState(game: Game): WerewolfTurnState {
   return (game.status as { turnState: WerewolfTurnState }).turnState;
 }
 

--- a/src/lib/game-modes/werewolf/services-tests/mentalist-helpers.ts
+++ b/src/lib/game-modes/werewolf/services-tests/mentalist-helpers.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_TIMER_CONFIG,
 } from "@/lib/types";
 import type { Game } from "@/lib/types";
+import type { AnyNightAction } from "@/lib/game-modes/werewolf";
 import { WerewolfPhase, WerewolfRole } from "@/lib/game-modes/werewolf";
 import type { WerewolfTurnState } from "@/lib/game-modes/werewolf";
 
@@ -27,10 +28,7 @@ export function makeMentalistGame(
       startedAt: 1000,
       nightPhaseOrder: [WerewolfRole.Mentalist],
       currentPhaseIndex: 0,
-      nightActions: nightActions as Record<
-        string,
-        import("@/lib/game-modes/werewolf").AnyNightAction
-      >,
+      nightActions: nightActions as Record<string, AnyNightAction>,
     },
     deadPlayerIds: [],
   };

--- a/src/lib/game-modes/werewolf/services-tests/nighttime-helpers.ts
+++ b/src/lib/game-modes/werewolf/services-tests/nighttime-helpers.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_TIMER_CONFIG,
 } from "@/lib/types";
 import type { Game } from "@/lib/types";
+import type { AnyNightAction } from "@/lib/game-modes/werewolf";
 import { WerewolfPhase, WerewolfRole } from "@/lib/game-modes/werewolf";
 import type { WerewolfTurnState } from "@/lib/game-modes/werewolf";
 
@@ -24,10 +25,7 @@ export function makeNighttimeGame(
       startedAt: 1000,
       nightPhaseOrder: [WerewolfRole.Witch],
       currentPhaseIndex: 0,
-      nightActions: nightActions as Record<
-        string,
-        import("@/lib/game-modes/werewolf").AnyNightAction
-      >,
+      nightActions: nightActions as Record<string, AnyNightAction>,
     },
     deadPlayerIds: [],
     ...(witchAbilityUsed ? { witchAbilityUsed: true } : {}),
@@ -77,10 +75,7 @@ export function makeNighttimeGameWithBonusPhase(
       startedAt: 1000,
       nightPhaseOrder: [WerewolfRole.Werewolf, BONUS_PHASE_KEY],
       currentPhaseIndex,
-      nightActions: nightActions as Record<
-        string,
-        import("@/lib/game-modes/werewolf").AnyNightAction
-      >,
+      nightActions: nightActions as Record<string, AnyNightAction>,
     },
     deadPlayerIds: [],
   };

--- a/src/lib/types/game.ts
+++ b/src/lib/types/game.ts
@@ -1,3 +1,5 @@
+import type { ModeConfig } from "./mode-config";
+
 export interface LobbyPlayer {
   id: string;
   name: string;
@@ -173,11 +175,9 @@ export interface GameModeConfig {
   ): boolean;
   readonly defaultTimerConfig: TimerConfig;
   /** Default game-mode-specific lobby config fields. */
-  readonly defaultModeConfig: import("./mode-config").ModeConfig;
+  readonly defaultModeConfig: ModeConfig;
   /** Parse raw Firebase data into typed mode-specific config, applying defaults. */
-  parseModeConfig(
-    raw: Record<string, unknown>,
-  ): import("./mode-config").ModeConfig;
+  parseModeConfig(raw: Record<string, unknown>): ModeConfig;
   readonly actions: Record<string, GameAction>;
   readonly services: GameModeServices;
 }
@@ -220,7 +220,7 @@ export interface Game {
   ownerPlayerId?: string;
   timerConfig: TimerConfig;
   /** Game-mode-specific configuration. Discriminated by `modeConfig.gameMode`. */
-  modeConfig: import("./mode-config").ModeConfig;
+  modeConfig: ModeConfig;
   /** Executioner: the player ID the Executioner must get eliminated at trial. */
   executionerTargetId?: string;
 }
@@ -261,7 +261,7 @@ export interface LobbyConfig {
   showRolesInPlay: ShowRolesInPlay;
   timerConfig: TimerConfig;
   /** Game-mode-specific configuration. Discriminated by `modeConfig.gameMode`. */
-  modeConfig: import("./mode-config").ModeConfig;
+  modeConfig: ModeConfig;
 }
 
 export interface Lobby {

--- a/src/services/FirebaseLobbyService.ts
+++ b/src/services/FirebaseLobbyService.ts
@@ -5,6 +5,7 @@ import type {
   RoleSlot,
   RoleConfigMode,
   ShowRolesInPlay,
+  TimerConfig,
 } from "@/lib/types";
 import { modeConfigToFirebase } from "@/lib/firebase/schema";
 import { getAdminDatabase } from "@/lib/firebase/admin";
@@ -186,7 +187,7 @@ export class FirebaseLobbyService {
       roleConfigMode?: RoleConfigMode;
       gameMode?: GameMode;
       roleSlots?: RoleSlot[];
-      timerConfig?: import("@/lib/types").TimerConfig;
+      timerConfig?: TimerConfig;
       modeConfig?: ModeConfig;
     },
   ): Promise<Lobby | undefined> {

--- a/src/services/GameService.ts
+++ b/src/services/GameService.ts
@@ -4,9 +4,11 @@ import type {
   Game,
   GameModeConfig,
   LobbyPlayer,
+  ModeConfig,
   RoleSlot,
   GameMode,
   ShowRolesInPlay,
+  TimerConfig,
 } from "@/lib/types";
 import type { PlayerGameState } from "@/server/types";
 import {
@@ -38,8 +40,8 @@ export class GameService {
     gameMode: GameMode,
     showRolesInPlay: ShowRolesInPlay,
     ownerPlayerId: string | undefined,
-    timerConfig: import("@/lib/types").TimerConfig,
-    modeConfig?: import("@/lib/types").ModeConfig,
+    timerConfig: TimerConfig,
+    modeConfig?: ModeConfig,
   ): Promise<Game> {
     const game = this.state.buildGame(
       randomUUID(),

--- a/src/services/GameStateService.ts
+++ b/src/services/GameStateService.ts
@@ -4,7 +4,10 @@ import type {
   GameModeConfig,
   GamePlayer,
   LobbyPlayer,
+  ModeConfig,
+  PlayingGameStatus,
   RoleSlot,
+  TimerConfig,
 } from "@/lib/types";
 import type { PlayerGameState, VisibleTeammate } from "@/server/types";
 import { GAME_MODES } from "@/lib/game-modes";
@@ -199,9 +202,9 @@ export class GameStateService {
     gameMode: GameMode,
     showRolesInPlay: ShowRolesInPlay,
     ownerPlayerId: string | undefined,
-    timerConfig: import("@/lib/types").TimerConfig,
+    timerConfig: TimerConfig,
     /** Game-mode-specific config (e.g., nominationsEnabled for Werewolf). */
-    modeConfig?: import("@/lib/types").ModeConfig,
+    modeConfig?: ModeConfig,
   ): Game {
     const config = this.getModeDefinition(gameMode);
     const { roles, services } = config;
@@ -244,9 +247,7 @@ export class GameStateService {
   /**
    * Build the initial turn state for transitioning from Starting → Playing.
    */
-  public buildPlayingStatus(
-    game: Game,
-  ): import("@/lib/types").PlayingGameStatus {
+  public buildPlayingStatus(game: Game): PlayingGameStatus {
     const { services } = this.getModeDefinition(game.gameMode);
     return {
       type: GameStatus.Playing,


### PR DESCRIPTION
## Summary
- Replace all inline `import("…").Type` annotations with module-level `import type { … }` statements across 10 source/test files
- Add "No IIFEs" and "No function-style imports" directives to AGENTS.md Code Conventions

## Test plan
- [x] `pnpm tsc` passes
- [x] `pnpm test` — all 914 tests pass
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)