### PR TITLE
Add unique role attribute; enforce max 1 in Custom and Advanced modes

### DIFF
--- a/src/components/lobby/Incrementer.tsx
+++ b/src/components/lobby/Incrementer.tsx
@@ -36,8 +36,6 @@ export function Incrementer({
         onClick={handleDecrement}
         disabled={
           disabled === true || (minValue !== undefined && value <= minValue)
-            ? true
-            : undefined
         }
       >
         −
@@ -51,8 +49,6 @@ export function Incrementer({
         onClick={handleIncrement}
         disabled={
           disabled === true || (maxValue !== undefined && value >= maxValue)
-            ? true
-            : undefined
         }
       >
         +

--- a/src/components/lobby/Incrementer.tsx
+++ b/src/components/lobby/Incrementer.tsx
@@ -34,7 +34,11 @@ export function Incrementer({
         variant="outline"
         size="icon-xs"
         onClick={handleDecrement}
-        disabled={disabled ?? (minValue !== undefined && value <= minValue)}
+        disabled={
+          disabled === true || (minValue !== undefined && value <= minValue)
+            ? true
+            : undefined
+        }
       >
         −
       </Button>
@@ -45,7 +49,11 @@ export function Incrementer({
         variant="outline"
         size="icon-xs"
         onClick={handleIncrement}
-        disabled={disabled ?? (maxValue !== undefined && value >= maxValue)}
+        disabled={
+          disabled === true || (maxValue !== undefined && value >= maxValue)
+            ? true
+            : undefined
+        }
       >
         +
       </Button>

--- a/src/components/lobby/RoleBucketConfig.copy.ts
+++ b/src/components/lobby/RoleBucketConfig.copy.ts
@@ -4,7 +4,10 @@ export const ROLE_BUCKET_CONFIG_COPY = {
   bucketNamePlaceholder: (index: number) => `Bucket ${String(index + 1)}`,
   playerCount: "Players",
   addRole: "Add role…",
-  unique: "Unique",
+  /** Badge shown on inherently unique roles (max 1 enforced, cannot be toggled). */
+  uniqueBadge: "Unique",
+  /** Bucket-level toggle — only shown when the bucket has non-unique roles. */
+  bucketUnique: "Limit to one copy per role",
   removeRole: "Remove",
   noRoles: "No roles added yet.",
 } as const;

--- a/src/components/lobby/RoleBucketConfig.spec.tsx
+++ b/src/components/lobby/RoleBucketConfig.spec.tsx
@@ -10,7 +10,7 @@ afterEach(cleanup);
 const mockRoles: RoleDefinition<string, Team>[] = [
   { id: "villager", name: "Villager", team: Team.Good },
   { id: "werewolf", name: "Werewolf", team: Team.Bad },
-  { id: "seer", name: "Seer", team: Team.Good },
+  { id: "seer", name: "Seer", team: Team.Good, unique: true },
 ];
 
 const defaultProps = {
@@ -23,7 +23,7 @@ const defaultProps = {
   onSetBucketPlayerCount: vi.fn(),
   onAddRole: vi.fn(),
   onRemoveRole: vi.fn(),
-  onSetUnique: vi.fn(),
+  onSetBucketUnique: vi.fn(),
 };
 
 describe("RoleBucketConfigView", () => {
@@ -110,5 +110,39 @@ describe("RoleBucketConfigView", () => {
     for (const button of buttons) {
       expect(button.getAttribute("disabled")).not.toBeNull();
     }
+  });
+
+  it("shows the Unique badge on inherently unique roles", () => {
+    const buckets: AdvancedRoleBucket[] = [
+      { playerCount: 2, roles: [{ roleId: "seer", max: 1 }] },
+    ];
+    render(<RoleBucketConfigView {...defaultProps} buckets={buckets} />);
+    expect(screen.getByText(ROLE_BUCKET_CONFIG_COPY.uniqueBadge)).toBeDefined();
+  });
+
+  it("does not show the Unique badge on non-unique roles", () => {
+    const buckets: AdvancedRoleBucket[] = [
+      { playerCount: 2, roles: [{ roleId: "villager" }] },
+    ];
+    render(<RoleBucketConfigView {...defaultProps} buckets={buckets} />);
+    expect(screen.queryByText(ROLE_BUCKET_CONFIG_COPY.uniqueBadge)).toBeNull();
+  });
+
+  it("shows the bucket-level unique toggle when non-unique roles are present", () => {
+    const buckets: AdvancedRoleBucket[] = [
+      { playerCount: 2, roles: [{ roleId: "villager" }] },
+    ];
+    render(<RoleBucketConfigView {...defaultProps} buckets={buckets} />);
+    expect(
+      screen.getByText(ROLE_BUCKET_CONFIG_COPY.bucketUnique),
+    ).toBeDefined();
+  });
+
+  it("does not show the bucket-level unique toggle when only inherently unique roles are in the bucket", () => {
+    const buckets: AdvancedRoleBucket[] = [
+      { playerCount: 1, roles: [{ roleId: "seer", max: 1 }] },
+    ];
+    render(<RoleBucketConfigView {...defaultProps} buckets={buckets} />);
+    expect(screen.queryByText(ROLE_BUCKET_CONFIG_COPY.bucketUnique)).toBeNull();
   });
 });

--- a/src/components/lobby/RoleBucketConfig.stories.tsx
+++ b/src/components/lobby/RoleBucketConfig.stories.tsx
@@ -7,8 +7,8 @@ import type { AdvancedRoleBucket, RoleDefinition } from "@/lib/types";
 const mockRoles: RoleDefinition<string, Team>[] = [
   { id: "villager", name: "Villager", team: Team.Good },
   { id: "werewolf", name: "Werewolf", team: Team.Bad },
-  { id: "seer", name: "Seer", team: Team.Good },
-  { id: "doctor", name: "Doctor", team: Team.Good },
+  { id: "seer", name: "Seer", team: Team.Good, unique: true },
+  { id: "doctor", name: "Doctor", team: Team.Good, unique: true },
 ];
 
 const emptyBucket: AdvancedRoleBucket = {
@@ -41,7 +41,7 @@ const meta = {
     onSetBucketPlayerCount: fn(),
     onAddRole: fn(),
     onRemoveRole: fn(),
-    onSetUnique: fn(),
+    onSetBucketUnique: fn(),
   },
 } satisfies Meta<typeof RoleBucketConfigView>;
 
@@ -78,6 +78,33 @@ export const UnnamedBuckets: Story = {
     buckets: [
       { playerCount: 2, roles: [{ roleId: "villager" }] },
       { playerCount: 1, roles: [{ roleId: "werewolf", max: 1 }] },
+    ],
+  },
+};
+
+export const MixedUniqueness: Story = {
+  args: {
+    buckets: [
+      {
+        playerCount: 3,
+        name: "Mixed",
+        roles: [{ roleId: "villager" }, { roleId: "seer", max: 1 }],
+      },
+    ],
+  },
+};
+
+export const AllUniqueBucket: Story = {
+  args: {
+    buckets: [
+      {
+        playerCount: 2,
+        name: "Special",
+        roles: [
+          { roleId: "villager", max: 1 },
+          { roleId: "werewolf", max: 1 },
+        ],
+      },
     ],
   },
 };

--- a/src/components/lobby/RoleBucketConfig.stories.tsx
+++ b/src/components/lobby/RoleBucketConfig.stories.tsx
@@ -94,7 +94,7 @@ export const MixedUniqueness: Story = {
   },
 };
 
-export const AllUniqueBucket: Story = {
+export const AllCappedBucket: Story = {
   args: {
     buckets: [
       {

--- a/src/components/lobby/RoleBucketConfig.tsx
+++ b/src/components/lobby/RoleBucketConfig.tsx
@@ -240,7 +240,7 @@ function BucketEditor({
       ) : (
         <ul className="space-y-1 list-none p-0">
           {bucket.roles.map((slot) => {
-            const roleDef = allRoles.find((r) => r.id === slot.roleId);
+            const roleDef = roleDefById.get(slot.roleId);
             return (
               <li
                 key={slot.roleId}

--- a/src/components/lobby/RoleBucketConfig.tsx
+++ b/src/components/lobby/RoleBucketConfig.tsx
@@ -15,9 +15,10 @@ import {
   setBucketName,
   addRoleToBucket,
   removeRoleFromBucket,
-  setBucketRoleUnique,
+  setBucketUnique,
 } from "@/store/game-config-slice";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import {
@@ -47,11 +48,15 @@ export function RoleBucketConfig({
   const advancedBuckets = buckets.filter(
     (b): b is AdvancedRoleBucket => !isSimpleRoleBucket(b),
   );
+  const allRoles = Object.values(roleDefinitions);
+  const inherentlyUniqueRoleIds = allRoles
+    .filter((r) => r.unique)
+    .map((r) => r.id);
 
   return (
     <RoleBucketConfigView
       buckets={advancedBuckets}
-      allRoles={Object.values(roleDefinitions)}
+      allRoles={allRoles}
       gameMode={gameMode}
       disabled={disabled}
       onAddBucket={() => {
@@ -66,14 +71,22 @@ export function RoleBucketConfig({
       onSetBucketPlayerCount={(i, count) => {
         dispatch(setBucketPlayerCount({ bucketIndex: i, playerCount: count }));
       }}
-      onAddRole={(i, roleId) => {
-        dispatch(addRoleToBucket({ bucketIndex: i, roleId }));
+      onAddRole={(i, roleId, isUnique, bucketIsUnique) => {
+        dispatch(
+          addRoleToBucket({ bucketIndex: i, roleId, isUnique, bucketIsUnique }),
+        );
       }}
       onRemoveRole={(i, roleId) => {
         dispatch(removeRoleFromBucket({ bucketIndex: i, roleId }));
       }}
-      onSetUnique={(i, roleId, unique) => {
-        dispatch(setBucketRoleUnique({ bucketIndex: i, roleId, unique }));
+      onSetBucketUnique={(i, unique) => {
+        dispatch(
+          setBucketUnique({
+            bucketIndex: i,
+            unique,
+            inherentlyUniqueRoleIds,
+          }),
+        );
       }}
     />
   );
@@ -88,9 +101,14 @@ export interface RoleBucketConfigViewProps {
   onRemoveBucket: (bucketIndex: number) => void;
   onSetBucketName: (bucketIndex: number, name: string) => void;
   onSetBucketPlayerCount: (bucketIndex: number, count: number) => void;
-  onAddRole: (bucketIndex: number, roleId: string) => void;
+  onAddRole: (
+    bucketIndex: number,
+    roleId: string,
+    isUnique: boolean,
+    bucketIsUnique: boolean,
+  ) => void;
   onRemoveRole: (bucketIndex: number, roleId: string) => void;
-  onSetUnique: (bucketIndex: number, roleId: string, unique: boolean) => void;
+  onSetBucketUnique: (bucketIndex: number, unique: boolean) => void;
 }
 
 export function RoleBucketConfigView({
@@ -104,7 +122,7 @@ export function RoleBucketConfigView({
   onSetBucketPlayerCount,
   onAddRole,
   onRemoveRole,
-  onSetUnique,
+  onSetBucketUnique,
 }: RoleBucketConfigViewProps) {
   return (
     <div className="space-y-4">
@@ -125,14 +143,14 @@ export function RoleBucketConfigView({
           onSetPlayerCount={(count) => {
             onSetBucketPlayerCount(bucketIndex, count);
           }}
-          onAddRole={(roleId) => {
-            onAddRole(bucketIndex, roleId);
+          onAddRole={(roleId, isUnique, bucketIsUnique) => {
+            onAddRole(bucketIndex, roleId, isUnique, bucketIsUnique);
           }}
           onRemoveRole={(roleId) => {
             onRemoveRole(bucketIndex, roleId);
           }}
-          onSetUnique={(roleId, unique) => {
-            onSetUnique(bucketIndex, roleId, unique);
+          onSetBucketUnique={(unique) => {
+            onSetBucketUnique(bucketIndex, unique);
           }}
         />
       ))}
@@ -157,9 +175,13 @@ interface BucketEditorProps {
   onRemove: () => void;
   onSetName: (name: string) => void;
   onSetPlayerCount: (count: number) => void;
-  onAddRole: (roleId: string) => void;
+  onAddRole: (
+    roleId: string,
+    isUnique: boolean,
+    bucketIsUnique: boolean,
+  ) => void;
   onRemoveRole: (roleId: string) => void;
-  onSetUnique: (roleId: string, unique: boolean) => void;
+  onSetBucketUnique: (unique: boolean) => void;
 }
 
 function BucketEditor({
@@ -173,10 +195,18 @@ function BucketEditor({
   onSetPlayerCount,
   onAddRole,
   onRemoveRole,
-  onSetUnique,
+  onSetBucketUnique,
 }: BucketEditorProps) {
   const assignedRoleIds = new Set(bucket.roles.map((r) => r.roleId));
   const availableRoles = allRoles.filter((r) => !assignedRoleIds.has(r.id));
+
+  const nonUniqueSlots = bucket.roles.filter((slot) => {
+    const roleDef = allRoles.find((r) => r.id === slot.roleId);
+    return !roleDef?.unique;
+  });
+  const hasNonUniqueRoles = nonUniqueSlots.length > 0;
+  const bucketIsUnique =
+    hasNonUniqueRoles && nonUniqueSlots.every((s) => s.max !== undefined);
 
   return (
     <div className="border rounded-md p-3 space-y-3">
@@ -240,42 +270,51 @@ function BucketEditor({
                       {slot.roleId}
                     </span>
                   )}
+                  {roleDef?.unique && (
+                    <Badge variant="secondary" className="text-xs shrink-0">
+                      {ROLE_BUCKET_CONFIG_COPY.uniqueBadge}
+                    </Badge>
+                  )}
                 </span>
-                <div className="flex items-center gap-3 shrink-0">
-                  <label className="flex items-center gap-1.5 cursor-pointer">
-                    <Checkbox
-                      checked={slot.max !== undefined}
-                      onCheckedChange={(checked) => {
-                        onSetUnique(slot.roleId, checked);
-                      }}
-                      disabled={disabled}
-                    />
-                    <span className="text-xs">
-                      {ROLE_BUCKET_CONFIG_COPY.unique}
-                    </span>
-                  </label>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    disabled={disabled}
-                    onClick={() => {
-                      onRemoveRole(slot.roleId);
-                    }}
-                  >
-                    {ROLE_BUCKET_CONFIG_COPY.removeRole}
-                  </Button>
-                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={disabled}
+                  onClick={() => {
+                    onRemoveRole(slot.roleId);
+                  }}
+                >
+                  {ROLE_BUCKET_CONFIG_COPY.removeRole}
+                </Button>
               </li>
             );
           })}
         </ul>
       )}
 
+      {hasNonUniqueRoles && (
+        <label className="flex items-center gap-1.5 cursor-pointer">
+          <Checkbox
+            checked={bucketIsUnique}
+            onCheckedChange={(checked) => {
+              onSetBucketUnique(checked);
+            }}
+            disabled={disabled}
+          />
+          <span className="text-xs">
+            {ROLE_BUCKET_CONFIG_COPY.bucketUnique}
+          </span>
+        </label>
+      )}
+
       {availableRoles.length > 0 && (
         <Select
           disabled={disabled}
           onValueChange={(roleId) => {
-            if (roleId) onAddRole(roleId as string);
+            if (!roleId) return;
+            const id = roleId as string;
+            const roleDef = allRoles.find((r) => r.id === id);
+            onAddRole(id, roleDef?.unique === true, bucketIsUnique);
           }}
         >
           <SelectTrigger className="w-48 h-8 text-sm">

--- a/src/components/lobby/RoleBucketConfig.tsx
+++ b/src/components/lobby/RoleBucketConfig.tsx
@@ -184,10 +184,10 @@ function BucketEditor({
   const assignedRoleIds = new Set(bucket.roles.map((r) => r.roleId));
   const availableRoles = allRoles.filter((r) => !assignedRoleIds.has(r.id));
 
-  const nonUniqueSlots = bucket.roles.filter((slot) => {
-    const roleDef = allRoles.find((r) => r.id === slot.roleId);
-    return !roleDef?.unique;
-  });
+  const roleDefById = new Map(allRoles.map((r) => [r.id, r]));
+  const nonUniqueSlots = bucket.roles.filter(
+    (slot) => !roleDefById.get(slot.roleId)?.unique,
+  );
   const hasNonUniqueRoles = nonUniqueSlots.length > 0;
   const bucketIsUnique =
     hasNonUniqueRoles && nonUniqueSlots.every((s) => s.max === 1);

--- a/src/components/lobby/RoleBucketConfig.tsx
+++ b/src/components/lobby/RoleBucketConfig.tsx
@@ -49,9 +49,6 @@ export function RoleBucketConfig({
     (b): b is AdvancedRoleBucket => !isSimpleRoleBucket(b),
   );
   const allRoles = Object.values(roleDefinitions);
-  const inherentlyUniqueRoleIds = allRoles
-    .filter((r) => r.unique)
-    .map((r) => r.id);
 
   return (
     <RoleBucketConfigView
@@ -71,22 +68,14 @@ export function RoleBucketConfig({
       onSetBucketPlayerCount={(i, count) => {
         dispatch(setBucketPlayerCount({ bucketIndex: i, playerCount: count }));
       }}
-      onAddRole={(i, roleId, isUnique, bucketIsUnique) => {
-        dispatch(
-          addRoleToBucket({ bucketIndex: i, roleId, isUnique, bucketIsUnique }),
-        );
+      onAddRole={(i, roleId, bucketIsUnique) => {
+        dispatch(addRoleToBucket({ bucketIndex: i, roleId, bucketIsUnique }));
       }}
       onRemoveRole={(i, roleId) => {
         dispatch(removeRoleFromBucket({ bucketIndex: i, roleId }));
       }}
       onSetBucketUnique={(i, unique) => {
-        dispatch(
-          setBucketUnique({
-            bucketIndex: i,
-            unique,
-            inherentlyUniqueRoleIds,
-          }),
-        );
+        dispatch(setBucketUnique({ bucketIndex: i, unique }));
       }}
     />
   );
@@ -104,7 +93,6 @@ export interface RoleBucketConfigViewProps {
   onAddRole: (
     bucketIndex: number,
     roleId: string,
-    isUnique: boolean,
     bucketIsUnique: boolean,
   ) => void;
   onRemoveRole: (bucketIndex: number, roleId: string) => void;
@@ -143,8 +131,8 @@ export function RoleBucketConfigView({
           onSetPlayerCount={(count) => {
             onSetBucketPlayerCount(bucketIndex, count);
           }}
-          onAddRole={(roleId, isUnique, bucketIsUnique) => {
-            onAddRole(bucketIndex, roleId, isUnique, bucketIsUnique);
+          onAddRole={(roleId, bucketIsUnique) => {
+            onAddRole(bucketIndex, roleId, bucketIsUnique);
           }}
           onRemoveRole={(roleId) => {
             onRemoveRole(bucketIndex, roleId);
@@ -175,11 +163,7 @@ interface BucketEditorProps {
   onRemove: () => void;
   onSetName: (name: string) => void;
   onSetPlayerCount: (count: number) => void;
-  onAddRole: (
-    roleId: string,
-    isUnique: boolean,
-    bucketIsUnique: boolean,
-  ) => void;
+  onAddRole: (roleId: string, bucketIsUnique: boolean) => void;
   onRemoveRole: (roleId: string) => void;
   onSetBucketUnique: (unique: boolean) => void;
 }
@@ -206,7 +190,7 @@ function BucketEditor({
   });
   const hasNonUniqueRoles = nonUniqueSlots.length > 0;
   const bucketIsUnique =
-    hasNonUniqueRoles && nonUniqueSlots.every((s) => s.max !== undefined);
+    hasNonUniqueRoles && nonUniqueSlots.every((s) => s.max === 1);
 
   return (
     <div className="border rounded-md p-3 space-y-3">
@@ -312,9 +296,7 @@ function BucketEditor({
           disabled={disabled}
           onValueChange={(roleId) => {
             if (!roleId) return;
-            const id = roleId as string;
-            const roleDef = allRoles.find((r) => r.id === id);
-            onAddRole(id, roleDef?.unique === true, bucketIsUnique);
+            onAddRole(roleId as string, bucketIsUnique);
           }}
         >
           <SelectTrigger className="w-48 h-8 text-sm">

--- a/src/components/lobby/RoleConfigEntry.spec.tsx
+++ b/src/components/lobby/RoleConfigEntry.spec.tsx
@@ -1,0 +1,79 @@
+import { afterEach, describe, it, expect } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import gameConfigReducer, { setRoleCount } from "@/store/game-config-slice";
+import { GameMode, RoleConfigMode, Team } from "@/lib/types";
+import type { RoleDefinition } from "@/lib/types";
+import { RoleConfigEntry } from "./RoleConfigEntry";
+
+afterEach(cleanup);
+
+function makeStore(roleCounts: Record<string, number> = {}) {
+  const store = configureStore({ reducer: { gameConfig: gameConfigReducer } });
+  for (const [roleId, count] of Object.entries(roleCounts)) {
+    store.dispatch(setRoleCount({ roleId, count }));
+  }
+  return store;
+}
+
+const uniqueRole: RoleDefinition<string, Team> = {
+  id: "seer",
+  name: "Seer",
+  team: Team.Good,
+  unique: true,
+};
+
+const nonUniqueRole: RoleDefinition<string, Team> = {
+  id: "villager",
+  name: "Villager",
+  team: Team.Good,
+};
+
+const baseEditableProps = {
+  gameMode: GameMode.Werewolf,
+  roleConfigMode: RoleConfigMode.Custom,
+  readOnly: false as const,
+  disabled: false,
+};
+
+describe("RoleConfigEntry — unique role in Custom mode", () => {
+  it("disables the increment button when a unique role is already at count 1", () => {
+    const store = makeStore({ [uniqueRole.id]: 1 });
+    render(
+      <Provider store={store}>
+        <ul>
+          <RoleConfigEntry {...baseEditableProps} role={uniqueRole} />
+        </ul>
+      </Provider>,
+    );
+    const incrementButton = screen.getByRole("button", { name: "+" });
+    expect(incrementButton.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("enables the increment button when a unique role is at count 0", () => {
+    const store = makeStore({ [uniqueRole.id]: 0 });
+    render(
+      <Provider store={store}>
+        <ul>
+          <RoleConfigEntry {...baseEditableProps} role={uniqueRole} />
+        </ul>
+      </Provider>,
+    );
+    const incrementButton = screen.getByRole("button", { name: "+" });
+    expect(incrementButton.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("does not disable the increment button for a non-unique role at count 1", () => {
+    const store = makeStore({ [nonUniqueRole.id]: 1 });
+    render(
+      <Provider store={store}>
+        <ul>
+          <RoleConfigEntry {...baseEditableProps} role={nonUniqueRole} />
+        </ul>
+      </Provider>,
+    );
+    const incrementButton = screen.getByRole("button", { name: "+" });
+    expect(incrementButton.hasAttribute("disabled")).toBe(false);
+  });
+});

--- a/src/components/lobby/RoleConfigEntry.tsx
+++ b/src/components/lobby/RoleConfigEntry.tsx
@@ -62,6 +62,7 @@ export function RoleConfigEntry(props: RoleConfigEntryProps) {
             onChange={handleCountChange}
             disabled={props.disabled}
             minValue={0}
+            maxValue={role.unique ? 1 : undefined}
           />
         </div>
       ) : count > 0 ? (

--- a/src/lib/game/modes/werewolf/roles.ts
+++ b/src/lib/game/modes/werewolf/roles.ts
@@ -138,6 +138,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "Each night, after the Werewolves have chosen their target, the Altruist learns which players are under attack. They may intercept one attack, saving the original target — but dying in their place. If the Altruist is themselves under attack, their intercept is ignored.",
     team: Team.Good,
+    unique: true,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Special,
     category: WerewolfRoleCategory.VillagerProtection,
@@ -149,6 +150,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "Each night the Bodyguard chooses one player to protect. If that player is attacked, they survive. The Bodyguard cannot protect the same player on consecutive nights.",
     team: Team.Good,
+    unique: true,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Protect,
     preventRepeatTarget: true,
@@ -161,6 +163,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "Each night the Chupacabra targets one player. The attack only succeeds if the target is a Werewolf — once all Werewolves have been eliminated, the Chupacabra can attack anyone. The Chupacabra is neutral and has its own win condition.",
     team: Team.Neutral,
+    unique: true,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Attack,
     category: WerewolfRoleCategory.NeutralKilling,
@@ -172,6 +175,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "Each night the Doctor chooses one player to protect from werewolf attacks. Unlike the Bodyguard, the Doctor can protect the same player on consecutive nights but cannot protect themselves.",
     team: Team.Good,
+    unique: true,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Protect,
     preventSelfTarget: true,
@@ -185,6 +189,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "On the first night only, the Elusive Seer wakes and is shown the identity of every plain Villager in the game. They have no night action on subsequent nights.",
     team: Team.Good,
+    unique: true,
     wakesAtNight: WakesAtNight.FirstNightOnly,
     targetCategory: TargetCategory.None,
     category: WerewolfRoleCategory.VillagerInvestigation,
@@ -207,6 +212,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "Once per game, the Exposer may target a player at night. When confirmed, that player's role is publicly revealed to all players at the start of the following day. This ability can only be used once.",
     team: Team.Good,
+    unique: true,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Special,
     oncePerGame: true,
@@ -269,6 +275,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "Each night the Mentalist selects two players and the Narrator privately reveals whether those two players are on the same team. The Mentalist does not learn either player's specific role — only whether their teams match.",
     team: Team.Good,
+    unique: true,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Investigate,
     dualTargetInvestigate: true,
@@ -281,6 +288,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "The Minion knows who the Werewolves are, but the Werewolves do not know the Minion's identity. The Minion wins with the Werewolves. The Seer's investigation reveals the Minion is not a Werewolf.",
     team: Team.Bad,
+    unique: true,
     awareOf: { werewolves: true },
     wakesAtNight: WakesAtNight.FirstNightOnly,
     targetCategory: TargetCategory.None,
@@ -295,6 +303,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "The Mirrorcaster starts in Protect mode, choosing a player to shield each night. When the protected player is attacked, the Mirrorcaster gains a charge and switches to Attack mode. Their next night action is an attack (blockable by protections). After attacking, the charge is consumed and they return to Protect mode.",
     team: Team.Good,
+    unique: true,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Special,
     preventSelfTarget: true,
@@ -307,6 +316,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "Each night, the Mortician targets one player to attack. If the target is protected, the attack fails and the Mortician receives a 'not a Werewolf' result regardless of the target's actual role. Once the Mortician successfully kills a Werewolf, their ability ends and they no longer wake at night.",
     team: Team.Good,
+    unique: true,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Attack,
     preventSelfTarget: true,
@@ -319,6 +329,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "Each night the Mummy selects a player to hypnotize. The following day, the hypnotized player's trial vote is automatically cast to match the Mummy's vote. The Mummy selects a new target each night.",
     team: Team.Good,
+    unique: true,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Special,
     category: WerewolfRoleCategory.VillagerSupport,
@@ -330,6 +341,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "Each night the Mystic Seer targets one player and the Narrator privately reveals that player's exact role — not merely whether they are a Werewolf. This is significantly more powerful than the Seer.",
     team: Team.Good,
+    unique: true,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Investigate,
     revealsExactRole: true,
@@ -353,6 +365,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "Each night the One-Eyed Seer targets one player and the Narrator privately reveals whether that player is a Werewolf (same check as the Seer). However, if the investigation reveals a Werewolf, the One-Eyed Seer is locked on — they cannot investigate any new players until that Werewolf is eliminated.",
     team: Team.Good,
+    unique: true,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Investigate,
     category: WerewolfRoleCategory.VillagerInvestigation,
@@ -376,6 +389,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "The Priest selects a player to place a ward on. The ward persists until the protected player is attacked, at which point the ward is consumed and the Priest selects a new target on the following night.",
     team: Team.Good,
+    unique: true,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Protect,
     category: WerewolfRoleCategory.VillagerProtection,
@@ -387,6 +401,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "Each night the Seer targets one player and the Narrator privately reveals whether that player is a Werewolf. Only Werewolves and Wolf Cubs are detected — other evil roles such as the Minion are not.",
     team: Team.Good,
+    unique: true,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Investigate,
     aliases: ["oracle", "prophet"],
@@ -399,6 +414,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "The Sentinel wakes on the first night and learns the identity of the Seer. They have no night action — their role is to use this knowledge to protect the Seer during daytime discussion without revealing them to the Werewolves.",
     team: Team.Good,
+    unique: true,
     awareOf: { roles: [WerewolfRole.Seer] },
     wakesAtNight: WakesAtNight.FirstNightOnly,
     targetCategory: TargetCategory.None,
@@ -411,6 +427,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "Each night the Spellcaster targets one player who is silenced the following day and cannot speak. The Spellcaster cannot target the same player on consecutive nights.",
     team: Team.Good,
+    unique: true,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Special,
     preventRepeatTarget: true,
@@ -457,6 +474,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "Starting on the second night, the Vigilante may choose one player to eliminate. If the target is protected, the kill is blocked. If the Vigilante successfully kills a Good-team player, the Vigilante also dies at the start of the following day.",
     team: Team.Good,
+    unique: true,
     wakesAtNight: WakesAtNight.AfterFirstNight,
     targetCategory: TargetCategory.Attack,
     preventSelfTarget: true,
@@ -507,6 +525,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "After all other night roles have acted, the Witch may use her special ability: either protect the player who was attacked that night, or attack any other player. This ability can only be used once per game.",
     team: Team.Good,
+    unique: true,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Special,
     aliases: ["potion"],
@@ -519,6 +538,7 @@ export const WEREWOLF_ROLES: Record<WerewolfRole, WerewolfRoleDefinition> = {
     description:
       "The Wizard wins with the Werewolves but operates alone — the wolves don't know the Wizard, and the Wizard doesn't know the wolves. Each night the Wizard targets one player and the Narrator privately reveals whether that player is the Seer. The Seer's own investigation returns 'not a Werewolf' for the Wizard.",
     team: Team.Bad,
+    unique: true,
     wakesAtNight: WakesAtNight.EveryNight,
     targetCategory: TargetCategory.Investigate,
     checksForSeer: true,

--- a/src/lib/types/game.ts
+++ b/src/lib/types/game.ts
@@ -132,6 +132,8 @@ export interface RoleDefinition<
   category?: string;
   /** Alternative names or terms this role can be found by when searching. */
   aliases?: string[];
+  /** Roles that wake alone with unique individual mechanics — multiple copies would break narrator UX. */
+  unique?: true;
 }
 
 /**

--- a/src/store/game-config-slice.ts
+++ b/src/store/game-config-slice.ts
@@ -305,6 +305,7 @@ const gameConfigSlice = createSlice({
       if (!bucket || isSimpleRoleBucket(bucket)) return;
       const modeRoles = GAME_MODES[state.gameMode].roles;
       for (const slot of bucket.roles) {
+        // Inherently unique roles are always capped at 1 — skip the toggle logic.
         if (modeRoles[slot.roleId]?.unique === true) {
           slot.max = 1;
           continue;

--- a/src/store/game-config-slice.ts
+++ b/src/store/game-config-slice.ts
@@ -258,12 +258,25 @@ const gameConfigSlice = createSlice({
 
     addRoleToBucket(
       state,
-      action: PayloadAction<{ bucketIndex: number; roleId: string }>,
+      action: PayloadAction<{
+        bucketIndex: number;
+        roleId: string;
+        /** True if this role is inherently unique (only one copy allowed). */
+        isUnique?: boolean;
+        /** True if the bucket is currently in all-unique mode — cap this slot too. */
+        bucketIsUnique?: boolean;
+      }>,
     ) {
       const bucket = state.roleBuckets[action.payload.bucketIndex];
       if (!bucket || isSimpleRoleBucket(bucket)) return;
       if (!bucket.roles.some((r) => r.roleId === action.payload.roleId)) {
-        bucket.roles.push({ roleId: action.payload.roleId });
+        const shouldCap =
+          action.payload.isUnique === true ||
+          action.payload.bucketIsUnique === true;
+        bucket.roles.push({
+          roleId: action.payload.roleId,
+          ...(shouldCap ? { max: 1 } : {}),
+        });
         state.isValid = recomputeIsValid(state);
         state.syncVersion++;
       }
@@ -282,26 +295,32 @@ const gameConfigSlice = createSlice({
       state.syncVersion++;
     },
 
-    setBucketRoleUnique(
+    setBucketUnique(
       state,
       action: PayloadAction<{
         bucketIndex: number;
-        roleId: string;
         unique: boolean;
+        /**
+         * Role IDs that are inherently unique — their max is always 1 and
+         * should not be touched by this toggle.
+         */
+        inherentlyUniqueRoleIds: string[];
       }>,
     ) {
       const bucket = state.roleBuckets[action.payload.bucketIndex];
       if (!bucket || isSimpleRoleBucket(bucket)) return;
-      const slot = bucket.roles.find((r) => r.roleId === action.payload.roleId);
-      if (slot) {
+      for (const slot of bucket.roles) {
+        if (action.payload.inherentlyUniqueRoleIds.includes(slot.roleId)) {
+          continue;
+        }
         if (action.payload.unique) {
           slot.max = 1;
         } else {
           delete slot.max;
         }
-        state.isValid = recomputeIsValid(state);
-        state.syncVersion++;
       }
+      state.isValid = recomputeIsValid(state);
+      state.syncVersion++;
     },
 
     setPlayerCount(state, action: PayloadAction<number>) {
@@ -388,7 +407,7 @@ export const {
   setBucketName,
   addRoleToBucket,
   removeRoleFromBucket,
-  setBucketRoleUnique,
+  setBucketUnique,
   setPlayerCount,
   setShowConfigToPlayers,
   setShowRolesInPlay,

--- a/src/store/game-config-slice.ts
+++ b/src/store/game-config-slice.ts
@@ -305,7 +305,10 @@ const gameConfigSlice = createSlice({
       if (!bucket || isSimpleRoleBucket(bucket)) return;
       const modeRoles = GAME_MODES[state.gameMode].roles;
       for (const slot of bucket.roles) {
-        if (modeRoles[slot.roleId]?.unique === true) continue;
+        if (modeRoles[slot.roleId]?.unique === true) {
+          slot.max = 1;
+          continue;
+        }
         if (action.payload.unique) {
           slot.max = 1;
         } else if (slot.max === 1) {

--- a/src/store/game-config-slice.ts
+++ b/src/store/game-config-slice.ts
@@ -261,8 +261,6 @@ const gameConfigSlice = createSlice({
       action: PayloadAction<{
         bucketIndex: number;
         roleId: string;
-        /** True if this role is inherently unique (only one copy allowed). */
-        isUnique?: boolean;
         /** True if the bucket is currently in all-unique mode — cap this slot too. */
         bucketIsUnique?: boolean;
       }>,
@@ -270,9 +268,10 @@ const gameConfigSlice = createSlice({
       const bucket = state.roleBuckets[action.payload.bucketIndex];
       if (!bucket || isSimpleRoleBucket(bucket)) return;
       if (!bucket.roles.some((r) => r.roleId === action.payload.roleId)) {
+        const roleDef = GAME_MODES[state.gameMode].roles[action.payload.roleId];
+        const isInherentlyUnique = roleDef?.unique === true;
         const shouldCap =
-          action.payload.isUnique === true ||
-          action.payload.bucketIsUnique === true;
+          isInherentlyUnique || action.payload.bucketIsUnique === true;
         bucket.roles.push({
           roleId: action.payload.roleId,
           ...(shouldCap ? { max: 1 } : {}),
@@ -300,22 +299,16 @@ const gameConfigSlice = createSlice({
       action: PayloadAction<{
         bucketIndex: number;
         unique: boolean;
-        /**
-         * Role IDs that are inherently unique — their max is always 1 and
-         * should not be touched by this toggle.
-         */
-        inherentlyUniqueRoleIds: string[];
       }>,
     ) {
       const bucket = state.roleBuckets[action.payload.bucketIndex];
       if (!bucket || isSimpleRoleBucket(bucket)) return;
+      const modeRoles = GAME_MODES[state.gameMode].roles;
       for (const slot of bucket.roles) {
-        if (action.payload.inherentlyUniqueRoleIds.includes(slot.roleId)) {
-          continue;
-        }
+        if (modeRoles[slot.roleId]?.unique === true) continue;
         if (action.payload.unique) {
           slot.max = 1;
-        } else {
+        } else if (slot.max === 1) {
           delete slot.max;
         }
       }


### PR DESCRIPTION
## Summary

- Adds `unique?: true` to `RoleDefinition` — marks roles where duplicates would break narrator UX (roles that wake alone with individual mechanics)
- Marks 20 Werewolf roles as unique: Altruist, Bodyguard, Chupacabra, Doctor, ElusiveSeer, Exposer, Mentalist, Minion, Mirrorcaster, Mortician, Mummy, MysticSeer, OneEyedSeer, Priest, Seer, Sentinel, Spellcaster, Vigilante, Witch, Wizard
- In **Custom mode**: unique roles are capped at max 1 via the `Incrementer` component
- In **Advanced (Bucket) mode**: replaces the per-slot Unique checkbox with a bucket-level "Limit to one copy per role" toggle; inherently unique roles display a read-only "Unique" badge instead

## Test plan

- [ ] Custom mode: incrementing a unique role stops at 1
- [ ] Advanced mode: "Limit to one copy per role" toggle sets/clears max on all non-unique slots in the bucket
- [ ] Advanced mode: unique roles show "Unique" badge and are unaffected by the bucket toggle
- [ ] `RoleBucketConfig.spec.tsx` — all 11 tests pass
- [ ] `pnpm test` passes
- [ ] `pnpm tsc` passes

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)