### PR TITLE
feat(codenames): add turn state types and board structure

### DIFF
--- a/src/lib/game/modes/codenames/index.ts
+++ b/src/lib/game/modes/codenames/index.ts
@@ -1,0 +1,1 @@
+export * from "./types";

--- a/src/lib/game/modes/codenames/types.ts
+++ b/src/lib/game/modes/codenames/types.ts
@@ -1,0 +1,115 @@
+// ---------------------------------------------------------------------------
+// Team and card color types
+// ---------------------------------------------------------------------------
+
+export enum CodenamesTeam {
+  Red = "red",
+  Blue = "blue",
+}
+
+export enum BoardCardColor {
+  Red = "red",
+  Blue = "blue",
+  Neutral = "neutral",
+  Assassin = "assassin",
+}
+
+// ---------------------------------------------------------------------------
+// Board card
+// ---------------------------------------------------------------------------
+
+export interface BoardCard {
+  /** The word displayed on this card. */
+  word: string;
+  /** The card's true color — hidden from Guessers until revealed. */
+  color: BoardCardColor;
+  /** Whether this card has been flipped by a team. */
+  revealed: boolean;
+  /** Which team flipped this card, if any. */
+  revealedBy?: CodenamesTeam;
+}
+
+// ---------------------------------------------------------------------------
+// Clue
+// ---------------------------------------------------------------------------
+
+export interface Clue {
+  /** The one-word clue given by the Codemaster. */
+  word: string;
+  /** The number of board words that relate to this clue. */
+  number: number;
+  /** The team whose Codemaster gave this clue. */
+  team: CodenamesTeam;
+  /** The turn number on which this clue was given. */
+  turn: number;
+}
+
+// ---------------------------------------------------------------------------
+// Phase enum and phase types (discriminated union)
+// ---------------------------------------------------------------------------
+
+export enum CodenamesPhase {
+  GiveClue = "give-clue",
+  Guess = "guess",
+}
+
+/** The active team's Codemaster enters a one-word clue and number. */
+export interface GiveCluePhase {
+  type: CodenamesPhase.GiveClue;
+}
+
+/** The active team's Guessers tap words on the board. */
+export interface GuessPhase {
+  type: CodenamesPhase.Guess;
+  /** The clue that prompted this guessing phase. */
+  clue: Clue;
+}
+
+export type CodenamesTurnPhase = GiveCluePhase | GuessPhase;
+
+// ---------------------------------------------------------------------------
+// Turn state
+// ---------------------------------------------------------------------------
+
+export interface CodenamesTurnState {
+  /** Current turn number. */
+  turn: number;
+  /** Current game phase. */
+  phase: CodenamesTurnPhase;
+  /** The team whose turn it currently is. */
+  activeTeam: CodenamesTeam;
+  /** The 25-card game board. */
+  board: [
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+    BoardCard,
+  ];
+  /** History of all clues given, in order. */
+  clueHistory: Clue[];
+  /** How many guesses the active team has remaining this turn. */
+  guessesRemaining: number;
+  /** The team that goes first and has 9 words assigned (the other has 8). */
+  startingTeam: CodenamesTeam;
+}

--- a/src/lib/game/modes/codenames/types.ts
+++ b/src/lib/game/modes/codenames/types.ts
@@ -63,9 +63,43 @@ export interface GuessPhase {
   type: CodenamesPhase.Guess;
   /** The clue that prompted this guessing phase. */
   clue: Clue;
+  /** How many guesses the active team has remaining this turn. */
+  guessesRemaining: number;
 }
 
 export type CodenamesTurnPhase = GiveCluePhase | GuessPhase;
+
+// ---------------------------------------------------------------------------
+// Board type alias
+// ---------------------------------------------------------------------------
+
+export type CodenamesBoard = [
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+  BoardCard,
+];
 
 // ---------------------------------------------------------------------------
 // Turn state
@@ -79,37 +113,9 @@ export interface CodenamesTurnState {
   /** The team whose turn it currently is. */
   activeTeam: CodenamesTeam;
   /** The 25-card game board. */
-  board: [
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-    BoardCard,
-  ];
+  board: CodenamesBoard;
   /** History of all clues given, in order. */
   clueHistory: Clue[];
-  /** How many guesses the active team has remaining this turn. */
-  guessesRemaining: number;
   /** The team that goes first and has 9 words assigned (the other has 8). */
   startingTeam: CodenamesTeam;
 }


### PR DESCRIPTION
Defines the core data types for Codenames gameplay state, including the board, clues, and turn structure.

- Adds `CodenamesTurnState` with board, phase, active team, clue history, and starting team
- Introduces `BoardCard`, `Clue`, `GiveCluePhase`, and `GuessPhase` types with enums for `CodenamesTeam`, `BoardCardColor`, and `CodenamesPhase`
- Board is typed as a fixed 25-element tuple to enforce board size at compile time
- Barrel `index.ts` exports all types from the new `codenames/` module

Closes #383