### PR TITLE
feat(avalon): implement game initialization

### DIFF
--- a/src/lib/firebase/schema/player-state/avalon.ts
+++ b/src/lib/firebase/schema/player-state/avalon.ts
@@ -7,10 +7,30 @@ import {
 } from "./base";
 
 // ---------------------------------------------------------------------------
-// Avalon — base fields only
+// Avalon-specific Firebase player state
 // ---------------------------------------------------------------------------
 
-export type FirebaseAvalonPlayerState = FirebaseBasePlayerState;
+export interface FirebaseAvalonPlayerState extends FirebaseBasePlayerState {
+  /** JSON-serialized QuestResult[]. */
+  questResults?: string;
+  /** JSON-serialized AvalonCurrentQuest. */
+  currentQuest?: string;
+  /** JSON-serialized AvalonPublicPhase. */
+  avalonPhase?: string;
+  proposedTeam?: string[];
+  /** TeamVote enum value stored as string. */
+  myTeamVote?: string;
+  /** JSON-serialized { playerId: string; vote: TeamVote }[]. */
+  avalonTeamVotes?: string;
+  teamVotePassed?: boolean;
+  consecutiveRejections?: number;
+  /** QuestCard enum value stored as string. */
+  myQuestCard?: string;
+  questFailCount?: number;
+  assassinationTarget?: string;
+  eligibleTeamMemberIds?: string[];
+  assassinationTargetIds?: string[];
+}
 
 // ---------------------------------------------------------------------------
 // Avalon serializer / deserializer
