### PR TITLE
Extract lobby construction into LobbyService

### DIFF
--- a/src/app/api/[gameMode]/game/create/route.ts
+++ b/src/app/api/[gameMode]/game/create/route.ts
@@ -1,6 +1,6 @@
 import { ServerResponseStatus } from "@/server/types";
 import type { CreateGameRequest } from "@/server/types";
-import { lobbyService } from "@/services/FirebaseLobbyService";
+import { lobbyService } from "@/services/LobbyService";
 import { gameService } from "@/services/GameService";
 import {
   authenticateLobby,

--- a/src/app/api/lobby/[lobbyId]/config/route.ts
+++ b/src/app/api/lobby/[lobbyId]/config/route.ts
@@ -1,7 +1,7 @@
 import { GameMode } from "@/lib/types";
 import { ServerResponseStatus } from "@/server/types";
 import type { UpdateLobbyConfigRequest } from "@/server/types";
-import { lobbyService } from "@/services/FirebaseLobbyService";
+import { lobbyService } from "@/services/LobbyService";
 import { gameService } from "@/services/GameService";
 import {
   authenticateLobby,

--- a/src/app/api/lobby/[lobbyId]/join/route.ts
+++ b/src/app/api/lobby/[lobbyId]/join/route.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "crypto";
 import { ServerResponseStatus, type JoinLobbyRequest } from "@/server/types";
-import { lobbyService } from "@/services/FirebaseLobbyService";
+import { lobbyService } from "@/services/LobbyService";
 import {
   errorResponse,
   normalizePlayerName,

--- a/src/app/api/lobby/[lobbyId]/owner/route.ts
+++ b/src/app/api/lobby/[lobbyId]/owner/route.ts
@@ -4,7 +4,7 @@ import {
   errorResponse,
   toPublicLobby,
 } from "@/server/utils";
-import { lobbyService } from "@/services/FirebaseLobbyService";
+import { lobbyService } from "@/services/LobbyService";
 
 export async function PUT(
   request: Request,

--- a/src/app/api/lobby/[lobbyId]/players/[playerId]/route.ts
+++ b/src/app/api/lobby/[lobbyId]/players/[playerId]/route.ts
@@ -4,7 +4,7 @@ import {
   errorResponse,
   toPublicLobby,
 } from "@/server/utils";
-import { lobbyService } from "@/services/FirebaseLobbyService";
+import { lobbyService } from "@/services/LobbyService";
 
 export async function DELETE(
   request: Request,

--- a/src/app/api/lobby/[lobbyId]/ready/route.ts
+++ b/src/app/api/lobby/[lobbyId]/ready/route.ts
@@ -1,5 +1,5 @@
 import { ServerResponseStatus } from "@/server/types";
-import { lobbyService } from "@/services/FirebaseLobbyService";
+import { lobbyService } from "@/services/LobbyService";
 import {
   authenticateLobby,
   errorResponse,

--- a/src/app/api/lobby/[lobbyId]/return/route.ts
+++ b/src/app/api/lobby/[lobbyId]/return/route.ts
@@ -1,6 +1,6 @@
 import { GameStatus } from "@/lib/types";
 import { ServerResponseStatus } from "@/server/types";
-import { lobbyService } from "@/services/FirebaseLobbyService";
+import { lobbyService } from "@/services/LobbyService";
 import { gameService } from "@/services/GameService";
 import {
   authenticateLobby,

--- a/src/app/api/lobby/create/route.ts
+++ b/src/app/api/lobby/create/route.ts
@@ -1,15 +1,12 @@
 import { randomUUID } from "crypto";
-import type { LobbyConfig } from "@/lib/types";
-import { GameMode, RoleConfigMode, ShowRolesInPlay } from "@/lib/types";
+import { GameMode } from "@/lib/types";
 import {
   DEFAULT_GAME_MODE,
-  getDefaultRoleSlots,
   isGameModeEnabled,
   parseGameMode,
-  GAME_MODES,
 } from "@/lib/game-modes";
 import { ServerResponseStatus, type CreateLobbyRequest } from "@/server/types";
-import { lobbyService } from "@/services/FirebaseLobbyService";
+import { lobbyService } from "@/services/LobbyService";
 import {
   errorResponse,
   toPublicLobby,
@@ -42,23 +39,8 @@ export async function POST(request: Request): Promise<Response> {
   } else {
     selectedGameMode = DEFAULT_GAME_MODE;
   }
-  const lobby = {
-    id: randomUUID(),
-    ownerSessionId: sessionId,
-    players: [owner],
-    config: {
-      gameMode: selectedGameMode,
-      roleConfigMode: RoleConfigMode.Default,
-      roleSlots: getDefaultRoleSlots(selectedGameMode, 1),
-      showConfigToPlayers: false,
-      showRolesInPlay: ShowRolesInPlay.ConfiguredOnly,
-      timerConfig: GAME_MODES[selectedGameMode].defaultTimerConfig,
-      modeConfig: GAME_MODES[selectedGameMode].defaultModeConfig,
-    } as LobbyConfig,
-    readyPlayerIds: [] as string[],
-  };
 
-  await lobbyService.addLobby(lobby);
+  const lobby = await lobbyService.addLobby(owner, selectedGameMode);
 
   return Response.json({
     status: ServerResponseStatus.Success,

--- a/src/server/utils/api-helpers.ts
+++ b/src/server/utils/api-helpers.ts
@@ -1,6 +1,6 @@
 import type { Lobby, Game, GamePlayer } from "@/lib/types";
 import { ServerResponseStatus } from "@/server/types";
-import { lobbyService } from "@/services/FirebaseLobbyService";
+import { lobbyService } from "@/services/LobbyService";
 import { gameService } from "@/services/GameService";
 import { isValidSession } from "./lobby-helpers";
 import { parseGameMode } from "@/lib/game-modes";

--- a/src/services/LobbyService.ts
+++ b/src/services/LobbyService.ts
@@ -1,0 +1,118 @@
+import { randomUUID } from "crypto";
+import type {
+  Lobby,
+  GameMode,
+  LobbyConfig,
+  ModeConfig,
+  RoleSlot,
+  RoleConfigMode,
+  ShowRolesInPlay,
+  TimerConfig,
+} from "@/lib/types";
+import {
+  RoleConfigMode as RoleConfigModeEnum,
+  ShowRolesInPlay as ShowRolesInPlayEnum,
+} from "@/lib/types";
+import { GAME_MODES, getDefaultRoleSlots } from "@/lib/game-modes";
+import {
+  FirebaseLobbyService,
+  lobbyService as firebaseLobbyService,
+} from "./FirebaseLobbyService";
+
+export class LobbyService {
+  constructor(private readonly firebase: FirebaseLobbyService) {}
+
+  async addLobby(
+    owner: { id: string; name: string; sessionId: string },
+    gameMode: GameMode,
+  ): Promise<Lobby> {
+    const lobbyId = randomUUID();
+    const config = {
+      gameMode,
+      roleConfigMode: RoleConfigModeEnum.Default,
+      roleSlots: getDefaultRoleSlots(gameMode, 1),
+      showConfigToPlayers: false,
+      showRolesInPlay: ShowRolesInPlayEnum.ConfiguredOnly,
+      timerConfig: GAME_MODES[gameMode].defaultTimerConfig,
+      modeConfig: GAME_MODES[gameMode].defaultModeConfig,
+    } as LobbyConfig;
+
+    const lobby: Lobby = {
+      id: lobbyId,
+      ownerSessionId: owner.sessionId,
+      players: [owner],
+      config,
+      readyPlayerIds: [],
+    };
+
+    await this.firebase.addLobby(lobby);
+    return lobby;
+  }
+
+  async getLobby(lobbyId: string): Promise<Lobby | undefined> {
+    return this.firebase.getLobby(lobbyId);
+  }
+
+  async clearGameId(lobbyId: string): Promise<Lobby | undefined> {
+    return this.firebase.clearGameId(lobbyId);
+  }
+
+  async setGameId(lobbyId: string, gameId: string): Promise<Lobby | undefined> {
+    return this.firebase.setGameId(lobbyId, gameId);
+  }
+
+  async transferOwner(
+    lobbyId: string,
+    targetPlayerId: string,
+  ): Promise<Lobby | undefined> {
+    return this.firebase.transferOwner(lobbyId, targetPlayerId);
+  }
+
+  async removePlayer(
+    lobbyId: string,
+    playerId: string,
+  ): Promise<Lobby | undefined> {
+    return this.firebase.removePlayer(lobbyId, playerId);
+  }
+
+  async addPlayer(
+    lobbyId: string,
+    player: { id: string; name: string; sessionId: string },
+  ): Promise<Lobby | undefined> {
+    return this.firebase.addPlayer(lobbyId, player);
+  }
+
+  async toggleReady(
+    lobbyId: string,
+    playerId: string,
+  ): Promise<Lobby | undefined> {
+    return this.firebase.toggleReady(lobbyId, playerId);
+  }
+
+  async clearReadyPlayerIds(lobbyId: string): Promise<void> {
+    return this.firebase.clearReadyPlayerIds(lobbyId);
+  }
+
+  async updateConfig(
+    lobbyId: string,
+    config: {
+      showConfigToPlayers?: boolean;
+      showRolesInPlay?: ShowRolesInPlay;
+      roleConfigMode?: RoleConfigMode;
+      gameMode?: GameMode;
+      roleSlots?: RoleSlot[];
+      timerConfig?: TimerConfig;
+      modeConfig?: ModeConfig;
+    },
+  ): Promise<Lobby | undefined> {
+    return this.firebase.updateConfig(lobbyId, config);
+  }
+}
+
+declare global {
+  var lobbyServiceInstance: LobbyService | undefined;
+}
+
+export const lobbyService: LobbyService =
+  globalThis.lobbyServiceInstance ??
+  (globalThis.lobbyServiceInstance = new LobbyService(firebaseLobbyService));


### PR DESCRIPTION
## Summary

- Added `src/services/LobbyService.ts` that wraps `FirebaseLobbyService` via composition, exposing a new `addLobby(owner, gameMode)` signature that handles lobby ID generation and `LobbyConfig` default-building internally
- Simplified `src/app/api/lobby/create/route.ts` to delegate all lobby construction to `LobbyService`, removing `LobbyConfig`, `RoleConfigMode`, `ShowRolesInPlay`, `GAME_MODES`, and `getDefaultRoleSlots` imports from the route
- Updated all other route files and `api-helpers.ts` to import `lobbyService` from `@/services/LobbyService` instead of `@/services/FirebaseLobbyService`

## Test plan

- [x] `pnpm tsc --noEmit` passes with no errors
- [x] `pnpm test --run` — all 960 tests pass across 108 test files
- [x] `pnpm lint` passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)