### PR TITLE
docs(werewolf): fix altruist-intercepted event shape

### DIFF
--- a/docs/werewolf/actions.md
+++ b/docs/werewolf/actions.md
@@ -289,7 +289,7 @@ interface TeamNightAction {
 - `{ type: "silenced", targetPlayerId }`
 - `{ type: "hypnotized", targetPlayerId }`
 - `{ type: "tough-guy-absorbed", targetPlayerId }`
-- `{ type: "altruist-intercepted", targetPlayerId }`
+- `{ type: "altruist-intercepted", altruistPlayerId, savedPlayerId }`
 
 After resolution, `start-day` performs additional checks:
 


### PR DESCRIPTION
Fixes the `altruist-intercepted` `NightResolutionEvent` shape documented in `docs/werewolf/actions.md`. The doc had `targetPlayerId` but the actual `AltruistInterceptedNightResolutionEvent` interface uses `altruistPlayerId` and `savedPlayerId`.

No code changes — docs-only fix surfaced during review of [#513](https://github.com/rmartz/hidden-role-game/pull/513).

Closes #571

---
*Created by Claude Sonnet 4.6*