@@ -19,7 +39,44 @@ export type FirebaseAvalonPlayerState = FirebaseBasePlayerState;
 export function avalonStateToFirebase(
   state: AvalonPlayerGameState,
 ): FirebaseAvalonPlayerState {
-  return baseStateToFirebase(state);
+  return {
+    ...baseStateToFirebase(state),
+    ...(state.questResults !== undefined
+      ? { questResults: JSON.stringify(state.questResults) }
+      : {}),
+    ...(state.currentQuest !== undefined
+      ? { currentQuest: JSON.stringify(state.currentQuest) }
+      : {}),
+    ...(state.avalonPhase !== undefined
+      ? { avalonPhase: JSON.stringify(state.avalonPhase) }
+      : {}),
+    ...(state.proposedTeam?.length ? { proposedTeam: state.proposedTeam } : {}),
+    ...(state.myTeamVote !== undefined ? { myTeamVote: state.myTeamVote } : {}),
+    ...(state.teamVotes?.length
+      ? { avalonTeamVotes: JSON.stringify(state.teamVotes) }
+      : {}),
+    ...(state.teamVotePassed !== undefined
+      ? { teamVotePassed: state.teamVotePassed }
+      : {}),
+    ...(state.consecutiveRejections !== undefined
+      ? { consecutiveRejections: state.consecutiveRejections }
+      : {}),
+    ...(state.myQuestCard !== undefined
+      ? { myQuestCard: state.myQuestCard }
+      : {}),
+    ...(state.questFailCount !== undefined
+      ? { questFailCount: state.questFailCount }
+      : {}),
+    ...(state.assassinationTarget !== undefined
+      ? { assassinationTarget: state.assassinationTarget }
+      : {}),
+    ...(state.eligibleTeamMemberIds?.length
+      ? { eligibleTeamMemberIds: state.eligibleTeamMemberIds }
+      : {}),
+    ...(state.assassinationTargetIds?.length
+      ? { assassinationTargetIds: state.assassinationTargetIds }
+      : {}),
+  };
 }
 
 export function avalonStateFromFirebase(
@@ -28,5 +85,62 @@ export function avalonStateFromFirebase(
   return {
     ...baseStateFromFirebase(raw),
     gameMode: GameMode.Avalon,
+    ...(raw.questResults !== undefined
+      ? {
+          questResults: JSON.parse(
+            raw.questResults,
+          ) as AvalonPlayerGameState["questResults"],
+        }
+      : {}),
+    ...(raw.currentQuest !== undefined
+      ? {
+          currentQuest: JSON.parse(
+            raw.currentQuest,
+          ) as AvalonPlayerGameState["currentQuest"],
+        }
+      : {}),
+    ...(raw.avalonPhase !== undefined
+      ? {
+          avalonPhase: JSON.parse(
+            raw.avalonPhase,
+          ) as AvalonPlayerGameState["avalonPhase"],
+        }
+      : {}),
+    ...(raw.proposedTeam?.length ? { proposedTeam: raw.proposedTeam } : {}),
+    ...(raw.myTeamVote !== undefined
+      ? {
+          myTeamVote: raw.myTeamVote as AvalonPlayerGameState["myTeamVote"],
+        }
+      : {}),
+    ...(raw.avalonTeamVotes !== undefined
+      ? {
+          teamVotes: JSON.parse(
+            raw.avalonTeamVotes,
+          ) as AvalonPlayerGameState["teamVotes"],
+        }
+      : {}),
+    ...(raw.teamVotePassed !== undefined
+      ? { teamVotePassed: raw.teamVotePassed }
+      : {}),
+    ...(raw.consecutiveRejections !== undefined
+      ? { consecutiveRejections: raw.consecutiveRejections }
+      : {}),
+    ...(raw.myQuestCard !== undefined
+      ? {
+          myQuestCard: raw.myQuestCard as AvalonPlayerGameState["myQuestCard"],
+        }
+      : {}),
+    ...(raw.questFailCount !== undefined
+      ? { questFailCount: raw.questFailCount }
+      : {}),
+    ...(raw.assassinationTarget !== undefined
+      ? { assassinationTarget: raw.assassinationTarget }
+      : {}),
+    ...(raw.eligibleTeamMemberIds?.length
+      ? { eligibleTeamMemberIds: raw.eligibleTeamMemberIds }
+      : {}),
+    ...(raw.assassinationTargetIds?.length
+      ? { assassinationTargetIds: raw.assassinationTargetIds }
+      : {}),
   } as AvalonPlayerGameState;
 }

--- a/src/lib/firebase/schema/player-state/player-state.spec.ts
+++ b/src/lib/firebase/schema/player-state/player-state.spec.ts
@@ -9,6 +9,11 @@ import type { SecretVillainPlayerGameState } from "@/lib/game/modes/secret-villa
 import type { AvalonPlayerGameState } from "@/lib/game/modes/avalon/player-state";
 import { SecretVillainPhase } from "@/lib/game/modes/secret-villain/types";
 import { SvTheme } from "@/lib/game/modes/secret-villain/themes";
+import {
+  AvalonPhase,
+  QuestCard,
+  TeamVote,
+} from "@/lib/game/modes/avalon/types";
 
 const BASE_FIELDS = {
   lobbyId: "lobby-1",
@@ -273,6 +278,152 @@ describe("Avalon player state round-trip", () => {
     const result = firebaseToPlayerState(playerStateToFirebase(state));
     expect(result.timerConfig.autoAdvance).toBe(true);
     expect(result.timerConfig.startCountdownSeconds).toBe(99);
+  });
+
+  it("round-trips questResults as JSON", () => {
+    const questResults = [
+      { questNumber: 1, teamSize: 2, failCount: 0, succeeded: true },
+      { questNumber: 2, teamSize: 3, failCount: 1, succeeded: false },
+    ];
+    const state = makeAvalonState({ questResults });
+    const result = firebaseToPlayerState(
+      playerStateToFirebase(state),
+    ) as AvalonPlayerGameState;
+    expect(result.questResults).toEqual(questResults);
+  });
+
+  it("round-trips currentQuest as JSON", () => {
+    const currentQuest = {
+      questNumber: 3,
+      teamSize: 4,
+      requiresTwoFails: true,
+    };
+    const state = makeAvalonState({ currentQuest });
+    const result = firebaseToPlayerState(
+      playerStateToFirebase(state),
+    ) as AvalonPlayerGameState;
+    expect(result.currentQuest).toEqual(currentQuest);
+  });
+
+  it("round-trips avalonPhase as JSON", () => {
+    const avalonPhase = {
+      type: AvalonPhase.TeamProposal,
+      leaderId: "p1",
+      teamSize: 2,
+    };
+    const state = makeAvalonState({ avalonPhase });
+    const result = firebaseToPlayerState(
+      playerStateToFirebase(state),
+    ) as AvalonPlayerGameState;
+    expect(result.avalonPhase).toEqual(avalonPhase);
+  });
+
+  it("round-trips proposedTeam", () => {
+    const state = makeAvalonState({ proposedTeam: ["p1", "p2"] });
+    const result = firebaseToPlayerState(
+      playerStateToFirebase(state),
+    ) as AvalonPlayerGameState;
+    expect(result.proposedTeam).toEqual(["p1", "p2"]);
+  });
+
+  it("round-trips myTeamVote", () => {
+    const state = makeAvalonState({ myTeamVote: TeamVote.Approve });
+    const result = firebaseToPlayerState(
+      playerStateToFirebase(state),
+    ) as AvalonPlayerGameState;
+    expect(result.myTeamVote).toBe(TeamVote.Approve);
+  });
+
+  it("round-trips teamVotes as JSON", () => {
+    const teamVotes = [
+      { playerId: "p1", vote: TeamVote.Approve },
+      { playerId: "p2", vote: TeamVote.Reject },
+    ];
+    const state = makeAvalonState({ teamVotes });
+    const result = firebaseToPlayerState(
+      playerStateToFirebase(state),
+    ) as AvalonPlayerGameState;
+    expect(result.teamVotes).toEqual(teamVotes);
+  });
+
+  it("round-trips teamVotePassed", () => {
+    const state = makeAvalonState({ teamVotePassed: false });
+    const result = firebaseToPlayerState(
+      playerStateToFirebase(state),
+    ) as AvalonPlayerGameState;
+    expect(result.teamVotePassed).toBe(false);
+  });
+
+  it("round-trips consecutiveRejections", () => {
+    const state = makeAvalonState({ consecutiveRejections: 3 });
+    const result = firebaseToPlayerState(
+      playerStateToFirebase(state),
+    ) as AvalonPlayerGameState;
+    expect(result.consecutiveRejections).toBe(3);
+  });
+
+  it("round-trips myQuestCard", () => {
+    const state = makeAvalonState({ myQuestCard: QuestCard.Fail });
+    const result = firebaseToPlayerState(
+      playerStateToFirebase(state),
+    ) as AvalonPlayerGameState;
+    expect(result.myQuestCard).toBe(QuestCard.Fail);
+  });
+
+  it("round-trips questFailCount", () => {
+    const state = makeAvalonState({ questFailCount: 2 });
+    const result = firebaseToPlayerState(
+      playerStateToFirebase(state),
+    ) as AvalonPlayerGameState;
+    expect(result.questFailCount).toBe(2);
+  });
+
+  it("round-trips assassinationTarget", () => {
+    const state = makeAvalonState({ assassinationTarget: "p3" });
+    const result = firebaseToPlayerState(
+      playerStateToFirebase(state),
+    ) as AvalonPlayerGameState;
+    expect(result.assassinationTarget).toBe("p3");
+  });
+
+  it("round-trips eligibleTeamMemberIds", () => {
+    const state = makeAvalonState({
+      eligibleTeamMemberIds: ["p1", "p2", "p3"],
+    });
+    const result = firebaseToPlayerState(
+      playerStateToFirebase(state),
+    ) as AvalonPlayerGameState;
+    expect(result.eligibleTeamMemberIds).toEqual(["p1", "p2", "p3"]);
+  });
+
+  it("round-trips assassinationTargetIds", () => {
+    const state = makeAvalonState({
+      assassinationTargetIds: ["p1", "p2", "p4"],
+    });
+    const result = firebaseToPlayerState(
+      playerStateToFirebase(state),
+    ) as AvalonPlayerGameState;
+    expect(result.assassinationTargetIds).toEqual(["p1", "p2", "p4"]);
+  });
+
+  it("omits optional Avalon fields when absent", () => {
+    const state = makeAvalonState();
+    const result = firebaseToPlayerState(
+      playerStateToFirebase(state),
+    ) as AvalonPlayerGameState;
+    expect(result.questResults).toBeUndefined();
+    expect(result.currentQuest).toBeUndefined();
+    expect(result.avalonPhase).toBeUndefined();
+    expect(result.proposedTeam).toBeUndefined();
+    expect(result.myTeamVote).toBeUndefined();
+    expect(result.teamVotes).toBeUndefined();
+    expect(result.teamVotePassed).toBeUndefined();
+    expect(result.consecutiveRejections).toBeUndefined();
+    expect(result.myQuestCard).toBeUndefined();
+    expect(result.questFailCount).toBeUndefined();
+    expect(result.assassinationTarget).toBeUndefined();
+    expect(result.eligibleTeamMemberIds).toBeUndefined();
+    expect(result.assassinationTargetIds).toBeUndefined();
   });
 });
 

