### PR TITLE
ci: add @storybook/addon-vitest for story-based browser tests

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
+      - run: pnpm exec playwright install chromium --with-deps
       - run: pnpm test
 
   lint:

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -2,7 +2,11 @@ import type { StorybookConfig } from "@storybook/nextjs-vite";
 
 const config: StorybookConfig = {
   stories: ["../src/**/*.stories.@(ts|tsx)"],
-  addons: ["@storybook/addon-a11y", "@storybook/addon-docs"],
+  addons: [
+    "@storybook/addon-a11y",
+    "@storybook/addon-docs",
+    "@storybook/addon-vitest",
+  ],
   framework: "@storybook/nextjs-vite",
 };
 export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -10,7 +10,7 @@ const preview: Preview = {
       },
     },
     a11y: {
-      test: "todo",
+      test: "error",
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@eslint/js": "^10.0.1",
     "@storybook/addon-a11y": "^10.3.6",
     "@storybook/addon-docs": "^10.3.6",
+    "@storybook/addon-vitest": "^10.3.6",
     "@storybook/nextjs-vite": "^10.3.6",
     "@tailwindcss/postcss": "^4.2.4",
     "@testing-library/react": "^16.3.2",
@@ -79,6 +80,8 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/browser": "^4.1.5",
+    "@vitest/browser-playwright": "^4.1.5",
     "eslint": "^10.3.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-storybook": "^10.3.6",
@@ -86,6 +89,7 @@
     "happy-dom": "^20.9.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
+    "playwright": "^1.59.1",
     "postcss": "^8.5.14",
     "prettier": "^3.8.3",
     "shadcn": "^4.6.0",
@@ -94,8 +98,8 @@
     "tsx": "^4.19.4",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.1",
-    "vite": "^8.0.10",
     "vercel-deploy-scripts": "https://github.com/rmartz/vercel-deploy-scripts/archive/refs/tags/v2.3.3.tar.gz",
+    "vite": "^8.0.10",
     "vitest": "^4.1.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@storybook/addon-docs':
         specifier: ^10.3.6
         version: 10.3.6(@types/react@19.2.14)(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))
+      '@storybook/addon-vitest':
+        specifier: ^10.3.6
+        version: 10.3.6(@vitest/browser-playwright@4.1.5)(@vitest/browser@4.1.5(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5))(@vitest/runner@4.1.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.5)
       '@storybook/nextjs-vite':
         specifier: ^10.3.6
         version: 10.3.6(@babel/core@7.29.0)(esbuild@0.27.7)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.2)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))
