### PR TITLE
chore: add Sentry release tracking to CI

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -50,3 +50,21 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
       - run: pnpm build
+
+  sentry-release:
+    name: Sentry Release
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    needs: [tests, lint, format, typecheck, build]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: getsentry/action-release@v3
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: reedmartz
+          SENTRY_PROJECT: hidden-role-game
+        with:
+          environment: production
+          version: ${{ github.sha }}


### PR DESCRIPTION
Adds a `sentry-release` CI job that creates a Sentry release on every push to `main`, associating it with the deployed commits so errors can be correlated with specific deploys.

The job runs only after all other CI checks pass (`needs: [tests, lint, format, typecheck, build]`) and uses `getsentry/action-release@v3` to run the `sentry-cli releases` commands. Full git history is fetched so `set-commits --auto` can walk back to the previous release.

## Acceptance Criteria
- [x] A Sentry release is created on every push to `main`, tagged with the commit SHA
- [x] Commits are associated with the release (`set-commits --auto`)
- [x] The release is finalized and marked deployed to `production`
- [x] The job only runs after a successful build and only on pushes (not PRs)

## Tests
No unit tests — pure CI config change.

> **Note:** one manual step remains: in the Sentry project settings, enable the GitHub integration (**Settings → Integrations → GitHub**) to link releases to PRs and commits in the Sentry UI.

Closes #577

---
*Created by Claude Sonnet 4.6*