### PR TITLE
Add action gate before private policy and special action views

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,10 @@
   },
   "lint-staged": {
     "*.{js,mjs,cjs,ts,tsx,jsx}": [
-      "eslint --fix --max-warnings 0 --no-warn-ignored"
+      "eslint --fix --max-warnings 0 --no-warn-ignored",
+      "prettier --write"
     ],
-    "*.{js,mjs,cjs,ts,tsx,jsx,json,md,yml,yaml}": [
+    "*.{json,md,yml,yaml}": [
       "prettier --write"
     ]
   },

--- a/src/components/game/secret-villain/ActionGateView.spec.tsx
+++ b/src/components/game/secret-villain/ActionGateView.spec.tsx
@@ -1,0 +1,42 @@
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { ActionGateView } from "./ActionGateView";
+import { SECRET_VILLAIN_COPY } from "@/lib/game/modes/secret-villain/copy";
+
+afterEach(cleanup);
+
+describe("ActionGateView", () => {
+  it("renders the heading", () => {
+    render(<ActionGateView onReveal={vi.fn()} />);
+    expect(
+      screen.getByText(SECRET_VILLAIN_COPY.actionGate.heading),
+    ).toBeDefined();
+  });
+
+  it("renders the description", () => {
+    render(<ActionGateView onReveal={vi.fn()} />);
+    expect(
+      screen.getByText(SECRET_VILLAIN_COPY.actionGate.description),
+    ).toBeDefined();
+  });
+
+  it("renders the Begin button", () => {
+    render(<ActionGateView onReveal={vi.fn()} />);
+    expect(
+      screen.getByRole("button", {
+        name: SECRET_VILLAIN_COPY.actionGate.begin,
+      }),
+    ).toBeDefined();
+  });
+
+  it("calls onReveal when Begin is clicked", () => {
+    const onReveal = vi.fn();
+    render(<ActionGateView onReveal={onReveal} />);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: SECRET_VILLAIN_COPY.actionGate.begin,
+      }),
+    );
+    expect(onReveal).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/game/secret-villain/ActionGateView.stories.tsx
+++ b/src/components/game/secret-villain/ActionGateView.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ActionGateView } from "./ActionGateView";
+
+const meta = {
+  component: ActionGateView,
+} satisfies Meta<typeof ActionGateView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    onReveal: () => undefined,
+  },
+};

