### PR TITLE
chore: add GitHub MCP server to project configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,9 @@
 {
   "mcpServers": {
+    "github": {
+      "command": "gh",
+      "args": ["mcp", "serve"]
+    },
     "shadcn": {
       "command": "npx",
       "args": ["shadcn@latest", "mcp"]


### PR DESCRIPTION
Adds `gh mcp serve` to `.mcp.json` so sub-agents have access to GitHub MCP tools (`mcp__github__*`) for posting reviews, inline comments, and other GitHub operations.

Sub-agents only load project-level `.mcp.json` — they do not inherit user-scoped `~/.claude/mcp.json`. GitHub MCP is therefore required here for agent use.

`gh mcp serve` uses the existing `gh auth` state on the machine; no credentials are stored in this file.