### PR TITLE
chore: document that Firebase backward-compat guards are not required

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ pnpm build-storybook  # Build static Storybook
 - **No function-style imports.** Do not use inline `import("…").Type` syntax in type annotations. Use module-level `import type { … } from "…"` statements at the top of the file. Dynamic `await import("…")` for services that require conditional loading (e.g., Sentry instrumentation) is acceptable.
 - **No unnecessary helpers.** Do not extract logic into a helper function unless it separates significant logic or belongs in a different module. Three similar lines is better than a premature abstraction.
 - **Role enums and definitions** in game mode files (e.g., `WerewolfRole` enum and `WEREWOLF_ROLES` object) must be kept in alphabetical order to minimize merge conflicts.
-- **Prefer enums over string literal unions** for any domain concept with two or more named states (e.g., use `enum TrialPhase { Defense = "defense", Voting = "voting" }` rather than `"defense" | "voting"`). String enum values must match the existing serialized literals so Firebase data round-trips without migration. Export new enums from the module barrel.
+- **Prefer enums over string literal unions** for any domain concept with two or more named states (e.g., use `enum TrialPhase { Defense = "defense", Voting = "voting" }` rather than `"defense" | "voting"`). String enum values must match the current serialized schema (keep code and literals in sync); do not add compatibility shims for old serialized values. Export new enums from the module barrel.
 
 ## User-Facing Text
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,10 @@ pnpm storybook        # Start Storybook dev server (port 6006)
 pnpm build-storybook  # Build static Storybook
 ```
 
+## Firebase Compatibility
+
+- **No backward-compatibility guards for Firebase data.** This project is not public-facing; breaking in-progress games on deploy is acceptable. Do not add migration guards, legacy-value fallbacks, or `"aye" | "yes"` dual-handling for renamed serialized values. Write code against the current schema only.
+
 ## TypeScript
 
 - Strict mode throughout. No `any` types. No `@ts-ignore`.


### PR DESCRIPTION
This project is not public-facing and breaking in-progress games on deploy is acceptable. Documents that explicitly in AGENTS.md so reviewers and agents don't flag serialized-value renames (e.g. `"aye"` → `"yes"`) as migration risks.