### PR TITLE
Add pnpm tsc to CI and fix spec file type errors

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -34,6 +34,14 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm run format:check
 
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - run: pnpm tsc
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/src/components/game/secret-villain/BoardDisplay.spec.tsx
+++ b/src/components/game/secret-villain/BoardDisplay.spec.tsx
@@ -56,17 +56,17 @@ describe("BoardDisplay", () => {
   it("marks the last bad slot as final", () => {
     render(<BoardDisplay {...defaultProps} />);
     const badSlots = screen.getAllByTestId(/^bad-slot-\d+$/);
-    expect(badSlots[badSlots.length - 1].getAttribute("data-final")).toBe(
-      "true",
-    );
+    const lastBadSlot = badSlots[badSlots.length - 1];
+    if (!lastBadSlot) throw new Error("No bad slots rendered");
+    expect(lastBadSlot.getAttribute("data-final")).toBe("true");
   });
 
   it("marks the last good slot as final", () => {
     render(<BoardDisplay {...defaultProps} />);
     const goodSlots = screen.getAllByTestId(/^good-slot-\d+$/);
-    expect(goodSlots[goodSlots.length - 1].getAttribute("data-final")).toBe(
-      "true",
-    );
+    const lastGoodSlot = goodSlots[goodSlots.length - 1];
+    if (!lastGoodSlot) throw new Error("No good slots rendered");
+    expect(lastGoodSlot.getAttribute("data-final")).toBe("true");
   });
 
   it("shows veto badge when vetoUnlocked is true", () => {

--- a/src/lib/game/modes/werewolf/actions/cast-vote-tests/apply.spec.ts
+++ b/src/lib/game/modes/werewolf/actions/cast-vote-tests/apply.spec.ts
@@ -124,7 +124,9 @@ describe("WerewolfAction.CastVote — apply (basic)", () => {
     ).turnState.phase;
     const p2Votes = phase.activeTrial.votes.filter((v) => v.playerId === "p2");
     expect(p2Votes).toHaveLength(1);
-    expect(p2Votes[0].vote).toBe("innocent");
+    const p2Vote = p2Votes[0];
+    if (!p2Vote) throw new Error("p2 vote not found");
+    expect(p2Vote.vote).toBe("innocent");
   });
 
   it("triggers Werewolves win when auto-resolve eliminates last non-Bad player", () => {


### PR DESCRIPTION
## Summary
- Adds a `typecheck` job to CI that runs `pnpm tsc`, catching TypeScript errors in `.spec.ts` files (previously invisible because `pnpm build` only type-checks app files)
- Fixes three `Object is possibly 'undefined'` errors in `BoardDisplay.spec.tsx` (lines 59, 67) and `apply.spec.ts` (line 127) by extracting indexed array access to named variables with guards

## Test plan
- [x] CI `typecheck` job passes on this branch
- [x] `pnpm tsc` runs clean locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)