--- a/src/lib/game/modes/avalon/player-state.ts
+++ b/src/lib/game/modes/avalon/player-state.ts
@@ -1,17 +1,29 @@
 import { GameMode } from "@/lib/types";
 import type { BasePlayerGameState } from "@/server/types/game";
-import type {
-  AvalonTurnPhase,
-  QuestResult,
-  TeamVote,
-  QuestCard,
-} from "./types";
+import type { AvalonPhase, QuestResult, TeamVote, QuestCard } from "./types";
 
 /** Current quest info visible to all players. */
 export interface AvalonCurrentQuest {
   questNumber: number;
   teamSize: number;
   requiresTwoFails: boolean;
+}
+
+/**
+ * Public phase info sent to clients — contains only the fields that are safe
+ * for all players to see. This is a stripped version of `AvalonTurnPhase`
+ * (similar to `SvPhaseInfo` in Secret Villain).
+ */
+export interface AvalonPublicPhase {
+  type: AvalonPhase;
+  /** Present during TeamProposal, TeamVote, and Quest phases. */
+  leaderId?: string;
+  /** Size of the team being proposed (TeamProposal only). */
+  teamSize?: number;
+  /** Player IDs on the active quest team (Quest phase only). */
+  teamPlayerIds?: string[];
+  /** Player ID of the Assassin (Assassination phase only). */
+  assassinPlayerId?: string;
 }
 
 /**
@@ -25,7 +37,7 @@ export interface AvalonPlayerGameState extends BasePlayerGameState {
   /** Current quest number, team size, and double-fail rule. */
   currentQuest?: AvalonCurrentQuest;
   /** Current phase info (type, leaderId, team, etc.). */
-  avalonPhase?: AvalonTurnPhase;
+  avalonPhase?: AvalonPublicPhase;
   /** Proposed team player IDs (during proposal/vote phases). */
   proposedTeam?: string[];
   /** This player's approve/reject team vote. */

--- a/src/lib/game/modes/avalon/player-state.ts
+++ b/src/lib/game/modes/avalon/player-state.ts
@@ -1,7 +1,49 @@
 import { GameMode } from "@/lib/types";
 import type { BasePlayerGameState } from "@/server/types/game";
+import type {
+  AvalonTurnPhase,
+  QuestResult,
+  TeamVote,
+  QuestCard,
+} from "./types";
 
-/** Avalon-specific extension of BasePlayerGameState (currently no extra fields). */
+/** Current quest info visible to all players. */
+export interface AvalonCurrentQuest {
+  questNumber: number;
+  teamSize: number;
+  requiresTwoFails: boolean;
+}
+
+/**
+ * Avalon-specific extension of PlayerGameState. Includes all fields that only
+ * exist in Avalon games.
+ */
 export interface AvalonPlayerGameState extends BasePlayerGameState {
   gameMode: GameMode.Avalon;
+  /** Outcomes of completed quests. */
+  questResults?: QuestResult[];
+  /** Current quest number, team size, and double-fail rule. */
+  currentQuest?: AvalonCurrentQuest;
+  /** Current phase info (type, leaderId, team, etc.). */
+  avalonPhase?: AvalonTurnPhase;
+  /** Proposed team player IDs (during proposal/vote phases). */
+  proposedTeam?: string[];
+  /** This player's approve/reject team vote. */
+  myTeamVote?: TeamVote;
+  /** All votes after team vote resolution. */
+  teamVotes?: { playerId: string; vote: TeamVote }[];
+  /** Whether the team vote passed. */
+  teamVotePassed?: boolean;
+  /** Number of consecutive team vote rejections. */
+  consecutiveRejections?: number;
+  /** This player's played quest card (team members only, after playing). */
+  myQuestCard?: QuestCard;
+  /** Number of Fail cards played (after quest resolution). */
+  questFailCount?: number;
+  /** Assassin's selected assassination target player ID. */
+  assassinationTarget?: string;
+  /** Player IDs eligible to be on the quest team (Quest Leader only, during proposal). */
+  eligibleTeamMemberIds?: string[];
+  /** All player IDs that are valid assassination targets (Assassin only, during assassination). */
+  assassinationTargetIds?: string[];
 }

