### PR TITLE
feat(werewolf): add narrator instructions for Night 1 roles

### DIFF
--- a/docs/werewolf/data-flow.md
+++ b/docs/werewolf/data-flow.md
@@ -248,6 +248,38 @@ The `wolfCubDied` flag is cleared when `start-night` consumes it to generate the
 
 When the Old Man role is in play, `start-day` checks whether the Old Man's timer has fired. The timer fires on turn `#werewolves + 2` (where `#werewolves` counts all roles with `isWerewolf`, including Wolf Cub). If the Old Man is still alive and was **not** attacked that same night, they die peacefully — the resolution emits a kill event with `attackedBy: [OLD_MAN_TIMER_KEY]`. If the Old Man was attacked and killed by wolves (or any other attacker), the attack takes precedence and no timer event is emitted.
 
+## Narrator Night Instructions
+
+`buildNarratorInstruction` (`src/lib/game/modes/werewolf/utils/narrator-instructions.ts`) produces a
+`NarratorInstruction` for the narrator's UI during Night 1. The instruction is shown by the
+`NarratorNightInstruction` component and contains three optional fields:
+
+| Field             | Description                                                                        |
+| ----------------- | ---------------------------------------------------------------------------------- |
+| `preWake`         | Script line spoken before waking a role (e.g. Werewolf thumb cue for Minion phase) |
+| `wakeInstruction` | Always-present line telling the role(s) to open their eyes                         |
+| `postWake`        | Script line spoken after the role is awake (e.g. action reminder)                  |
+
+The function accepts a `phaseKey` (which may be a suffixed group-phase key such as
+`"werewolf-werewolf:2"`) and a set of active role IDs. It normalises suffixed group-phase keys via
+`baseGroupPhaseKey()` before looking up the role definition.
+
+Per-role script logic:
+
+- **Minion** — `preWake` tells all Werewolves to raise their thumbs. When extra werewolf-aligned
+  roles (e.g. Wolf Cub, Lone Wolf) are in play, their names are interpolated:
+  `"All Werewolves, including Wolf Cub, raise your thumbs."`
+- **Sentinel** — `preWake` tells the Seer to raise their thumb only when the Seer is active.
+- **Mason** — `wakeInstruction` uses the plural form; `postWake` asks them to find each other.
+- **Group-phase roles** (`teamTargeting: true`, e.g. Werewolves) — plural `wakeInstruction` with
+  target-selection reminder.
+- **Solo roles with night activity** (`targetCategory !== None`) — standard wake plus "look at
+  the Narrator" `postWake`.
+- **All other roles** — wake instruction only, no `postWake`.
+
+The narrator instruction is displayed during Night 1 only; subsequent nights do not show the
+`NarratorNightInstruction` panel.
+
 ## WerewolfWinner Values
 
 The `WerewolfWinner` enum determines the outcome of the game. In addition to the standard team-based outcomes, the following individual-win values exist:

--- a/src/components/game/werewolf/NarratorNightInstruction.copy.ts
+++ b/src/components/game/werewolf/NarratorNightInstruction.copy.ts
@@ -1,0 +1,3 @@
+export const NARRATOR_NIGHT_INSTRUCTION_COPY = {
+  heading: "Say aloud:",
+} as const;

