### PR TITLE
fix: allow vercel-deploy-scripts build scripts in pnpm onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
       "@firebase/util",
       "esbuild",
       "protobufjs",
-      "sharp"
+      "sharp",
+      "vercel-deploy-scripts"
     ]
   },
   "lint-staged": {


### PR DESCRIPTION
pnpm 10 requires git-hosted packages that execute build scripts to be listed in `onlyBuiltDependencies`. `vercel-deploy-scripts` v1.7.0 added a `prepare` script, which causes `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` on CI when the Dependabot update PR (#545) is installed.

This adds `vercel-deploy-scripts` to the allowlist so CI passes after the Dependabot bump merges.

Fixes the CI failure in Dependabot PR #545.

---
*Created by Claude Sonnet 4.6*