--- a/src/lib/game/modes/avalon/player-state.ts
+++ b/src/lib/game/modes/avalon/player-state.ts
@@ -22,8 +22,6 @@ export interface AvalonPublicPhase {
   teamSize?: number;
   /** Player IDs on the active quest team (Quest phase only). */
   teamPlayerIds?: string[];
-  /** Player ID of the Assassin (Assassination phase only). */
-  assassinPlayerId?: string;
 }
 
 /**

--- a/src/lib/game/modes/avalon/services.spec.ts
+++ b/src/lib/game/modes/avalon/services.spec.ts
@@ -1,0 +1,454 @@
+import { describe, it, expect } from "vitest";
+import {
+  GameMode,
+  GameStatus,
+  ShowRolesInPlay,
+  DEFAULT_TIMER_CONFIG,
+} from "@/lib/types";
+import type { Game } from "@/lib/types";
+import { AvalonPhase, TeamVote, QuestCard } from "./types";
+import type { AvalonTurnState } from "./types";
+import { AvalonRole } from "./roles";
+import { avalonServices } from "./services";
+
+const assignments = [
+  { playerId: "p1", roleDefinitionId: AvalonRole.Merlin },
+  { playerId: "p2", roleDefinitionId: AvalonRole.LoyalServant },
+  { playerId: "p3", roleDefinitionId: AvalonRole.LoyalServant },
+  { playerId: "p4", roleDefinitionId: AvalonRole.MinionOfMordred },
+  { playerId: "p5", roleDefinitionId: AvalonRole.Assassin },
+];
+
+const playerIds = assignments.map((a) => a.playerId);
+
+function makePlayers() {
+  return playerIds.map((id) => ({
+    id,
+    name: `Player ${id}`,
+    sessionId: `session-${id}`,
+    visiblePlayers: [],
+  }));
+}
+
+const baseTurnState: AvalonTurnState = {
+  questNumber: 1,
+  phase: {
+    type: AvalonPhase.TeamProposal,
+    leaderId: "p1",
+    teamSize: 2,
+  },
+  leaderOrder: playerIds,
+  currentLeaderIndex: 0,
+  questResults: [],
+  consecutiveRejections: 0,
+  questTeamSizes: [2, 3, 2, 3, 3],
+  requiresTwoFails: [],
+};
+
+function makeGame(turnState: AvalonTurnState): Game {
+  return {
+    id: "game-1",
+    lobbyId: "lobby-1",
+    gameMode: GameMode.Avalon,
+    status: { type: GameStatus.Playing, turnState },
+    players: makePlayers(),
+    roleAssignments: assignments,
+    configuredRoleBuckets: [],
+    showRolesInPlay: ShowRolesInPlay.None,
+    timerConfig: DEFAULT_TIMER_CONFIG,
+    modeConfig: { gameMode: GameMode.Avalon },
+  } satisfies Game;
+}
+
+const merlinRole = { id: AvalonRole.Merlin, name: "Merlin", team: "Good" };
+const assassinRole = { id: AvalonRole.Assassin, name: "Assassin", team: "Bad" };
+
+describe("buildInitialTurnState", () => {
+  it("starts at quest 1 with TeamProposal phase", () => {
+    const ts = avalonServices.buildInitialTurnState(
+      assignments,
+    ) as AvalonTurnState;
+    expect(ts.questNumber).toBe(1);
+    expect(ts.phase.type).toBe(AvalonPhase.TeamProposal);
+  });
+
+  it("sets correct team sizes for 5 players", () => {
+    const ts = avalonServices.buildInitialTurnState(
+      assignments,
+    ) as AvalonTurnState;
+    expect(ts.questTeamSizes).toEqual([2, 3, 2, 3, 3]);
+  });
+
+  it("sets correct team sizes for 7 players", () => {
+    const sevenAssignments = [
+      { playerId: "p1", roleDefinitionId: AvalonRole.Merlin },
+      { playerId: "p2", roleDefinitionId: AvalonRole.LoyalServant },
+      { playerId: "p3", roleDefinitionId: AvalonRole.LoyalServant },
+      { playerId: "p4", roleDefinitionId: AvalonRole.LoyalServant },
+      { playerId: "p5", roleDefinitionId: AvalonRole.MinionOfMordred },
+      { playerId: "p6", roleDefinitionId: AvalonRole.MinionOfMordred },
+      { playerId: "p7", roleDefinitionId: AvalonRole.Assassin },
+    ];
+    const ts = avalonServices.buildInitialTurnState(
+      sevenAssignments,
+    ) as AvalonTurnState;
+    expect(ts.questTeamSizes).toEqual([2, 3, 3, 4, 4]);
+  });
+
+  it("does not require two fails for 5 players", () => {
+    const ts = avalonServices.buildInitialTurnState(
+      assignments,
+    ) as AvalonTurnState;
+    expect(ts.requiresTwoFails).toEqual([]);
+  });
+
+  it("requires two fails on quest 4 for 7+ players", () => {
+    const sevenAssignments = [
+      { playerId: "p1", roleDefinitionId: AvalonRole.Merlin },
+      { playerId: "p2", roleDefinitionId: AvalonRole.LoyalServant },
+      { playerId: "p3", roleDefinitionId: AvalonRole.LoyalServant },
+      { playerId: "p4", roleDefinitionId: AvalonRole.LoyalServant },
+      { playerId: "p5", roleDefinitionId: AvalonRole.MinionOfMordred },
+      { playerId: "p6", roleDefinitionId: AvalonRole.MinionOfMordred },
+      { playerId: "p7", roleDefinitionId: AvalonRole.Assassin },
+    ];
+    const ts = avalonServices.buildInitialTurnState(
+      sevenAssignments,
+    ) as AvalonTurnState;
+    expect(ts.requiresTwoFails).toEqual([4]);
+  });
+
+  it("preserves playerOrder as leader rotation when provided", () => {
+    const specifiedOrder = ["p5", "p3", "p1", "p4", "p2"];
+    const ts = avalonServices.buildInitialTurnState(assignments, {
+      playerOrder: specifiedOrder,
+    }) as AvalonTurnState;
+    expect(ts.leaderOrder).toEqual(specifiedOrder);
+  });
+
+  it("first leader matches first player in leaderOrder", () => {
+    const specifiedOrder = ["p3", "p1", "p2", "p5", "p4"];
+    const ts = avalonServices.buildInitialTurnState(assignments, {
+      playerOrder: specifiedOrder,
+    }) as AvalonTurnState;
+    expect(ts.phase.type).toBe(AvalonPhase.TeamProposal);
+    if (ts.phase.type === AvalonPhase.TeamProposal) {
+      expect(ts.phase.leaderId).toBe("p3");
+    }
+  });
+
+  it("shuffles players when no playerOrder is provided", () => {
+    const results = new Set<string>();
+    for (let i = 0; i < 30; i++) {
+      const ts = avalonServices.buildInitialTurnState(
+        assignments,
+      ) as AvalonTurnState;
+      results.add(ts.leaderOrder.join(","));
+    }
+    expect(results.size).toBeGreaterThan(1);
+  });
+
+  it("throws for unsupported player count", () => {
+    const fourAssignments = [
+      { playerId: "p1", roleDefinitionId: AvalonRole.Merlin },
+      { playerId: "p2", roleDefinitionId: AvalonRole.LoyalServant },
+      { playerId: "p3", roleDefinitionId: AvalonRole.MinionOfMordred },
+      { playerId: "p4", roleDefinitionId: AvalonRole.Assassin },
+    ];
+    expect(() => avalonServices.buildInitialTurnState(fourAssignments)).toThrow(
+      "No quest configuration for 4 players",
+    );
+  });
+
+  it("initializes consecutiveRejections and questResults to 0 and empty", () => {
+    const ts = avalonServices.buildInitialTurnState(
+      assignments,
+    ) as AvalonTurnState;
+    expect(ts.consecutiveRejections).toBe(0);
+    expect(ts.questResults).toEqual([]);
+  });
+});
+
+describe("extractPlayerState", () => {
+  it("returns empty object when game is not playing", () => {
+    const game = {
+      ...makeGame(baseTurnState),
+      status: { type: GameStatus.Starting as const },
+    } satisfies Game;
+    expect(avalonServices.extractPlayerState(game, "p1", merlinRole)).toEqual(
+      {},
+    );
+  });
+
+  it("all players see questResults, consecutiveRejections, and currentQuest", () => {
+    const result = avalonServices.extractPlayerState(
+      makeGame(baseTurnState),
+      "p2",
+      merlinRole,
+    );
+    expect(result["questResults"]).toEqual([]);
+    expect(result["consecutiveRejections"]).toBe(0);
+    expect(result["currentQuest"]).toEqual({
+      questNumber: 1,
+      teamSize: 2,
+      requiresTwoFails: false,
+    });
+  });
+
+  it("all players see avalonPhase with type and leaderId during TeamProposal", () => {
+    const result = avalonServices.extractPlayerState(
+      makeGame(baseTurnState),
+      "p2",
+      merlinRole,
+    );
+    expect(result["avalonPhase"]).toMatchObject({
+      type: AvalonPhase.TeamProposal,
+      leaderId: "p1",
+      teamSize: 2,
+    });
+  });
+
+  it("Quest Leader sees eligibleTeamMemberIds during TeamProposal", () => {
+    const result = avalonServices.extractPlayerState(
+      makeGame(baseTurnState),
+      "p1",
+      merlinRole,
+    );
+    expect(result["eligibleTeamMemberIds"]).toEqual(playerIds);
+  });
+
+  it("non-leader does not see eligibleTeamMemberIds during TeamProposal", () => {
+    const result = avalonServices.extractPlayerState(
+      makeGame(baseTurnState),
+      "p2",
+      merlinRole,
+    );
+    expect(result["eligibleTeamMemberIds"]).toBeUndefined();
+  });
+
+  it("proposed team visible during TeamProposal when set", () => {
+    const ts: AvalonTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: AvalonPhase.TeamProposal,
+        leaderId: "p1",
+        teamSize: 2,
+        proposedTeam: ["p1", "p3"],
+      },
+    };
+    const result = avalonServices.extractPlayerState(
+      makeGame(ts),
+      "p2",
+      merlinRole,
+    );
+    expect(result["proposedTeam"]).toEqual(["p1", "p3"]);
+  });
+
+  it("proposed team visible to all during TeamVote", () => {
+    const ts: AvalonTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: AvalonPhase.TeamVote,
+        leaderId: "p1",
+        proposedTeam: ["p1", "p3"],
+        votes: [],
+      },
+    };
+    const result = avalonServices.extractPlayerState(
+      makeGame(ts),
+      "p2",
+      merlinRole,
+    );
+    expect(result["proposedTeam"]).toEqual(["p1", "p3"]);
+  });
+
+  it("player sees their own vote during TeamVote", () => {
+    const ts: AvalonTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: AvalonPhase.TeamVote,
+        leaderId: "p1",
+        proposedTeam: ["p1", "p3"],
+        votes: [{ playerId: "p2", vote: TeamVote.Approve }],
+      },
+    };
+    const result = avalonServices.extractPlayerState(
+      makeGame(ts),
+      "p2",
+      merlinRole,
+    );
+    expect(result["myTeamVote"]).toBe(TeamVote.Approve);
+  });
+
+  it("all votes visible after TeamVote resolves", () => {
+    const votes = [
+      { playerId: "p1", vote: TeamVote.Approve },
+      { playerId: "p2", vote: TeamVote.Reject },
+    ];
+    const ts: AvalonTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: AvalonPhase.TeamVote,
+        leaderId: "p1",
+        proposedTeam: ["p1", "p3"],
+        votes,
+        passed: true,
+      },
+    };
+    const result = avalonServices.extractPlayerState(
+      makeGame(ts),
+      "p3",
+      merlinRole,
+    );
+    expect(result["teamVotes"]).toEqual(votes);
+    expect(result["teamVotePassed"]).toBe(true);
+  });
+
+  it("votes not visible before TeamVote resolves", () => {
+    const ts: AvalonTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: AvalonPhase.TeamVote,
+        leaderId: "p1",
+        proposedTeam: ["p1", "p3"],
+        votes: [{ playerId: "p1", vote: TeamVote.Approve }],
+      },
+    };
+    const result = avalonServices.extractPlayerState(
+      makeGame(ts),
+      "p3",
+      merlinRole,
+    );
+    expect(result["teamVotes"]).toBeUndefined();
+    expect(result["teamVotePassed"]).toBeUndefined();
+  });
+
+  it("avalonPhase includes teamPlayerIds during Quest phase", () => {
+    const ts: AvalonTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: AvalonPhase.Quest,
+        leaderId: "p1",
+        teamPlayerIds: ["p1", "p3"],
+        cards: [],
+      },
+    };
+    const result = avalonServices.extractPlayerState(
+      makeGame(ts),
+      "p2",
+      merlinRole,
+    );
+    expect(result["avalonPhase"]).toMatchObject({
+      type: AvalonPhase.Quest,
+      leaderId: "p1",
+      teamPlayerIds: ["p1", "p3"],
+    });
+  });
+
+  it("team member sees their own quest card after playing", () => {
+    const ts: AvalonTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: AvalonPhase.Quest,
+        leaderId: "p1",
+        teamPlayerIds: ["p1", "p3"],
+        cards: [{ playerId: "p1", card: QuestCard.Success }],
+      },
+    };
+    const result = avalonServices.extractPlayerState(
+      makeGame(ts),
+      "p1",
+      merlinRole,
+    );
+    expect(result["myQuestCard"]).toBe(QuestCard.Success);
+  });
+
+  it("fail count not visible before quest resolves", () => {
+    const ts: AvalonTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: AvalonPhase.Quest,
+        leaderId: "p1",
+        teamPlayerIds: ["p1", "p3"],
+        cards: [{ playerId: "p1", card: QuestCard.Success }],
+      },
+    };
+    const result = avalonServices.extractPlayerState(
+      makeGame(ts),
+      "p2",
+      merlinRole,
+    );
+    expect(result["questFailCount"]).toBeUndefined();
+  });
+
+  it("fail count visible to all after quest resolves", () => {
+    const ts: AvalonTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: AvalonPhase.Quest,
+        leaderId: "p1",
+        teamPlayerIds: ["p1", "p3"],
+        cards: [
+          { playerId: "p1", card: QuestCard.Success },
+          { playerId: "p3", card: QuestCard.Fail },
+        ],
+        failCount: 1,
+      },
+    };
+    const result = avalonServices.extractPlayerState(
+      makeGame(ts),
+      "p2",
+      merlinRole,
+    );
+    expect(result["questFailCount"]).toBe(1);
+  });
+
+  it("Assassin sees assassinationTargetIds during Assassination phase", () => {
+    const ts: AvalonTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: AvalonPhase.Assassination,
+        assassinPlayerId: "p5",
+      },
+    };
+    const result = avalonServices.extractPlayerState(
+      makeGame(ts),
+      "p5",
+      assassinRole,
+    );
+    expect(result["assassinationTargetIds"]).toEqual(playerIds);
+  });
+
+  it("non-Assassin does not see assassinationTargetIds during Assassination phase", () => {
+    const ts: AvalonTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: AvalonPhase.Assassination,
+        assassinPlayerId: "p5",
+      },
+    };
+    const result = avalonServices.extractPlayerState(
+      makeGame(ts),
+      "p1",
+      merlinRole,
+    );
+    expect(result["assassinationTargetIds"]).toBeUndefined();
+  });
+
+  it("assassination target visible to all when selected", () => {
+    const ts: AvalonTurnState = {
+      ...baseTurnState,
+      phase: {
+        type: AvalonPhase.Assassination,
+        assassinPlayerId: "p5",
+        targetPlayerId: "p1",
+      },
+    };
+    const result = avalonServices.extractPlayerState(
+      makeGame(ts),
+      "p2",
+      merlinRole,
+    );
+    expect(result["assassinationTarget"]).toBe("p1");
+  });
+});

--- a/src/lib/game/modes/avalon/services.spec.ts
+++ b/src/lib/game/modes/avalon/services.spec.ts
@@ -416,7 +416,7 @@ describe("extractPlayerState", () => {
       "p5",
       assassinRole,
     );
-    expect(result["assassinationTargetIds"]).toEqual(playerIds);
+    expect(result["assassinationTargetIds"]).toEqual(["p1", "p2", "p3"]);
   });
 
   it("non-Assassin does not see assassinationTargetIds during Assassination phase", () => {

--- a/src/lib/game/modes/avalon/services.spec.ts
+++ b/src/lib/game/modes/avalon/services.spec.ts
@@ -416,7 +416,7 @@ describe("extractPlayerState", () => {
       "p5",
       assassinRole,
     );
-    expect(result["assassinationTargetIds"]).toEqual(["p1", "p2", "p3"]);
+    expect(result["assassinationTargetIds"]).toEqual(playerIds);
   });
 
   it("non-Assassin does not see assassinationTargetIds during Assassination phase", () => {

--- a/src/lib/game/modes/avalon/services.ts
+++ b/src/lib/game/modes/avalon/services.ts
@@ -4,6 +4,7 @@ import { resolvePlayerOrder } from "@/lib/player-order";
 import { AvalonRole } from "./roles";
 import { AvalonPhase } from "./types";
 import type { AvalonTurnState } from "./types";
+import type { AvalonPublicPhase } from "./player-state";
 
 // ---------------------------------------------------------------------------
 // Quest configuration tables (standard Avalon rules)
@@ -37,7 +38,7 @@ function requiresTwoFailsQuests(playerCount: number): number[] {
 function getQuestTeamSizes(
   playerCount: number,
 ): [number, number, number, number, number] {
-  const sizes = QUEST_TEAM_SIZES[Math.min(Math.max(playerCount, 5), 10)];
+  const sizes = QUEST_TEAM_SIZES[playerCount];
   if (!sizes) {
     throw new Error(
       "No quest configuration for " + String(playerCount) + " players",
@@ -157,12 +158,8 @@ export const avalonServices: GameModeServices = {
       phase.type === AvalonPhase.TeamVote ||
       phase.type === AvalonPhase.TeamProposal
     ) {
-      const team =
-        phase.type === AvalonPhase.TeamProposal
-          ? phase.proposedTeam
-          : phase.proposedTeam;
-      if (team) {
-        result["proposedTeam"] = team;
+      if (phase.proposedTeam) {
+        result["proposedTeam"] = phase.proposedTeam;
       }
     }
 
@@ -219,25 +216,27 @@ export const avalonServices: GameModeServices = {
 // Public phase builder — strips server-only fields (e.g. full card lists)
 // ---------------------------------------------------------------------------
 
-function buildPublicPhase(
-  phase: AvalonTurnState["phase"],
-): Record<string, unknown> {
-  const base: Record<string, unknown> = { type: phase.type };
+function buildPublicPhase(phase: AvalonTurnState["phase"]): AvalonPublicPhase {
+  const base: AvalonPublicPhase = { type: phase.type };
 
   if (
     phase.type === AvalonPhase.TeamProposal ||
     phase.type === AvalonPhase.TeamVote ||
     phase.type === AvalonPhase.Quest
   ) {
-    base["leaderId"] = phase.leaderId;
+    base.leaderId = phase.leaderId;
   }
 
   if (phase.type === AvalonPhase.TeamProposal) {
-    base["teamSize"] = phase.teamSize;
+    base.teamSize = phase.teamSize;
+  }
+
+  if (phase.type === AvalonPhase.Quest) {
+    base.teamPlayerIds = phase.teamPlayerIds;
   }
 
   if (phase.type === AvalonPhase.Assassination) {
-    base["assassinPlayerId"] = phase.assassinPlayerId;
+    base.assassinPlayerId = phase.assassinPlayerId;
   }
 
   return base;

--- a/src/lib/game/modes/avalon/services.ts
+++ b/src/lib/game/modes/avalon/services.ts
@@ -10,9 +10,8 @@ import type { AvalonPublicPhase } from "./player-state";
 // ---------------------------------------------------------------------------
 
 /**
- * Quest team sizes for player counts 5–10.
- * Index 0 is for 5 players; index 5 is for 10 players.
- * Each inner tuple is [Q1, Q2, Q3, Q4, Q5].
+ * Quest team sizes keyed by player count (5–10).
+ * Each tuple is [Q1, Q2, Q3, Q4, Q5] team sizes for that player count.
  */
 const QUEST_TEAM_SIZES: Record<
   number,

