### PR TITLE
chore: validate all required Firebase Admin env vars at init time

### DIFF
--- a/src/lib/firebase/admin.spec.ts
+++ b/src/lib/firebase/admin.spec.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, it, expect, vi } from "vitest";
+
+// Use the real admin.ts, not the global mock from firebase-admin-mock.ts setupFile
+vi.unmock("@/lib/firebase/admin");
+
+// Stub out Firebase Admin SDK to avoid real initialization
+vi.mock("firebase-admin/app", () => ({
+  getApps: vi.fn(() => []),
+  initializeApp: vi.fn(() => ({ name: "[DEFAULT]" })),
+  cert: vi.fn(),
+}));
+vi.mock("firebase-admin/database", () => ({
+  getDatabase: vi.fn(() => ({})),
+}));
+vi.mock("firebase-admin/auth", () => ({
+  getAuth: vi.fn(() => ({})),
+}));
+
+import { getAdminDatabase } from "@/lib/firebase/admin";
+
+const VALID_ENV = {
+  FIREBASE_PROJECT_ID: "test-project",
+  FIREBASE_CLIENT_EMAIL: "sa@test-project.iam.gserviceaccount.com",
+  FIREBASE_DATABASE_URL: "https://test-project.firebaseio.com",
+  FIREBASE_PRIVATE_KEY: "-----BEGIN TEST KEY-----",
+};
+
+function stubValidEnv(overrides: Record<string, string> = {}) {
+  for (const [k, v] of Object.entries({ ...VALID_ENV, ...overrides })) {
+    vi.stubEnv(k, v);
+  }
+}
+
+describe("initAdminApp", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("initializes without throwing when all env vars are valid", () => {
+    stubValidEnv();
+    expect(() => getAdminDatabase()).not.toThrow();
+  });
+
+  describe("FIREBASE_PROJECT_ID", () => {
+    it("throws when missing", () => {
+      stubValidEnv({ FIREBASE_PROJECT_ID: "" });
+      expect(() => getAdminDatabase()).toThrow(
+        "[Firebase Admin] FIREBASE_PROJECT_ID is missing or invalid",
+      );
+    });
+  });
+
+  describe("FIREBASE_CLIENT_EMAIL", () => {
+    it("throws when missing", () => {
+      stubValidEnv({ FIREBASE_CLIENT_EMAIL: "" });
+      expect(() => getAdminDatabase()).toThrow(
+        "[Firebase Admin] FIREBASE_CLIENT_EMAIL is missing or invalid",
+      );
+    });
+
+    it("throws when not a service account address", () => {
+      stubValidEnv({ FIREBASE_CLIENT_EMAIL: "user@gmail.com" });
+      expect(() => getAdminDatabase()).toThrow(
+        "[Firebase Admin] FIREBASE_CLIENT_EMAIL is missing or invalid",
+      );
+    });
+  });
+
+  describe("FIREBASE_DATABASE_URL", () => {
+    it("throws when missing", () => {
+      stubValidEnv({ FIREBASE_DATABASE_URL: "" });
+      expect(() => getAdminDatabase()).toThrow(
+        "[Firebase Admin] FIREBASE_DATABASE_URL is missing or invalid",
+      );
+    });
+  });
+
+  describe("FIREBASE_PRIVATE_KEY", () => {
+    it("throws when missing", () => {
+      stubValidEnv({ FIREBASE_PRIVATE_KEY: "" });
+      expect(() => getAdminDatabase()).toThrow(
+        "[Firebase Admin] FIREBASE_PRIVATE_KEY is missing or invalid",
+      );
+    });
+
+    it("throws when present but not a PEM key", () => {
+      stubValidEnv({ FIREBASE_PRIVATE_KEY: "not-a-key" });
+      expect(() => getAdminDatabase()).toThrow(
+        "[Firebase Admin] FIREBASE_PRIVATE_KEY is missing or invalid",
+      );
+    });
+  });
+});

--- a/src/lib/firebase/admin.ts
+++ b/src/lib/firebase/admin.ts
@@ -2,24 +2,44 @@ import { initializeApp, getApps, cert } from "firebase-admin/app";
 import { getDatabase } from "firebase-admin/database";
 import { getAuth } from "firebase-admin/auth";
 
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `[Firebase Admin] ${name} is missing or invalid. Check Vercel environment variables.`,
+    );
+  }
+  return value;
+}
+
 function initAdminApp() {
   const existing = getApps().find((a) => a.name === "[DEFAULT]");
   if (existing) return existing;
 
-  const privateKey = process.env["FIREBASE_PRIVATE_KEY"]?.replace(/\\n/g, "\n");
-  if (!privateKey?.startsWith("-----BEGIN")) {
+  const projectId = requireEnv("FIREBASE_PROJECT_ID");
+  const clientEmail = requireEnv("FIREBASE_CLIENT_EMAIL");
+  const databaseURL = requireEnv("FIREBASE_DATABASE_URL");
+
+  const rawPrivateKey = requireEnv("FIREBASE_PRIVATE_KEY");
+  const privateKey = rawPrivateKey.replace(/\\n/g, "\n");
+  if (!privateKey.startsWith("-----BEGIN")) {
     throw new Error(
-      `[Firebase Admin] FIREBASE_PRIVATE_KEY is missing or malformed — value does not start with "-----BEGIN". Check Vercel environment variables.`,
+      `[Firebase Admin] FIREBASE_PRIVATE_KEY is missing or invalid — value does not start with "-----BEGIN". Check Vercel environment variables.`,
+    );
+  }
+
+  if (
+    !clientEmail.includes("@") ||
+    !clientEmail.endsWith(".iam.gserviceaccount.com")
+  ) {
+    throw new Error(
+      `[Firebase Admin] FIREBASE_CLIENT_EMAIL is missing or invalid — expected a service account address ending in .iam.gserviceaccount.com. Check Vercel environment variables.`,
     );
   }
 
   return initializeApp({
-    credential: cert({
-      projectId: process.env["FIREBASE_PROJECT_ID"],
-      clientEmail: process.env["FIREBASE_CLIENT_EMAIL"],
-      privateKey,
-    }),
-    databaseURL: process.env["FIREBASE_DATABASE_URL"],
+    credential: cert({ projectId, clientEmail, privateKey }),
+    databaseURL,
   });
 }
 


### PR DESCRIPTION
Extends the `FIREBASE_PRIVATE_KEY` guard added in #534 to cover all four required Firebase Admin env vars. Each missing or malformed value throws before `initializeApp()` is called, so misconfigured deploys surface a clear error rather than a cryptic Firebase SDK message.

**Validated:**
- `FIREBASE_PROJECT_ID` — must be non-empty
- `FIREBASE_CLIENT_EMAIL` — must be non-empty and end in `.iam.gserviceaccount.com`
- `FIREBASE_DATABASE_URL` — must be non-empty
- `FIREBASE_PRIVATE_KEY` — must be non-empty and start with `-----BEGIN`

7 new tests in `admin.spec.ts` cover all missing and malformed cases.

Closes #535

---
*Created by Claude Sonnet 4.6*