@@ -99,6 +102,12 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/browser':
+        specifier: ^4.1.5
+        version: 4.1.5(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.5
+        version: 4.1.5(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(playwright@1.59.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
       eslint:
         specifier: ^10.3.0
         version: 10.3.0(jiti@2.6.1)
@@ -120,6 +129,9 @@ importers:
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
+      playwright:
+        specifier: ^1.59.1
+        version: 1.59.1
       postcss:
         specifier: ^8.5.14
         version: 8.5.14
@@ -152,7 +164,7 @@ importers:
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(happy-dom@20.9.0)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.5)(happy-dom@20.9.0)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -327,6 +339,9 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@blazediff/core@1.9.1':
+    resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -1551,6 +1566,9 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
   '@prisma/instrumentation@7.6.0':
     resolution: {integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==}
     peerDependencies:
@@ -2020,6 +2038,24 @@ packages:
     peerDependencies:
       storybook: ^10.3.6
 
+  '@storybook/addon-vitest@10.3.6':
+    resolution: {integrity: sha512-HXj7RrPJY+xzoNjL+xZu2oLw1fI5BA87Noh1NAXMPuECHR5R5fuRM/tTsJuIGXHFMO06FjSi/rekDIfCj1fL4w==}
+    peerDependencies:
+      '@vitest/browser': ^3.0.0 || ^4.0.0
+      '@vitest/browser-playwright': ^4.0.0
+      '@vitest/runner': ^3.0.0 || ^4.0.0
+      storybook: ^10.3.6
+      vitest: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/runner':
+        optional: true
+      vitest:
+        optional: true
+
   '@storybook/builder-vite@10.3.6':
     resolution: {integrity: sha512-gpvR/sE4BcrFtmQZ+Ker7zD23oQzoVeqD9nF6cK6yzY+Q0svJXyX2EPmFG4y+EwygD5/vNzDpP84gGMut8VRwg==}
     peerDependencies:
@@ -2444,6 +2480,17 @@ packages:
         optional: true
       babel-plugin-react-compiler:
         optional: true
+
+  '@vitest/browser-playwright@4.1.5':
+    resolution: {integrity: sha512-CWy0lBQJq97nionyJJdnaU4961IXTl43a7UCu5nHy51IoKxAt6PVIJLo+76rVl7KOOgcWHNkG4kbJu/pW7knvA==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.1.5
+
+  '@vitest/browser@4.1.5':
+    resolution: {integrity: sha512-iCDGI8c4yg+xmjUg2VsygdAUSIIB4x5Rht/P68OXy1hPELKXHDkzh87lkuTcdYmemRChDkEpB426MmDjzC0ziA==}
+    peerDependencies:
+      vitest: 4.1.5
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -3279,6 +3326,11 @@ packages:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3939,6 +3991,10 @@ packages:
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -4170,6 +4226,20 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -4475,6 +4545,10 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -4700,6 +4774,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
@@ -5314,6 +5392,8 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@blazediff/core@1.9.1': {}
 
   '@date-fns/tz@1.4.1':
     optional: true
@@ -6519,6 +6599,8 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
+  '@polka/url@1.0.0-next.29': {}
+
   '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -6928,6 +7010,20 @@ snapshots:
       - rollup
       - vite
       - webpack
+
+  '@storybook/addon-vitest@10.3.6(@vitest/browser-playwright@4.1.5)(@vitest/browser@4.1.5(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5))(@vitest/runner@4.1.5)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.5)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      storybook: 10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+    optionalDependencies:
+      '@vitest/browser': 4.1.5(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/browser-playwright': 4.1.5(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(playwright@1.59.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/runner': 4.1.5
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.5)(happy-dom@20.9.0)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@storybook/builder-vite@10.3.6(esbuild@0.27.7)(rollup@4.60.2)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.27.7))':
     dependencies:
@@ -7377,6 +7473,36 @@ snapshots:
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/browser-playwright@4.1.5(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(playwright@1.59.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)':
+    dependencies:
+      '@vitest/browser': 4.1.5(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
+      '@vitest/mocker': 4.1.5(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      playwright: 1.59.1
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.5)(happy-dom@20.9.0)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.5(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.5(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.5)(happy-dom@20.9.0)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -8341,6 +8467,9 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -8970,6 +9099,8 @@ snapshots:
 
   module-details-from-path@1.0.4: {}
 
+  mrmime@2.0.1: {}
+
   ms@2.1.3: {}
 
   msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3):
@@ -9193,6 +9324,16 @@ snapshots:
   picomatch@4.0.4: {}
 
   pkce-challenge@5.0.1: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  pngjs@7.0.0: {}
 
   postcss-selector-parser@7.1.1:
     dependencies:
@@ -9652,6 +9793,12 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   sisteransi@1.0.5: {}
 
   slice-ansi@7.1.2:
@@ -9858,6 +10005,8 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  totalist@3.0.1: {}
+
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.30
@@ -10016,7 +10165,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(happy-dom@20.9.0)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.5)(happy-dom@20.9.0)(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -10041,6 +10190,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.6.0
+      '@vitest/browser-playwright': 4.1.5(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(playwright@1.59.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.5)
       happy-dom: 20.9.0
     transitivePeerDependencies:
       - msw

--- a/src/components/game/GameTimer.tsx
+++ b/src/components/game/GameTimer.tsx
@@ -81,7 +81,7 @@ export function GameTimer({
       <p
         className={
           hasExpired && !autoAdvance
-            ? "text-red-800/60 dark:text-red-400/60"
+            ? "text-red-700 dark:text-red-400"
             : "text-muted-foreground"
         }
       >

--- a/src/components/game/VisibilityGroupCard.stories.tsx
+++ b/src/components/game/VisibilityGroupCard.stories.tsx
@@ -94,7 +94,7 @@ export const WithActions: Story = {
     gameMode: GameMode.Werewolf,
     myRoleId: WerewolfRole.Werewolf,
     renderActions: (_playerId, playerName) => (
-      <button className="text-xs text-blue-500">Select {playerName}</button>
+      <button className="text-xs text-blue-700">Select {playerName}</button>
     ),
   },
 };

--- a/src/components/game/secret-villain/BoardDisplay.tsx
+++ b/src/components/game/secret-villain/BoardDisplay.tsx
@@ -81,7 +81,7 @@ function TrackSlots({ filled, size, variant, labels }: TrackSlotsProps) {
                   ? "text-muted-foreground line-through"
                   : i === filled
                     ? "font-medium"
-                    : "text-muted-foreground/60",
+                    : "text-muted-foreground",
               )}
               data-testid={`${variant}-slot-label-${String(i)}`}
             >

--- a/src/components/game/secret-villain/PolicyPeekView.tsx
+++ b/src/components/game/secret-villain/PolicyPeekView.tsx
@@ -34,8 +34,8 @@ export function PolicyPeekView({
               className={cn(
                 "rounded border-2 px-4 py-2 text-sm font-medium",
                 card === "good"
-                  ? "border-green-500 bg-green-500 text-white"
-                  : "border-red-500 bg-red-500 text-white",
+                  ? "border-green-700 bg-green-700 text-white"
+                  : "border-red-700 bg-red-700 text-white",
               )}
             >
               {card === "good"

--- a/src/components/game/werewolf/ConfirmTargetButtonView.tsx
+++ b/src/components/game/werewolf/ConfirmTargetButtonView.tsx
@@ -52,7 +52,7 @@ export function ConfirmTargetButtonView({
       : WEREWOLF_COPY.confirmButton.skip;
 
   return isConfirmed ? (
-    <p className="mt-3 text-sm text-green-600 font-medium">
+    <p className="mt-3 text-sm text-green-800 font-medium dark:text-green-400">
       {WEREWOLF_COPY.confirmButton.actionConfirmed}
     </p>
   ) : (

--- a/src/components/game/werewolf/PlayerNightSummaryItem.tsx
+++ b/src/components/game/werewolf/PlayerNightSummaryItem.tsx
@@ -49,7 +49,7 @@ export function PlayerNightSummaryItem({
   if (survived) {
     const suffix = silenced ? " You have also been silenced." : "";
     return (
-      <li className="text-sm font-medium text-orange-600">
+      <li className="text-sm font-medium text-orange-800 dark:text-orange-400">
         {WEREWOLF_COPY.day.toughGuySurvived}
         {suffix}
       </li>
@@ -69,7 +69,7 @@ export function PlayerNightSummaryItem({
 
   if (wasProtected) {
     return (
-      <li className="text-sm font-medium text-green-600">
+      <li className="text-sm font-medium text-green-800 dark:text-green-400">
         {WEREWOLF_COPY.day.protected(playerName)}
       </li>
     );

--- a/src/components/lobby/ExpandedRoleList.stories.tsx
+++ b/src/components/lobby/ExpandedRoleList.stories.tsx
@@ -1,10 +1,19 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Provider } from "react-redux";
 import { GameMode, RoleConfigMode, Team } from "@/lib/types";
 import type { RoleDefinition } from "@/lib/types";
+import { store } from "@/store";
 import { ExpandedRoleList } from "./ExpandedRoleList";
 
 const meta = {
   component: ExpandedRoleList,
+  decorators: [
+    (Story) => (
+      <Provider store={store}>
+        <Story />
+      </Provider>
+    ),
+  ],
 } satisfies Meta<typeof ExpandedRoleList>;
 
 export default meta;

--- a/src/components/lobby/ExpandedRoleList.stories.tsx
+++ b/src/components/lobby/ExpandedRoleList.stories.tsx
@@ -1,18 +1,24 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { configureStore } from "@reduxjs/toolkit";
 import { Provider } from "react-redux";
 import { GameMode, RoleConfigMode, Team } from "@/lib/types";
 import type { RoleDefinition } from "@/lib/types";
-import { store } from "@/store";
+import gameConfigReducer from "@/store/game-config-slice";
 import { ExpandedRoleList } from "./ExpandedRoleList";
 
 const meta = {
   component: ExpandedRoleList,
   decorators: [
-    (Story) => (
-      <Provider store={store}>
-        <Story />
-      </Provider>
-    ),
+    (Story) => {
+      const freshStore = configureStore({
+        reducer: { gameConfig: gameConfigReducer },
+      });
+      return (
+        <Provider store={freshStore}>
+          <Story />
+        </Provider>
+      );
+    },
   ],
 } satisfies Meta<typeof ExpandedRoleList>;
 

--- a/src/components/lobby/PlayerList.stories.tsx
+++ b/src/components/lobby/PlayerList.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { fn } from "storybook/test";
+import { expect, fn, within } from "storybook/test";
 import { PlayerList } from "./PlayerList";
+import { PLAYER_LIST_COPY } from "./PlayerList.copy";
 import { GameMode, RoleConfigMode, ShowRolesInPlay } from "@/lib/types";
 import { DEFAULT_WEREWOLF_TIMER_CONFIG } from "@/lib/game/modes/werewolf/timer-config";
 import type { PublicLobby } from "@/server/types";
@@ -68,6 +69,19 @@ export const PlayerView: Story = {
     isReadyPending: false,
     countdownDurationSeconds: 5,
   },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.getByText(`${PLAYER_LIST_COPY.title} (5)`),
+    ).toBeDefined();
+    await expect(canvas.getByText("Alice")).toBeDefined();
+    await expect(canvas.getByText("Bob")).toBeDefined();
+    await expect(canvas.getByText("Charlie")).toBeDefined();
+    await expect(
+      canvas.getByRole("button", { name: PLAYER_LIST_COPY.readyButton }),
+    ).toBeDefined();
+  },
 };
 
 export const OwnerView: Story = {
@@ -83,6 +97,15 @@ export const OwnerView: Story = {
     disabled: false,
     isReadyPending: false,
     countdownDurationSeconds: 5,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText("Alice")).toBeDefined();
+    await expect(
+      canvas.getByRole("button", { name: PLAYER_LIST_COPY.readyButton }),
+    ).toBeDefined();
+    await expect(canvas.getByText(PLAYER_LIST_COPY.dragHint)).toBeDefined();
   },
 };
 

--- a/src/components/lobby/RoleBucketConfig.tsx
+++ b/src/components/lobby/RoleBucketConfig.tsx
@@ -316,7 +316,10 @@ function BucketEditor({
             onAddRole(roleId as string, bucketIsUnique);
           }}
         >
-          <SelectTrigger className="w-48 h-8 text-sm">
+          <SelectTrigger
+            className="w-48 h-8 text-sm"
+            aria-label={ROLE_BUCKET_CONFIG_COPY.addRole}
+          >
             <SelectValue placeholder={ROLE_BUCKET_CONFIG_COPY.addRole} />
           </SelectTrigger>
           <SelectContent>

--- a/src/components/lobby/RoleListEntry.stories.tsx
+++ b/src/components/lobby/RoleListEntry.stories.tsx
@@ -1,9 +1,20 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Provider } from "react-redux";
 import { GameMode, RoleConfigMode, Team } from "@/lib/types";
+import { store } from "@/store";
 import { RoleListEntry } from "./RoleListEntry";
 
 const meta = {
   component: RoleListEntry,
+  decorators: [
+    (Story) => (
+      <Provider store={store}>
+        <ul>
+          <Story />
+        </ul>
+      </Provider>
+    ),
+  ],
 } satisfies Meta<typeof RoleListEntry>;
 
 export default meta;

--- a/src/components/lobby/RoleListEntry.stories.tsx
+++ b/src/components/lobby/RoleListEntry.stories.tsx
@@ -1,19 +1,25 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { configureStore } from "@reduxjs/toolkit";
 import { Provider } from "react-redux";
 import { GameMode, RoleConfigMode, Team } from "@/lib/types";
-import { store } from "@/store";
+import gameConfigReducer from "@/store/game-config-slice";
 import { RoleListEntry } from "./RoleListEntry";
 
 const meta = {
   component: RoleListEntry,
   decorators: [
-    (Story) => (
-      <Provider store={store}>
-        <ul>
-          <Story />
-        </ul>
-      </Provider>
-    ),
+    (Story) => {
+      const freshStore = configureStore({
+        reducer: { gameConfig: gameConfigReducer },
+      });
+      return (
+        <Provider store={freshStore}>
+          <ul>
+            <Story />
+          </ul>
+        </Provider>
+      );
+    },
   ],
 } satisfies Meta<typeof RoleListEntry>;
 

--- a/src/components/lobby/WerewolfConfigPanel.stories.tsx
+++ b/src/components/lobby/WerewolfConfigPanel.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { fn } from "storybook/test";
+import { expect, fn, userEvent, within } from "storybook/test";
 import { DEFAULT_WEREWOLF_TIMER_CONFIG } from "@/lib/game/modes/werewolf/timer-config";
 import { WerewolfConfigPanel } from "./WerewolfConfigPanel";
+import { WEREWOLF_CONFIG_PANEL_COPY } from "./WerewolfConfigPanel.copy";
 
 const meta = {
   component: WerewolfConfigPanel,
@@ -28,6 +29,17 @@ const DEFAULT_ARGS = {
 
 export const Default: Story = {
   args: DEFAULT_ARGS,
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    const nominationSwitch = canvas.getByRole("switch", {
+      name: WEREWOLF_CONFIG_PANEL_COPY.nominationEnabled,
+    });
+    await expect(nominationSwitch).toBeDefined();
+
+    await userEvent.click(nominationSwitch);
+    await expect(args.onNominationEnabledChange).toHaveBeenCalled();
+  },
 };
 
 export const RolesHiddenOnDeath: Story = {
@@ -48,5 +60,14 @@ export const ReadOnly: Story = {
   args: {
     ...DEFAULT_ARGS,
     disabled: true,
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    const nominationSwitch = canvas.getByRole("switch", {
+      name: WEREWOLF_CONFIG_PANEL_COPY.nominationEnabled,
+    });
+    await userEvent.click(nominationSwitch);
+    await expect(args.onNominationEnabledChange).not.toHaveBeenCalled();
   },
 };

--- a/src/components/lobby/WerewolfConfigPanel.stories.tsx
+++ b/src/components/lobby/WerewolfConfigPanel.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const DEFAULT_ARGS = {
+const DEFAULT_PROPS = {
   timerConfig: DEFAULT_WEREWOLF_TIMER_CONFIG,
   nominationEnabled: true,
   trialsPerDay: 1,
@@ -19,16 +19,23 @@ const DEFAULT_ARGS = {
   showRolesOnDeath: true,
   hiddenRole: false,
   autoRevealNightOutcome: true,
-  onWerewolfTimerConfigChange: fn(),
-  onNominationEnabledChange: fn(),
-  onTrialsPerDayChange: fn(),
-  onRevealProtectionsChange: fn(),
-  onShowRolesOnDeathChange: fn(),
-  onAutoRevealNightOutcomeChange: fn(),
-} as Story["args"];
+};
+
+function makeArgs(overrides: Partial<Story["args"]> = {}): Story["args"] {
+  return {
+    ...DEFAULT_PROPS,
+    onWerewolfTimerConfigChange: fn(),
+    onNominationEnabledChange: fn(),
+    onTrialsPerDayChange: fn(),
+    onRevealProtectionsChange: fn(),
+    onShowRolesOnDeathChange: fn(),
+    onAutoRevealNightOutcomeChange: fn(),
+    ...overrides,
+  } as Story["args"];
+}
 
 export const Default: Story = {
-  args: DEFAULT_ARGS,
+  args: makeArgs(),
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
 
@@ -43,24 +50,15 @@ export const Default: Story = {
 };
 
 export const RolesHiddenOnDeath: Story = {
-  args: {
-    ...DEFAULT_ARGS,
-    showRolesOnDeath: false,
-  },
+  args: makeArgs({ showRolesOnDeath: false }),
 };
 
 export const ManualRevealNightOutcomes: Story = {
-  args: {
-    ...DEFAULT_ARGS,
-    autoRevealNightOutcome: false,
-  },
+  args: makeArgs({ autoRevealNightOutcome: false }),
 };
 
 export const ReadOnly: Story = {
-  args: {
-    ...DEFAULT_ARGS,
-    disabled: true,
-  },
+  args: makeArgs({ disabled: true }),
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
 

--- a/src/components/lobby/WerewolfConfigPanel.stories.tsx
+++ b/src/components/lobby/WerewolfConfigPanel.stories.tsx
@@ -31,7 +31,7 @@ function makeArgs(overrides: Partial<Story["args"]> = {}): Story["args"] {
     onShowRolesOnDeathChange: fn(),
     onAutoRevealNightOutcomeChange: fn(),
     ...overrides,
-  } as Story["args"];
+  };
 }
 
 export const Default: Story = {

--- a/src/components/lobby/secret-villain/CustomPowerTableEditor.tsx
+++ b/src/components/lobby/secret-villain/CustomPowerTableEditor.tsx
@@ -91,7 +91,12 @@ export function CustomPowerTableEditor({
               handleSlotChange(index, value);
             }}
           >
-            <SelectTrigger className="w-[180px]">
+            <SelectTrigger
+              className="w-[180px]"
+              aria-label={SECRET_VILLAIN_CONFIG_PANEL_COPY.badCardSlotLabel(
+                index + 1,
+              )}
+            >
               <SelectValue>{toSelectLabel(slot)}</SelectValue>
             </SelectTrigger>
             <SelectContent>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,7 +18,7 @@ const buttonVariants = cva(
         ghost:
           "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
         destructive:
-          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+          "bg-transparent text-destructive hover:bg-destructive/10 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-transparent dark:hover:bg-destructive/20 dark:focus-visible:ring-destructive/40",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/src/components/ui/item.tsx
+++ b/src/components/ui/item.tsx
@@ -9,7 +9,6 @@ import { Separator } from "@/components/ui/separator";
 function ItemGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
-      role="list"
       data-slot="item-group"
       className={cn(
         "group/item-group flex w-full flex-col gap-4 has-data-[size=sm]:gap-2.5 has-data-[size=xs]:gap-2",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,5 +1,7 @@
 import { defineConfig } from "vitest/config";
 import path from "path";
+import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
+import { playwright } from "@vitest/browser-playwright";
 
 export default defineConfig({
   test: {
@@ -29,6 +31,19 @@ export default defineConfig({
           include: ["src/**/*.spec.tsx"],
         },
         resolve: { alias: { "@": path.resolve(import.meta.dirname, "./src") } },
+      },
+      {
+        plugins: [storybookTest()],
+        test: {
+          name: "storybook",
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [{ browser: "chromium" }],
+          },
+          setupFiles: ["@storybook/addon-vitest/internal/setup-file"],
+        },
       },
     ],
   },


### PR DESCRIPTION
Wires up `@storybook/addon-vitest` so stories with `play` functions run as Playwright/Chromium browser tests in CI. Also enables `@storybook/addon-a11y` in `"error"` mode so accessibility failures block CI.

Adds a `storybook` Vitest workspace project with browser mode enabled, registers the addon in `.storybook/main.ts`, adds `play` functions to `PlayerList` and `WerewolfConfigPanel` stories, and installs Playwright Chromium before `pnpm test` in the CI workflow. Fixes all pre-existing a11y violations exposed by the stricter a11y mode (color contrast, listitem containment, missing accessible names).

## Acceptance Criteria
- [x] Add `@storybook/addon-vitest`, `playwright`, `@vitest/browser-playwright` as devDependencies
- [x] Add a `storybook` project to `vitest.config.mts` (browser-mode Vitest workspace project)
- [x] Register the addon in `.storybook/main.ts`
- [x] Write `play` functions on representative existing stories (`PlayerList`, `WerewolfConfigPanel`)
- [x] Add CI workflow step to run `playwright install chromium --with-deps` then `pnpm test`
- [x] Verify accessibility failures from `@storybook/addon-a11y` fail CI

## Tests
153 story tests added, all passing. Full suite: 1645 tests passing.

Closes #553

---
*Created by Claude Sonnet 4.6*