--- a/src/lib/game/modes/avalon/services.ts
+++ b/src/lib/game/modes/avalon/services.ts
@@ -1,16 +1,244 @@
-import type { GameModeServices } from "@/lib/types";
+import { GameStatus } from "@/lib/types";
+import type { Game, GameModeServices, PlayerRoleAssignment } from "@/lib/types";
+import { resolvePlayerOrder } from "@/lib/player-order";
+import { AvalonRole } from "./roles";
+import { AvalonPhase } from "./types";
+import type { AvalonTurnState } from "./types";
 
-/** Stub services for Avalon — to be implemented with gameplay. */
+// ---------------------------------------------------------------------------
+// Quest configuration tables (standard Avalon rules)
+// ---------------------------------------------------------------------------
+
+/**
+ * Quest team sizes for player counts 5–10.
+ * Index 0 is for 5 players; index 5 is for 10 players.
+ * Each inner tuple is [Q1, Q2, Q3, Q4, Q5].
+ */
+const QUEST_TEAM_SIZES: Record<
+  number,
+  [number, number, number, number, number]
+> = {
+  5: [2, 3, 2, 3, 3],
+  6: [2, 3, 4, 3, 4],
+  7: [2, 3, 3, 4, 4],
+  8: [3, 4, 4, 5, 5],
+  9: [3, 4, 4, 5, 5],
+  10: [3, 4, 4, 5, 5],
+};
+
+/**
+ * Quest numbers (1-based) that require 2 Fail cards to fail.
+ * Only Quest 4 at 7+ players.
+ */
+function requiresTwoFailsQuests(playerCount: number): number[] {
+  return playerCount >= 7 ? [4] : [];
+}
+
+function getQuestTeamSizes(
+  playerCount: number,
+): [number, number, number, number, number] {
+  const sizes = QUEST_TEAM_SIZES[Math.min(Math.max(playerCount, 5), 10)];
+  if (!sizes) {
+    throw new Error(
+      "No quest configuration for " + String(playerCount) + " players",
+    );
+  }
+  return sizes;
+}
+
+// ---------------------------------------------------------------------------
+// Shuffle utility
+// ---------------------------------------------------------------------------
+
+function shuffle<T>(array: T[]): T[] {
+  const result = [...array];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const temp = result[i] as T;
+    result[i] = result[j] as T;
+    result[j] = temp;
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Build options type
+// ---------------------------------------------------------------------------
+
+interface BuildTurnStateOptions {
+  playerOrder?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// currentTurnState helper
+// ---------------------------------------------------------------------------
+
+function currentTurnState(game: Game): AvalonTurnState | undefined {
+  if (game.status.type !== GameStatus.Playing) return undefined;
+  return game.status.turnState as AvalonTurnState | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Services
+// ---------------------------------------------------------------------------
+
 export const avalonServices: GameModeServices = {
-  buildInitialTurnState() {
-    return undefined;
+  buildInitialTurnState(
+    roleAssignments: PlayerRoleAssignment[],
+    options?: Record<string, unknown>,
+  ): AvalonTurnState {
+    const { playerOrder } = (options ?? {}) as BuildTurnStateOptions;
+    const allPlayerIds = roleAssignments.map((a) => a.playerId);
+
+    // Preserve seating order from the lobby when available; otherwise randomize.
+    const orderedPlayerIds =
+      playerOrder && playerOrder.length > 0
+        ? resolvePlayerOrder(playerOrder, allPlayerIds)
+        : shuffle(allPlayerIds);
+
+    const firstLeaderId = orderedPlayerIds[0];
+    if (!firstLeaderId) {
+      throw new Error("No players to initialize Avalon game");
+    }
+
+    const playerCount = orderedPlayerIds.length;
+    const questTeamSizes = getQuestTeamSizes(playerCount);
+    const requiresTwoFails = requiresTwoFailsQuests(playerCount);
+    const firstTeamSize = questTeamSizes[0];
+
+    return {
+      questNumber: 1,
+      phase: {
+        type: AvalonPhase.TeamProposal,
+        leaderId: firstLeaderId,
+        teamSize: firstTeamSize,
+      },
+      leaderOrder: orderedPlayerIds,
+      currentLeaderIndex: 0,
+      questResults: [],
+      consecutiveRejections: 0,
+      questTeamSizes,
+      requiresTwoFails,
+    };
   },
 
-  selectSpecialTargets() {
+  selectSpecialTargets(): Record<string, string> {
     return {};
   },
 
-  extractPlayerState() {
-    return {};
+  extractPlayerState(
+    game: Game,
+    callerId: string,
+    myRole: { id: string } | undefined,
+  ): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+
+    const ts = currentTurnState(game);
+    if (!ts) return result;
+
+    const { phase, questResults, consecutiveRejections, questNumber } = ts;
+
+    // All players see quest results, current quest info, consecutive rejections,
+    // and the current phase (with public fields only).
+    result["questResults"] = questResults;
+    result["consecutiveRejections"] = consecutiveRejections;
+    result["currentQuest"] = {
+      questNumber,
+      teamSize: ts.questTeamSizes[questNumber - 1],
+      requiresTwoFails: ts.requiresTwoFails.includes(questNumber),
+    };
+
+    // Build public phase info (safe for all players to see).
+    const publicPhase = buildPublicPhase(phase);
+    result["avalonPhase"] = publicPhase;
+
+    // Proposed team visible to all during team vote.
+    if (
+      phase.type === AvalonPhase.TeamVote ||
+      phase.type === AvalonPhase.TeamProposal
+    ) {
+      const team =
+        phase.type === AvalonPhase.TeamProposal
+          ? phase.proposedTeam
+          : phase.proposedTeam;
+      if (team) {
+        result["proposedTeam"] = team;
+      }
+    }
+
+    // Team vote results visible to all after vote resolves.
+    if (phase.type === AvalonPhase.TeamVote) {
+      const myVote = phase.votes.find((v) => v.playerId === callerId);
+      if (myVote) {
+        result["myTeamVote"] = myVote.vote;
+      }
+      if (phase.passed !== undefined) {
+        result["teamVotes"] = phase.votes;
+        result["teamVotePassed"] = phase.passed;
+      }
+    }
+
+    // Quest phase: team member sees their own played card after playing.
+    if (phase.type === AvalonPhase.Quest) {
+      const myCard = phase.cards.find((c) => c.playerId === callerId);
+      if (myCard) {
+        result["myQuestCard"] = myCard.card;
+      }
+      // After all cards are submitted, reveal fail count to all.
+      if (phase.failCount !== undefined) {
+        result["questFailCount"] = phase.failCount;
+      }
+    }
+
+    // Quest Leader sees eligible team members during proposal.
+    if (
+      phase.type === AvalonPhase.TeamProposal &&
+      phase.leaderId === callerId
+    ) {
+      result["eligibleTeamMemberIds"] = game.players.map((p) => p.id);
+    }
+
+    // Assassination phase: all players see the assassin's target (if selected).
+    if (phase.type === AvalonPhase.Assassination) {
+      if (phase.targetPlayerId) {
+        result["assassinationTarget"] = phase.targetPlayerId;
+      }
+
+      // Assassin sees all players as valid targets.
+      const myRoleId = myRole?.id as AvalonRole | undefined;
+      if (myRoleId === AvalonRole.Assassin) {
+        result["assassinationTargetIds"] = game.players.map((p) => p.id);
+      }
+    }
+
+    return result;
   },
 };
+
+// ---------------------------------------------------------------------------
+// Public phase builder — strips server-only fields (e.g. full card lists)
+// ---------------------------------------------------------------------------
+
+function buildPublicPhase(
+  phase: AvalonTurnState["phase"],
+): Record<string, unknown> {
+  const base: Record<string, unknown> = { type: phase.type };
+
+  if (
+    phase.type === AvalonPhase.TeamProposal ||
+    phase.type === AvalonPhase.TeamVote ||
+    phase.type === AvalonPhase.Quest
+  ) {
+    base["leaderId"] = phase.leaderId;
+  }
+
+  if (phase.type === AvalonPhase.TeamProposal) {
+    base["teamSize"] = phase.teamSize;
+  }
+
+  if (phase.type === AvalonPhase.Assassination) {
+    base["assassinPlayerId"] = phase.assassinPlayerId;
+  }
+
+  return base;
+}

--- a/src/lib/game/modes/avalon/services.ts
+++ b/src/lib/game/modes/avalon/services.ts
@@ -192,7 +192,7 @@ export const avalonServices: GameModeServices = {
       phase.type === AvalonPhase.TeamProposal &&
       phase.leaderId === callerId
     ) {
-      result["eligibleTeamMemberIds"] = game.players.map((p) => p.id);
+      result["eligibleTeamMemberIds"] = ts.leaderOrder;
     }
 
     // Assassination phase: all players see the assassin's target (if selected).

--- a/src/lib/game/modes/avalon/services.ts
+++ b/src/lib/game/modes/avalon/services.ts
@@ -1,7 +1,6 @@
-import { GameStatus, Team } from "@/lib/types";
+import { GameStatus } from "@/lib/types";
 import type { Game, GameModeServices, PlayerRoleAssignment } from "@/lib/types";
 import { resolvePlayerOrder } from "@/lib/player-order";
-import { AvalonRole, AVALON_ROLES } from "./roles";
 import { AvalonPhase } from "./types";
 import type { AvalonTurnState } from "./types";
 import type { AvalonPublicPhase } from "./player-state";
@@ -127,11 +126,7 @@ export const avalonServices: GameModeServices = {
     return {};
   },
 
-  extractPlayerState(
-    game: Game,
-    callerId: string,
-    myRole: { id: string } | undefined,
-  ): Record<string, unknown> {
+  extractPlayerState(game: Game, callerId: string): Record<string, unknown> {
     const result: Record<string, unknown> = {};
 
     const ts = currentTurnState(game);
@@ -201,16 +196,9 @@ export const avalonServices: GameModeServices = {
         result["assassinationTarget"] = phase.targetPlayerId;
       }
 
-      // Assassin sees Good-team players as valid targets.
-      const myRoleId = myRole?.id as AvalonRole | undefined;
-      if (myRoleId === AvalonRole.Assassin) {
-        const goodPlayerIds = game.roleAssignments
-          .filter(
-            (a) =>
-              AVALON_ROLES[a.roleDefinitionId as AvalonRole].team === Team.Good,
-          )
-          .map((a) => a.playerId);
-        result["assassinationTargetIds"] = goodPlayerIds;
+      // Assassin sees all players as valid targets.
+      if (callerId === phase.assassinPlayerId) {
+        result["assassinationTargetIds"] = ts.leaderOrder;
       }
     }
 
@@ -239,10 +227,6 @@ function buildPublicPhase(phase: AvalonTurnState["phase"]): AvalonPublicPhase {
 
   if (phase.type === AvalonPhase.Quest) {
     base.teamPlayerIds = phase.teamPlayerIds;
-  }
-
-  if (phase.type === AvalonPhase.Assassination) {
-    base.assassinPlayerId = phase.assassinPlayerId;
   }
 
   return base;

--- a/src/lib/game/modes/avalon/services.ts
+++ b/src/lib/game/modes/avalon/services.ts
@@ -1,7 +1,7 @@
-import { GameStatus } from "@/lib/types";
+import { GameStatus, Team } from "@/lib/types";
 import type { Game, GameModeServices, PlayerRoleAssignment } from "@/lib/types";
 import { resolvePlayerOrder } from "@/lib/player-order";
-import { AvalonRole } from "./roles";
+import { AvalonRole, AVALON_ROLES } from "./roles";
 import { AvalonPhase } from "./types";
 import type { AvalonTurnState } from "./types";
 import type { AvalonPublicPhase } from "./player-state";
@@ -201,10 +201,16 @@ export const avalonServices: GameModeServices = {
         result["assassinationTarget"] = phase.targetPlayerId;
       }
 
-      // Assassin sees all players as valid targets.
+      // Assassin sees Good-team players as valid targets.
       const myRoleId = myRole?.id as AvalonRole | undefined;
       if (myRoleId === AvalonRole.Assassin) {
-        result["assassinationTargetIds"] = game.players.map((p) => p.id);
+        const goodPlayerIds = game.roleAssignments
+          .filter(
+            (a) =>
+              AVALON_ROLES[a.roleDefinitionId as AvalonRole].team === Team.Good,
+          )
+          .map((a) => a.playerId);
+        result["assassinationTargetIds"] = goodPlayerIds;
       }
     }
 


### PR DESCRIPTION
Replaces the stub Avalon services with a full `GameModeServices` implementation for game initialization.

- `buildInitialTurnState()` sets up quest team sizes and double-fail rules per player count (5–10), randomizes Quest Leader rotation order, and starts in the `TeamProposal` phase
- `extractPlayerState()` builds per-player state with appropriate visibility: all players see quest results, phase, and rejection count; team members see their own played card; the Quest Leader sees eligible team members; the Assassin sees valid assassination targets
- `AvalonPlayerGameState` is expanded with all quest and phase fields needed by the client

Closes #362