### PR TITLE
chore: surface Firebase credential and createGame errors explicitly

### DIFF
--- a/src/app/api/debug/game/route.ts
+++ b/src/app/api/debug/game/route.ts
@@ -78,16 +78,23 @@ export async function POST(request: Request): Promise<Response> {
 
   const ownerPlayer = ownerTitle ? players[0] : undefined;
 
-  const game = await createGame(
-    `debug-${randomUUID()}`,
-    players,
-    roleBuckets,
-    gameMode,
-    showRolesInPlay,
-    ownerPlayer?.id ?? undefined,
-    { ...GAME_MODES[gameMode].defaultTimerConfig, ...timerConfig },
-    resolvedModeConfig,
-  );
+  let game;
+  try {
+    game = await createGame(
+      `debug-${randomUUID()}`,
+      players,
+      roleBuckets,
+      gameMode,
+      showRolesInPlay,
+      ownerPlayer?.id ?? undefined,
+      { ...GAME_MODES[gameMode].defaultTimerConfig, ...timerConfig },
+      resolvedModeConfig,
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[debug/game] createGame failed:", err);
+    return Response.json({ error: message }, { status: 500 });
+  }
 
   const debugPlayers: DebugPlayer[] = players.map((p) => ({
     id: p.id,

--- a/src/lib/firebase/admin.ts
+++ b/src/lib/firebase/admin.ts
@@ -6,11 +6,18 @@ function initAdminApp() {
   const existing = getApps().find((a) => a.name === "[DEFAULT]");
   if (existing) return existing;
 
+  const privateKey = process.env["FIREBASE_PRIVATE_KEY"]?.replace(/\\n/g, "\n");
+  if (!privateKey?.startsWith("-----BEGIN")) {
+    throw new Error(
+      `[Firebase Admin] FIREBASE_PRIVATE_KEY is missing or malformed — value does not start with "-----BEGIN". Check Vercel environment variables.`,
+    );
+  }
+
   return initializeApp({
     credential: cert({
       projectId: process.env["FIREBASE_PROJECT_ID"],
       clientEmail: process.env["FIREBASE_CLIENT_EMAIL"],
-      privateKey: process.env["FIREBASE_PRIVATE_KEY"]?.replace(/\\n/g, "\n"),
+      privateKey,
     }),
     databaseURL: process.env["FIREBASE_DATABASE_URL"],
   });


### PR DESCRIPTION
Improves error visibility for Firebase failures in the debug game flow.

- `admin.ts`: validates `FIREBASE_PRIVATE_KEY` format at init time — if the key is missing or doesn't start with `-----BEGIN`, throws a clear message immediately rather than letting the Firebase SDK surface the cryptic `error:1E08010C:DECODER routines::unsupported` OpenSSL error later during a write.
- `debug/game` route: wraps `createGame` in a try/catch and returns the error message in the JSON 500 response body, so debug game failures are visible in the network tab without needing to open Vercel logs.

Motivated by a 500 on the PR [#533](https://github.com/rmartz/hidden-role-game/pull/533) preview deployment where the Firebase credential error was only discoverable by reading the Vercel runtime logs.

---
*Created by Claude Sonnet 4.6*