### PR TITLE
chore: configure Dependabot to use Conventional Commit prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
     groups:
       dev-dependencies:
         dependency-type: development
@@ -18,3 +22,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
Adds `commit-message` configuration to both Dependabot ecosystems so generated PRs and commits use Conventional Commit syntax.

- npm: `chore(deps): bump X` for production deps, `chore(deps-dev): bump X` for dev deps
- github-actions: `chore(deps): bump action X`

The `include: "scope"` option adds the dependency scope automatically — no manual scope needed.

---
*Created by Claude Sonnet 4.6*