--- a/src/components/game/secret-villain/ActionGateView.tsx
+++ b/src/components/game/secret-villain/ActionGateView.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { SECRET_VILLAIN_COPY } from "@/lib/game/modes/secret-villain/copy";
+
+interface ActionGateViewProps {
+  onReveal: () => void;
+}
+
+export function ActionGateView({ onReveal }: ActionGateViewProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{SECRET_VILLAIN_COPY.actionGate.heading}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm">{SECRET_VILLAIN_COPY.actionGate.description}</p>
+        <Button onClick={onReveal}>
+          {SECRET_VILLAIN_COPY.actionGate.begin}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/game/secret-villain/PolicyChancellorView.spec.tsx
+++ b/src/components/game/secret-villain/PolicyChancellorView.spec.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, it, expect, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { PolicyChancellorView } from "./PolicyChancellorView";
 import { SECRET_VILLAIN_COPY } from "@/lib/game/modes/secret-villain/copy";
 
@@ -16,6 +16,11 @@ const defaultProps = {
 describe("PolicyChancellorView", () => {
   it("shows 2 card buttons when chancellor", () => {
     render(<PolicyChancellorView {...defaultProps} />);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: SECRET_VILLAIN_COPY.actionGate.begin,
+      }),
+    );
     const goodButtons = screen.getAllByText(
       SECRET_VILLAIN_COPY.policy.goodCard,
     );
@@ -31,6 +36,11 @@ describe("PolicyChancellorView", () => {
         onProposeVeto={vi.fn()}
       />,
     );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: SECRET_VILLAIN_COPY.actionGate.begin,
+      }),
+    );
     expect(
       screen.getByRole("button", {
         name: SECRET_VILLAIN_COPY.policy.proposeVeto,
@@ -40,6 +50,11 @@ describe("PolicyChancellorView", () => {
 
   it("hides veto button when veto is not unlocked", () => {
     render(<PolicyChancellorView {...defaultProps} />);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: SECRET_VILLAIN_COPY.actionGate.begin,
+      }),
+    );
     expect(
       screen.queryByRole("button", {
         name: SECRET_VILLAIN_COPY.policy.proposeVeto,
@@ -56,6 +71,11 @@ describe("PolicyChancellorView", () => {
         vetoResponse={false}
         onProposeVeto={vi.fn()}
       />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: SECRET_VILLAIN_COPY.actionGate.begin,
+      }),
     );
     expect(
       screen.getByText(SECRET_VILLAIN_COPY.policy.vetoRejected),

--- a/src/components/game/secret-villain/PolicyChancellorView.tsx
+++ b/src/components/game/secret-villain/PolicyChancellorView.tsx
@@ -72,7 +72,13 @@ export function PolicyChancellorView({
   }
 
   if (!revealed) {
-    return <ActionGateView onReveal={() => { setRevealed(true); }} />;
+    return (
+      <ActionGateView
+        onReveal={() => {
+          setRevealed(true);
+        }}
+      />
+    );
   }
 
   const vetoWasRejected = vetoProposed && vetoResponse === false;

--- a/src/components/game/secret-villain/PolicyChancellorView.tsx
+++ b/src/components/game/secret-villain/PolicyChancellorView.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { SECRET_VILLAIN_COPY } from "@/lib/game/modes/secret-villain/copy";
 import { getSvThemeLabels } from "@/lib/game/modes/secret-villain/themes";
 import type { SvTheme } from "@/lib/game/modes/secret-villain/themes";
 import { cn } from "@/lib/utils";
+import { ActionGateView } from "./ActionGateView";
 
 interface PolicyChancellorViewProps {
   remainingCards: string[];
@@ -36,6 +38,7 @@ export function PolicyChancellorView({
   chancellorName,
   svTheme,
 }: PolicyChancellorViewProps) {
+  const [revealed, setRevealed] = useState(false);
   const themeLabels = getSvThemeLabels(svTheme);
 
   if (!isChancellor) {
@@ -66,6 +69,10 @@ export function PolicyChancellorView({
         </CardContent>
       </Card>
     );
+  }
+
+  if (!revealed) {
+    return <ActionGateView onReveal={() => { setRevealed(true); }} />;
   }
 
   const vetoWasRejected = vetoProposed && vetoResponse === false;

--- a/src/components/game/secret-villain/PolicyPresidentView.spec.tsx
+++ b/src/components/game/secret-villain/PolicyPresidentView.spec.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, it, expect, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { PolicyPresidentView } from "./PolicyPresidentView";
 import { SECRET_VILLAIN_COPY } from "@/lib/game/modes/secret-villain/copy";
 
@@ -24,6 +24,11 @@ describe("PolicyPresidentView", () => {
         cardsRevealed={false}
       />,
     );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: SECRET_VILLAIN_COPY.actionGate.begin,
+      }),
+    );
     expect(
       screen.getByRole("button", {
         name: SECRET_VILLAIN_COPY.policy.presidentDraw,
@@ -39,12 +44,22 @@ describe("PolicyPresidentView", () => {
         cardsRevealed={false}
       />,
     );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: SECRET_VILLAIN_COPY.actionGate.begin,
+      }),
+    );
     expect(screen.queryByText(SECRET_VILLAIN_COPY.policy.goodCard)).toBeNull();
     expect(screen.queryByText(SECRET_VILLAIN_COPY.policy.badCard)).toBeNull();
   });
 
   it("shows 3 card buttons after drawing", () => {
     render(<PolicyPresidentView {...defaultProps} />);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: SECRET_VILLAIN_COPY.actionGate.begin,
+      }),
+    );
     const goodButtons = screen.getAllByText(
       SECRET_VILLAIN_COPY.policy.goodCard,
     );
@@ -63,6 +78,11 @@ describe("PolicyPresidentView", () => {
 
   it("discard button is disabled without selection", () => {
     render(<PolicyPresidentView {...defaultProps} />);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: SECRET_VILLAIN_COPY.actionGate.begin,
+      }),
+    );
     const discardButton = screen.getByRole("button", {
       name: SECRET_VILLAIN_COPY.policy.discard,
     });
@@ -71,6 +91,11 @@ describe("PolicyPresidentView", () => {
 
   it("discard button is enabled with selection", () => {
     render(<PolicyPresidentView {...defaultProps} selectedIndex={0} />);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: SECRET_VILLAIN_COPY.actionGate.begin,
+      }),
+    );
     const discardButton = screen.getByRole("button", {
       name: SECRET_VILLAIN_COPY.policy.discard,
     });

--- a/src/components/game/secret-villain/PolicyPresidentView.tsx
+++ b/src/components/game/secret-villain/PolicyPresidentView.tsx
@@ -52,7 +52,13 @@ export function PolicyPresidentView({
   }
 
   if (!revealed) {
-    return <ActionGateView onReveal={() => { setRevealed(true); }} />;
+    return (
+      <ActionGateView
+        onReveal={() => {
+          setRevealed(true);
+        }}
+      />
+    );
   }
 
   // Before drawing: show "Draw" button.

--- a/src/components/game/secret-villain/PolicyPresidentView.tsx
+++ b/src/components/game/secret-villain/PolicyPresidentView.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { SECRET_VILLAIN_COPY } from "@/lib/game/modes/secret-villain/copy";
 import { getSvThemeLabels } from "@/lib/game/modes/secret-villain/themes";
 import type { SvTheme } from "@/lib/game/modes/secret-villain/themes";
 import { cn } from "@/lib/utils";
+import { ActionGateView } from "./ActionGateView";
 
 interface PolicyPresidentViewProps {
   drawnCards: string[];
@@ -32,6 +34,7 @@ export function PolicyPresidentView({
   presidentName,
   svTheme,
 }: PolicyPresidentViewProps) {
+  const [revealed, setRevealed] = useState(false);
   const themeLabels = getSvThemeLabels(svTheme);
   if (!isPresident) {
     return (
@@ -46,6 +49,10 @@ export function PolicyPresidentView({
         </CardContent>
       </Card>
     );
+  }
+
+  if (!revealed) {
+    return <ActionGateView onReveal={() => { setRevealed(true); }} />;
   }
 
   // Before drawing: show "Draw" button.

--- a/src/components/game/secret-villain/SpecialActionView.spec.tsx
+++ b/src/components/game/secret-villain/SpecialActionView.spec.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, it, expect, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { SpecialActionView } from "./SpecialActionView";
 import { SECRET_VILLAIN_COPY } from "@/lib/game/modes/secret-villain/copy";
 import { SpecialActionType } from "@/lib/game/modes/secret-villain/types";
@@ -79,6 +79,11 @@ describe("SpecialActionView", () => {
         peekedCards={["good", "bad", "bad"]}
       />,
     );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: SECRET_VILLAIN_COPY.actionGate.begin,
+      }),
+    );
     const goodCards = screen.getAllByText(SECRET_VILLAIN_COPY.policy.goodCard);
     const badCards = screen.getAllByText(SECRET_VILLAIN_COPY.policy.badCard);
     expect(goodCards.length + badCards.length).toBe(3);
@@ -98,6 +103,11 @@ describe("SpecialActionView", () => {
         investigationResult={{ targetPlayerId: "p2", team: "Bad" }}
       />,
     );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: SECRET_VILLAIN_COPY.actionGate.begin,
+      }),
+    );
     expect(
       screen.getByText(
         SECRET_VILLAIN_COPY.specialAction.investigateResult("Bob", "Bad"),
@@ -112,6 +122,11 @@ describe("SpecialActionView", () => {
         investigationResult={{ targetPlayerId: "p2", team: "bad" }}
         onResolve={vi.fn()}
       />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: SECRET_VILLAIN_COPY.actionGate.begin,
+      }),
     );
     expect(
       screen.getByRole("button", {
@@ -143,6 +158,11 @@ describe("SpecialActionView", () => {
         onResolve={vi.fn()}
       />,
     );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: SECRET_VILLAIN_COPY.actionGate.begin,
+      }),
+    );
     expect(
       screen.getByRole("button", {
         name: SECRET_VILLAIN_COPY.specialAction.policyPeekConfirm,
@@ -158,6 +178,11 @@ describe("SpecialActionView", () => {
         actionType={SpecialActionType.PolicyPeek}
         onPeek={onPeek}
       />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: SECRET_VILLAIN_COPY.actionGate.begin,
+      }),
     );
     expect(
       screen.getByRole("button", {
@@ -178,6 +203,11 @@ describe("SpecialActionView", () => {
         actionType={SpecialActionType.PolicyPeek}
         onPeek={vi.fn()}
       />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: SECRET_VILLAIN_COPY.actionGate.begin,
+      }),
     );
     expect(screen.queryByText("Alice")).toBeNull();
     expect(screen.queryByText("Bob")).toBeNull();

--- a/src/components/game/secret-villain/SpecialActionView.tsx
+++ b/src/components/game/secret-villain/SpecialActionView.tsx
@@ -131,7 +131,13 @@ export function SpecialActionView({
   const needsGate =
     actionType === SpecialActionType.PolicyPeek || !!investigationResult;
   if (!revealed && needsGate) {
-    return <ActionGateView onReveal={() => { setRevealed(true); }} />;
+    return (
+      <ActionGateView
+        onReveal={() => {
+          setRevealed(true);
+        }}
+      />
+    );
   }
 
   // President: investigation result — show result with "Done" button.

--- a/src/components/game/secret-villain/SpecialActionView.tsx
+++ b/src/components/game/secret-villain/SpecialActionView.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { SECRET_VILLAIN_COPY } from "@/lib/game/modes/secret-villain/copy";
@@ -8,6 +9,7 @@ import type { SvTheme } from "@/lib/game/modes/secret-villain/themes";
 import { Team } from "@/lib/types";
 import { SpecialActionType } from "@/lib/game/modes/secret-villain/types";
 
+import { ActionGateView } from "./ActionGateView";
 import { InvestigationConsentView } from "./InvestigationConsentView";
 import { PlayerSelectionView } from "./PlayerSelectionView";
 import { PolicyPeekView } from "./PolicyPeekView";
@@ -94,6 +96,7 @@ export function SpecialActionView({
   peekedCards,
   svTheme,
 }: SpecialActionViewProps) {
+  const [revealed, setRevealed] = useState(false);
   const config = getActionConfig(actionType, svTheme);
 
   if (!isPresident) {
@@ -123,6 +126,12 @@ export function SpecialActionView({
         </CardContent>
       </Card>
     );
+  }
+
+  const needsGate =
+    actionType === SpecialActionType.PolicyPeek || !!investigationResult;
+  if (!revealed && needsGate) {
+    return <ActionGateView onReveal={() => { setRevealed(true); }} />;
   }
 
   // President: investigation result — show result with "Done" button.

--- a/src/lib/game/modes/secret-villain/copy.ts
+++ b/src/lib/game/modes/secret-villain/copy.ts
@@ -8,6 +8,11 @@ export const SECRET_VILLAIN_COPY = {
     [SvBoardPreset.Medium]: "7–8 Players",
     [SvBoardPreset.Small]: "5–6 Players",
   } satisfies Record<SvBoardPreset, string>,
+  actionGate: {
+    heading: "It's your turn",
+    description: "Take the device, then tap below when ready.",
+    begin: "Begin",
+  },
   board: {
     goodTrack: "Good Policies",
     badTrack: "Bad Policies",


### PR DESCRIPTION
## Summary

- Adds a new `ActionGateView` component that shows a generic "It's your turn / Take the device, then tap below when ready. / Begin" screen
- Gates the **PolicyPresidentView** president flow (Draw + card selection) behind the gate
- Gates the **PolicyChancellorView** card selection behind the gate (veto waiting screens are ungated — they're not private)
- Gates **SpecialActionView** for PolicyPeek (entire president experience) and InvestigateTeam result (the only sensitive output); Shoot and SpecialElection are ungated as target selection is not sensitive information

The `revealed` state is managed locally with `useState(false)` in each view, so it resets naturally on component unmount between phases.

## Test plan

- [x] `ActionGateView.spec.tsx` — heading, description, Begin button renders, `onReveal` called on click
- [x] `PolicyPresidentView.spec.tsx` — all president-facing tests click Begin before asserting
- [x] `PolicyChancellorView.spec.tsx` — all chancellor-facing tests click Begin before asserting
- [x] `SpecialActionView.spec.tsx` — PolicyPeek and investigationResult tests click Begin; Shoot/SpecialElection/waiting tests unchanged
- [x] All 29 tests pass

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)