### PR TITLE
ci: add merge_group trigger for merge queue support

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds the `merge_group:` event trigger to the CI workflow so GitHub's Merge Queue can run CI checks against the virtual merge branch before completing a merge.

Without this trigger, the merge queue has no CI results to evaluate and cannot proceed.

**Note:** The merge queue itself must be enabled via the GitHub UI: Settings → Branches → Edit protection rule for `main` → "Require merge queue" (SQUASH method). The GitHub API for enabling merge queue rulesets does not work on this repository.