--- a/src/components/game/werewolf/NarratorNightInstruction.spec.tsx
+++ b/src/components/game/werewolf/NarratorNightInstruction.spec.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { NarratorNightInstruction } from "./NarratorNightInstruction";
+import { NARRATOR_NIGHT_INSTRUCTION_COPY } from "./NarratorNightInstruction.copy";
+
+afterEach(cleanup);
+
+describe("NarratorNightInstruction", () => {
+  it("renders the heading and wake instruction only when no optional fields are provided", () => {
+    render(
+      <NarratorNightInstruction
+        instruction={{ wakeInstruction: "Tell Seer to open their eyes." }}
+      />,
+    );
+
+    expect(
+      screen.getByText(NARRATOR_NIGHT_INSTRUCTION_COPY.heading),
+    ).toBeDefined();
+    expect(screen.getByText("“Tell Seer to open their eyes.”")).toBeDefined();
+    expect(screen.queryByText(/raise your thumbs/)).toBeNull();
+    expect(screen.queryByText(/look around/)).toBeNull();
+  });
+
+  it("renders preWake, wakeInstruction, and postWake when all fields are present", () => {
+    render(
+      <NarratorNightInstruction
+        instruction={{
+          preWake: "All Werewolves, raise your thumbs.",
+          wakeInstruction: "Tell Minion to open their eyes.",
+          postWake: "Tell them to look around, then close their eyes.",
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText("“All Werewolves, raise your thumbs.”"),
+    ).toBeDefined();
+    expect(screen.getByText("“Tell Minion to open their eyes.”")).toBeDefined();
+    expect(
+      screen.getByText("“Tell them to look around, then close their eyes.”"),
+    ).toBeDefined();
+  });
+
+  it("renders wakeInstruction and postWake without preWake when preWake is omitted", () => {
+    render(
+      <NarratorNightInstruction
+        instruction={{
+          wakeInstruction: "Tell all Werewolves to open their eyes.",
+          postWake: "Tell them to find their teammates and choose a target.",
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText("“Tell all Werewolves to open their eyes.”"),
+    ).toBeDefined();
+    expect(
+      screen.getByText(
+        "“Tell them to find their teammates and choose a target.”",
+      ),
+    ).toBeDefined();
+    expect(screen.queryByText(/raise your thumbs/)).toBeNull();
+  });
+});

--- a/src/components/game/werewolf/NarratorNightInstruction.stories.tsx
+++ b/src/components/game/werewolf/NarratorNightInstruction.stories.tsx
@@ -25,7 +25,7 @@ export const MinionWithExtraWerewolves: Story = {
   args: {
     instruction: {
       preWake:
-        "All werewolves, including Wolf Cub, Lone Wolf, raise your thumbs.",
+        "All Werewolves, including Wolf Cub, Lone Wolf, raise your thumbs.",
       wakeInstruction: "Tell Minion to open their eyes.",
       postWake: "Tell them to look around, then close their eyes.",
     },

--- a/src/components/game/werewolf/NarratorNightInstruction.stories.tsx
+++ b/src/components/game/werewolf/NarratorNightInstruction.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { NarratorNightInstruction } from "./NarratorNightInstruction";
+
+const meta: Meta<typeof NarratorNightInstruction> = {
+  title: "Werewolf/NarratorNightInstruction",
+  component: NarratorNightInstruction,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof NarratorNightInstruction>;
+
+export const WerewolfPhase: Story = {
+  args: {
+    instruction: {
+      wakeInstruction: "Tell all Werewolves to open their eyes.",
+      postWake: "Tell them to find their teammates and choose a target.",
+    },
+  },
+};
+
+export const MinionWithExtraWerewolves: Story = {
+  args: {
+    instruction: {
+      preWake:
+        "All werewolves, including Wolf Cub, Lone Wolf, raise your thumbs.",
+      wakeInstruction: "Tell Minion to open their eyes.",
+      postWake: "Tell them to look around, then close their eyes.",
+    },
+  },
+};
+
+export const MinionBasic: Story = {
+  args: {
+    instruction: {
+      preWake: "All Werewolves, raise your thumbs.",
+      wakeInstruction: "Tell Minion to open their eyes.",
+      postWake: "Tell them to look around, then close their eyes.",
+    },
+  },
+};
+
+export const SentinelWithSeer: Story = {
+  args: {
+    instruction: {
+      preWake: "Tell the Seer to raise their thumb.",
+      wakeInstruction: "Tell Sentinel to open their eyes.",
+      postWake: "Tell them to look around, then close their eyes.",
+    },
+  },
+};
+
+export const SentinelWithoutSeer: Story = {
+  args: {
+    instruction: {
+      wakeInstruction: "Tell Sentinel to open their eyes.",
+      postWake: "Tell them to look around, then close their eyes.",
+    },
+  },
+};
+
+export const Masons: Story = {
+  args: {
+    instruction: {
+      wakeInstruction: "Tell all Masons to open their eyes.",
+      postWake: "Tell them to find each other.",
+    },
+  },
+};
+
+export const SeerWithActivity: Story = {
+  args: {
+    instruction: {
+      wakeInstruction: "Tell Seer to open their eyes.",
+      postWake: "Tell them to look at the Narrator.",
+    },
+  },
+};
+
+export const ElusiveSeerNoActivity: Story = {
+  args: {
+    instruction: {
+      wakeInstruction: "Tell Elusive Seer to open their eyes.",
+    },
+  },
+};

--- a/src/components/game/werewolf/NarratorNightInstruction.tsx
+++ b/src/components/game/werewolf/NarratorNightInstruction.tsx
@@ -1,0 +1,31 @@
+import type { NarratorInstruction } from "@/lib/game/modes/werewolf";
+import { NARRATOR_NIGHT_INSTRUCTION_COPY } from "./NarratorNightInstruction.copy";
+
+interface NarratorNightInstructionProps {
+  instruction: NarratorInstruction;
+}
+
+export function NarratorNightInstruction({
+  instruction,
+}: NarratorNightInstructionProps) {
+  return (
+    <div className="mb-4 rounded-md border border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/30 p-3 text-sm">
+      <p className="text-xs font-medium uppercase tracking-wide text-amber-700 dark:text-amber-400 mb-1">
+        {NARRATOR_NIGHT_INSTRUCTION_COPY.heading}
+      </p>
+      {instruction.preWake && (
+        <p className="mb-1 text-foreground">
+          &ldquo;{instruction.preWake}&rdquo;
+        </p>
+      )}
+      <p className="text-foreground">
+        &ldquo;{instruction.wakeInstruction}&rdquo;
+      </p>
+      {instruction.postWake && (
+        <p className="mt-1 text-foreground">
+          &ldquo;{instruction.postWake}&rdquo;
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/game/werewolf/OwnerGameNightScreen.tsx
+++ b/src/components/game/werewolf/OwnerGameNightScreen.tsx
@@ -36,6 +36,8 @@ import { OwnerNightTargetPanel } from "./OwnerNightTargetPanel";
 import { OwnerPlayerActionsGrid } from "./OwnerPlayerActionsGrid";
 import { NightPhaseOrderList } from "./NightPhaseOrderList";
 import { WEREWOLF_COPY } from "@/lib/game/modes/werewolf/copy";
+import { buildNarratorInstruction } from "@/lib/game/modes/werewolf";
+import { NarratorNightInstruction } from "./NarratorNightInstruction";
 
 interface OwnerGameNightScreenProps {
   gameId: string;
@@ -136,6 +138,16 @@ export function OwnerGameNightScreen({
       : undefined;
 
   const isFirstTurn = turnState.turn === 1;
+  const activeRoleIds = isFirstTurn
+    ? new Set(
+        gameState.visibleRoleAssignments.flatMap((a) =>
+          a.role ? [a.role.id] : [],
+        ),
+      )
+    : new Set<string>();
+  const narratorInstruction = isFirstTurn
+    ? buildNarratorInstruction(activePhaseKey, activeRoleIds)
+    : undefined;
 
   const isActionConfirmed = isGroupPhase
     ? !!groupAction?.confirmed
@@ -296,6 +308,9 @@ export function OwnerGameNightScreen({
               <span> ({activePlayerNames.join(", ")})</span>
             )}
           </p>
+          {isFirstTurn && narratorInstruction && (
+            <NarratorNightInstruction instruction={narratorInstruction} />
+          )}
           {isRoleActive(activePhaseKey, WerewolfRole.Mirrorcaster) && (
             <p className="mb-3 text-sm text-muted-foreground italic">
               {turnState.mirrorcasterCharged

--- a/src/lib/game/modes/werewolf/utils/index.ts
+++ b/src/lib/game/modes/werewolf/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./narrator-instructions";
 export * from "./phase-keys";
 export * from "./targeting";
 export * from "./game-state";

--- a/src/lib/game/modes/werewolf/utils/narrator-instructions.spec.ts
+++ b/src/lib/game/modes/werewolf/utils/narrator-instructions.spec.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { buildNarratorInstruction } from "./narrator-instructions";
+import { WerewolfRole } from "../roles";
+
+describe("buildNarratorInstruction", () => {
+  describe("Werewolf group phase", () => {
+    it("returns wake instruction for all Werewolves", () => {
+      const activeRoleIds = new Set([WerewolfRole.Werewolf]);
+      const result = buildNarratorInstruction(
+        WerewolfRole.Werewolf,
+        activeRoleIds,
+      );
+      expect(result?.wakeInstruction).toBe(
+        "Tell all Werewolves to open their eyes.",
+      );
+      expect(result?.postWake).toBe(
+        "Tell them to find their teammates and choose a target.",
+      );
+    });
+  });
+
+  describe("Minion", () => {
+    it("uses basic werewolf pre-wake when only plain Werewolf is in play", () => {
+      const activeRoleIds = new Set([
+        WerewolfRole.Werewolf,
+        WerewolfRole.Minion,
+      ]);
+      const result = buildNarratorInstruction(
+        WerewolfRole.Minion,
+        activeRoleIds,
+      );
+      expect(result?.preWake).toBe("All Werewolves, raise your thumbs.");
+      expect(result?.wakeInstruction).toBe("Tell Minion to open their eyes.");
+    });
+
+    it("includes extra werewolf role names when Wolf Cub is in play", () => {
+      const activeRoleIds = new Set([
+        WerewolfRole.Werewolf,
+        WerewolfRole.WolfCub,
+        WerewolfRole.Minion,
+      ]);
+      const result = buildNarratorInstruction(
+        WerewolfRole.Minion,
+        activeRoleIds,
+      );
+      expect(result?.preWake).toBe(
+        "All werewolves, including Wolf Cub, raise your thumbs.",
+      );
+    });
+
+    it("includes Lone Wolf in the pre-wake when in play", () => {
+      const activeRoleIds = new Set([
+        WerewolfRole.Werewolf,
+        WerewolfRole.LoneWolf,
+        WerewolfRole.Minion,
+      ]);
+      const result = buildNarratorInstruction(
+        WerewolfRole.Minion,
+        activeRoleIds,
+      );
+      expect(result?.preWake).toBe(
+        "All werewolves, including Lone Wolf, raise your thumbs.",
+      );
+    });
+  });
+
+  describe("Sentinel", () => {
+    it("tells the Seer to raise their thumb when the Seer is in play", () => {
+      const activeRoleIds = new Set([WerewolfRole.Seer, WerewolfRole.Sentinel]);
+      const result = buildNarratorInstruction(
+        WerewolfRole.Sentinel,
+        activeRoleIds,
+      );
+      expect(result?.preWake).toBe("Tell the Seer to raise their thumb.");
+      expect(result?.wakeInstruction).toBe("Tell Sentinel to open their eyes.");
+    });
+
+    it("omits preWake when the Seer is not in play", () => {
+      const activeRoleIds = new Set([WerewolfRole.Sentinel]);
+      const result = buildNarratorInstruction(
+        WerewolfRole.Sentinel,
+        activeRoleIds,
+      );
+      expect(result?.preWake).toBeUndefined();
+    });
+  });
+
+  describe("Mason", () => {
+    it("tells all Masons to open their eyes and find each other", () => {
+      const activeRoleIds = new Set([WerewolfRole.Mason]);
+      const result = buildNarratorInstruction(
+        WerewolfRole.Mason,
+        activeRoleIds,
+      );
+      expect(result?.wakeInstruction).toBe(
+        "Tell all Masons to open their eyes.",
+      );
+      expect(result?.postWake).toBe("Tell them to find each other.");
+    });
+  });
+
+  describe("roles with night activity", () => {
+    it("tells the Seer to look at the Narrator", () => {
+      const activeRoleIds = new Set([WerewolfRole.Seer]);
+      const result = buildNarratorInstruction(WerewolfRole.Seer, activeRoleIds);
+      expect(result?.wakeInstruction).toBe("Tell Seer to open their eyes.");
+      expect(result?.postWake).toBe("Tell them to look at the Narrator.");
+    });
+
+    it("tells the Doctor to look at the Narrator", () => {
+      const activeRoleIds = new Set([WerewolfRole.Doctor]);
+      const result = buildNarratorInstruction(
+        WerewolfRole.Doctor,
+        activeRoleIds,
+      );
+      expect(result?.wakeInstruction).toBe("Tell Doctor to open their eyes.");
+      expect(result?.postWake).toBe("Tell them to look at the Narrator.");
+    });
+  });
+
+  describe("roles with no night activity", () => {
+    it("gives a basic wake instruction for Elusive Seer", () => {
+      const activeRoleIds = new Set([WerewolfRole.ElusiveSeer]);
+      const result = buildNarratorInstruction(
+        WerewolfRole.ElusiveSeer,
+        activeRoleIds,
+      );
+      expect(result?.wakeInstruction).toBe(
+        "Tell Elusive Seer to open their eyes.",
+      );
+      expect(result?.postWake).toBeUndefined();
+    });
+  });
+
+  describe("unknown phase key", () => {
+    it("returns undefined for an unrecognized phase key", () => {
+      const result = buildNarratorInstruction("unknown-role", new Set());
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/src/lib/game/modes/werewolf/utils/narrator-instructions.spec.ts
+++ b/src/lib/game/modes/werewolf/utils/narrator-instructions.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { buildNarratorInstruction } from "./narrator-instructions";
 import { WerewolfRole } from "../roles";
+import { GROUP_PHASE_KEY_SEPARATOR } from "./phase-keys";
 
 describe("buildNarratorInstruction", () => {
   describe("Werewolf group phase", () => {
@@ -44,7 +45,7 @@ describe("buildNarratorInstruction", () => {
         activeRoleIds,
       );
       expect(result?.preWake).toBe(
-        "All werewolves, including Wolf Cub, raise your thumbs.",
+        "All Werewolves, including Wolf Cub, raise your thumbs.",
       );
     });
 
@@ -59,7 +60,7 @@ describe("buildNarratorInstruction", () => {
         activeRoleIds,
       );
       expect(result?.preWake).toBe(
-        "All werewolves, including Lone Wolf, raise your thumbs.",
+        "All Werewolves, including Lone Wolf, raise your thumbs.",
       );
     });
   });
@@ -129,6 +130,20 @@ describe("buildNarratorInstruction", () => {
         "Tell Elusive Seer to open their eyes.",
       );
       expect(result?.postWake).toBeUndefined();
+    });
+  });
+
+  describe("group phase key with suffix", () => {
+    it("normalizes a suffixed group phase key to the base role", () => {
+      const suffixedKey = `${WerewolfRole.Werewolf}${GROUP_PHASE_KEY_SEPARATOR}2`;
+      const activeRoleIds = new Set([WerewolfRole.Werewolf]);
+      const result = buildNarratorInstruction(suffixedKey, activeRoleIds);
+      expect(result?.wakeInstruction).toBe(
+        "Tell all Werewolves to open their eyes.",
+      );
+      expect(result?.postWake).toBe(
+        "Tell them to find their teammates and choose a target.",
+      );
     });
   });
 

--- a/src/lib/game/modes/werewolf/utils/narrator-instructions.ts
+++ b/src/lib/game/modes/werewolf/utils/narrator-instructions.ts
@@ -1,0 +1,83 @@
+import { WerewolfRole, WEREWOLF_ROLES, getWerewolfRole } from "../roles";
+import { TargetCategory } from "../types";
+import { baseGroupPhaseKey, isGroupPhaseKey } from "./phase-keys";
+
+export interface NarratorInstruction {
+  preWake?: string;
+  wakeInstruction: string;
+  postWake?: string;
+}
+
+function extraWerewolfRoleNames(activeRoleIds: Set<string>): string[] {
+  return Object.values(WEREWOLF_ROLES)
+    .filter(
+      (r) =>
+        r.isWerewolf &&
+        r.id !== WerewolfRole.Werewolf &&
+        activeRoleIds.has(r.id),
+    )
+    .map((r) => r.name);
+}
+
+export function buildNarratorInstruction(
+  phaseKey: string,
+  activeRoleIds: Set<string>,
+): NarratorInstruction | undefined {
+  const baseKey = isGroupPhaseKey(phaseKey)
+    ? baseGroupPhaseKey(phaseKey)
+    : phaseKey;
+  const roleDef = getWerewolfRole(baseKey);
+  if (!roleDef) return undefined;
+
+  const roleName = roleDef.name;
+  const hasNightActivity = roleDef.targetCategory !== TargetCategory.None;
+
+  if (roleDef.id === WerewolfRole.Minion) {
+    const extraNames = extraWerewolfRoleNames(activeRoleIds);
+    const preWake =
+      extraNames.length > 0
+        ? `All werewolves, including ${extraNames.join(", ")}, raise your thumbs.`
+        : "All Werewolves, raise your thumbs.";
+    return {
+      preWake,
+      wakeInstruction: `Tell ${roleName} to open their eyes.`,
+      postWake: "Tell them to look around, then close their eyes.",
+    };
+  }
+
+  if (roleDef.id === WerewolfRole.Sentinel) {
+    const preWake = activeRoleIds.has(WerewolfRole.Seer)
+      ? "Tell the Seer to raise their thumb."
+      : undefined;
+    return {
+      preWake,
+      wakeInstruction: `Tell ${roleName} to open their eyes.`,
+      postWake: "Tell them to look around, then close their eyes.",
+    };
+  }
+
+  if (roleDef.id === WerewolfRole.Mason) {
+    return {
+      wakeInstruction: "Tell all Masons to open their eyes.",
+      postWake: "Tell them to find each other.",
+    };
+  }
+
+  if (roleDef.teamTargeting) {
+    return {
+      wakeInstruction: "Tell all Werewolves to open their eyes.",
+      postWake: "Tell them to find their teammates and choose a target.",
+    };
+  }
+
+  if (hasNightActivity) {
+    return {
+      wakeInstruction: `Tell ${roleName} to open their eyes.`,
+      postWake: "Tell them to look at the Narrator.",
+    };
+  }
+
+  return {
+    wakeInstruction: `Tell ${roleName} to open their eyes.`,
+  };
+}

--- a/src/lib/game/modes/werewolf/utils/narrator-instructions.ts
+++ b/src/lib/game/modes/werewolf/utils/narrator-instructions.ts
@@ -36,7 +36,7 @@ export function buildNarratorInstruction(
     const extraNames = extraWerewolfRoleNames(activeRoleIds);
     const preWake =
       extraNames.length > 0
-        ? `All werewolves, including ${extraNames.join(", ")}, raise your thumbs.`
+        ? `All Werewolves, including ${extraNames.join(", ")}, raise your thumbs.`
         : "All Werewolves, raise your thumbs.";
     return {
       preWake,


### PR DESCRIPTION
Adds narrator script instructions displayed during Night 1 for each role phase. The narrator now sees a highlighted \"Say aloud\" card telling them what to read to the table for each phase.

## Technical details

- New `buildNarratorInstruction(phaseKey, activeRoleIds)` utility in `narrator-instructions.ts` computes per-role script lines:
  - Minion: pre-wake instruction tells werewolves (including any non-Werewolf `isWerewolf` roles like Wolf Cub / Lone Wolf) to raise thumbs; includes special phrasing when multiple werewolf roles are present
  - Sentinel: pre-wake instruction tells Seer to raise thumb (omitted if no Seer in play)
  - Mason: group wake instruction to find each other
  - Werewolf group phase: group wake to find teammates and choose target
  - Roles with night activity (Investigate/Attack/Protect/Special): "look at the Narrator"
  - Roles with no night activity: basic wake instruction only
- New `NarratorNightInstruction` component renders the instruction in an amber bordered card
- `OwnerGameNightScreen` computes and displays the instruction for Night 1 only (turn 1)
- 11 unit tests covering all role categories and edge cases

Closes #231

---
*Created by Claude Sonnet 4.6*