### PR TITLE
chore: document and enforce code quality conventions in AGENTS.md

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -20,7 +20,7 @@ jobs:
             echo "PR title is valid: $PR_TITLE"
           else
             echo "PR title does not follow Conventional Commits format."
-            echo "Expected: <type>: description  or  <type>(<scope>): description"
+            echo "Expected: <type>[!]: description  or  <type>(<scope>)[!]: description"
             echo "Valid types: feat, fix, docs, chore, refactor, test, style, perf, ci, build, revert"
             echo "Got: $PR_TITLE"
             exit 1

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -16,7 +16,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if echo "$PR_TITLE" | grep -qE '^(feat|fix|docs|chore|refactor|test|style|perf|ci|build|revert)(\([^)]+\))?!?: '; then
+          if printf '%s\n' "$PR_TITLE" | grep -qE '^(feat|fix|docs|chore|refactor|test|style|perf|ci|build|revert)(\([^)]+\))?!?: [^[:space:]].*$'; then
             echo "PR title is valid: $PR_TITLE"
           else
             echo "PR title does not follow Conventional Commits format."

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,27 @@
+name: PR Title Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if echo "$PR_TITLE" | grep -qE '^(feat|fix|docs|chore|refactor|test|style|perf|ci|build|revert)(\([^)]+\))?!?: '; then
+            echo "PR title is valid: $PR_TITLE"
+          else
+            echo "PR title does not follow Conventional Commits format."
+            echo "Expected: <type>: description  or  <type>(<scope>): description"
+            echo "Valid types: feat, fix, docs, chore, refactor, test, style, perf, ci, build, revert"
+            echo "Got: $PR_TITLE"
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,9 +35,11 @@ pnpm build-storybook  # Build static Storybook
 
 ## Code Conventions
 
+- **Favor type inference.** Explicit type parameterization is a code smell — let TypeScript infer where it can.
 - **No spurious variables.** Do not assign a value to a variable only to immediately return it on the next line — return the expression directly instead.
 - **No IIFEs.** Do not use immediately-invoked function expressions. Extract the logic into a named helper function or compute the value with a plain expression instead.
 - **No function-style imports.** Do not use inline `import("…").Type` syntax in type annotations. Use module-level `import type { … } from "…"` statements at the top of the file. Dynamic `await import("…")` for services that require conditional loading (e.g., Sentry instrumentation) is acceptable.
+- **No unnecessary helpers.** Do not extract logic into a helper function unless it separates significant logic or belongs in a different module. Three similar lines is better than a premature abstraction.
 - **Role enums and definitions** in game mode files (e.g., `WerewolfRole` enum and `WEREWOLF_ROLES` object) must be kept in alphabetical order to minimize merge conflicts.
 - **Prefer enums over string literal unions** for any domain concept with two or more named states (e.g., use `enum TrialPhase { Defense = "defense", Voting = "voting" }` rather than `"defense" | "voting"`). String enum values must match the existing serialized literals so Firebase data round-trips without migration. Export new enums from the module barrel.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ pnpm build-storybook  # Build static Storybook
 
 - Branch names: lowercase with hyphens, prefixed by type: `feature/`, `chore/`, `refactor/`, `docs/`, with issue number suffix (e.g., `feature/secret-villain-deck-290`).
 - Commit messages: imperative verbs (Add, Implement, Fix, Update, Extract, Remove). No `feat:`/`fix:` prefixes.
+- PR titles must follow Conventional Commits format: `<type>: description` or `<type>(<scope>): description`. Valid types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `style`, `perf`, `ci`, `build`, `revert`. A `!` suffix is allowed before the colon to denote breaking changes (e.g., `feat!: remove legacy auth`). This is enforced by CI.
 - PR descriptions must use `Closes #123`, `Fixes #123`, or `Resolves #123` to trigger GitHub's automatic issue close on merge. Phrases like "Addresses #123" or "Related to #123" do NOT trigger auto-close.
 
 ## Storybook

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ pnpm build-storybook  # Build static Storybook
 
 - Branch names: lowercase with hyphens, prefixed by type: `feature/`, `chore/`, `refactor/`, `docs/`, with issue number suffix (e.g., `feature/secret-villain-deck-290`).
 - Commit messages: imperative verbs (Add, Implement, Fix, Update, Extract, Remove). No `feat:`/`fix:` prefixes.
-- PR titles must follow Conventional Commits format: `<type>: description` or `<type>(<scope>): description`. Valid types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `style`, `perf`, `ci`, `build`, `revert`. A `!` suffix is allowed before the colon to denote breaking changes (e.g., `feat!: remove legacy auth`). This is enforced by CI.
+- PR titles must follow Conventional Commits format: `<type>: description` or `<type>(<scope>): description`. This Conventional Commits requirement applies to PR titles only; commit messages remain imperative and should not use `feat:`/`fix:` prefixes. Valid types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `style`, `perf`, `ci`, `build`, `revert`. A `!` suffix is allowed before the colon to denote breaking changes (e.g., `feat!: remove legacy auth`). This is enforced by CI.
 - PR descriptions must use `Closes #123`, `Fixes #123`, or `Resolves #123` to trigger GitHub's automatic issue close on merge. Phrases like "Addresses #123" or "Related to #123" do NOT trigger auto-close.
 
 ## Storybook

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ pnpm build-storybook  # Build static Storybook
 
 ## Code Conventions
 
-- **Favor type inference.** Explicit type parameterization is a code smell — let TypeScript infer where it can.
+- **Favor type inference.** Explicit generic type arguments (for example, `someFn<Foo>(...)`) are a code smell when TypeScript can infer them.
 - **No spurious variables.** Do not assign a value to a variable only to immediately return it on the next line — return the expression directly instead.
 - **No IIFEs.** Do not use immediately-invoked function expressions. Extract the logic into a named helper function or compute the value with a plain expression instead.
 - **No function-style imports.** Do not use inline `import("…").Type` syntax in type annotations. Use module-level `import type { … } from "…"` statements at the top of the file. Dynamic `await import("…")` for services that require conditional loading (e.g., Sentry instrumentation) is acceptable.


### PR DESCRIPTION
Consolidates code quality directives into `AGENTS.md` so all contributors and AI agents (Copilot, etc.) are held to the same standards.

- Moves the PR title Conventional Commits rule from the private agent config into the project
- Adds type inference and helper function conventions missing from `AGENTS.md`
- Adds a CI workflow (`pr-title-lint.yml`) that enforces the PR title format on every PR