### PR TITLE
chore: harden GameAction.isValid against null/undefined payload

### DIFF
--- a/src/lib/game/modes/avalon/actions/cast-team-vote.ts
+++ b/src/lib/game/modes/avalon/actions/cast-team-vote.ts
@@ -19,6 +19,7 @@ export const castTeamVoteAction: GameAction = {
     if (ts.phase.passed !== undefined) return false;
     if (!game.players.some((p) => p.id === callerId)) return false;
 
+    if (!payload || typeof payload !== "object") return false;
     const { vote } = payload as { vote?: unknown };
     return typeof vote === "string" && VALID_VOTES.includes(vote as TeamVote);
   },
@@ -26,6 +27,7 @@ export const castTeamVoteAction: GameAction = {
   apply(game: Game, payload: unknown, callerId: string) {
     const ts = currentTurnState(game);
     if (ts?.phase.type !== AvalonPhase.TeamVote) return;
+    if (!payload || typeof payload !== "object") return;
 
     const { vote } = payload as { vote: TeamVote };
 

--- a/src/lib/game/modes/avalon/actions/play-quest-card.ts
+++ b/src/lib/game/modes/avalon/actions/play-quest-card.ts
@@ -31,6 +31,7 @@ export const playQuestCardAction: GameAction = {
     // No replaying
     if (ts.phase.cards.some((c) => c.playerId === callerId)) return false;
 
+    if (!payload || typeof payload !== "object") return false;
     const { card } = payload as { card?: unknown };
     if (typeof card !== "string") return false;
     if (!VALID_CARDS.includes(card as QuestCard)) return false;
@@ -46,6 +47,7 @@ export const playQuestCardAction: GameAction = {
   apply(game: Game, payload: unknown, callerId: string) {
     const ts = currentTurnState(game);
     if (ts?.phase.type !== AvalonPhase.Quest) return;
+    if (!payload || typeof payload !== "object") return;
 
     const { card } = payload as { card: QuestCard };
     ts.phase.cards = [...ts.phase.cards, { playerId: callerId, card }];

--- a/src/lib/game/modes/avalon/actions/propose-team.ts
+++ b/src/lib/game/modes/avalon/actions/propose-team.ts
@@ -15,6 +15,7 @@ export const proposeTeamAction: GameAction = {
     if (ts.phase.type !== AvalonPhase.TeamProposal) return false;
     if (ts.phase.leaderId !== callerId) return false;
 
+    if (!payload || typeof payload !== "object") return false;
     const { teamPlayerIds } = payload as { teamPlayerIds?: unknown };
     if (!Array.isArray(teamPlayerIds)) return false;
     if (teamPlayerIds.length !== ts.phase.teamSize) return false;
@@ -31,6 +32,7 @@ export const proposeTeamAction: GameAction = {
   apply(game: Game, payload: unknown) {
     const ts = currentTurnState(game);
     if (ts?.phase.type !== AvalonPhase.TeamProposal) return;
+    if (!payload || typeof payload !== "object") return;
 
     const { teamPlayerIds } = payload as { teamPlayerIds: string[] };
 

--- a/src/lib/game/modes/avalon/actions/select-assassination-target.ts
+++ b/src/lib/game/modes/avalon/actions/select-assassination-target.ts
@@ -22,6 +22,7 @@ export const selectAssassinationTargetAction: GameAction = {
     // Target cannot be changed once the assassination is resolved
     if (ts.phase.correct !== undefined) return false;
 
+    if (!payload || typeof payload !== "object") return false;
     const { targetPlayerId } = payload as { targetPlayerId?: unknown };
     if (typeof targetPlayerId !== "string") return false;
     // Target must be a valid player in the game
@@ -31,6 +32,7 @@ export const selectAssassinationTargetAction: GameAction = {
   apply(game: Game, payload: unknown) {
     const ts = currentTurnState(game);
     if (ts?.phase.type !== AvalonPhase.Assassination) return;
+    if (!payload || typeof payload !== "object") return;
 
     const { targetPlayerId } = payload as { targetPlayerId: string };
     ts.phase.targetPlayerId = targetPlayerId;

--- a/src/lib/game/modes/clocktower/actions/cast-public-vote.ts
+++ b/src/lib/game/modes/clocktower/actions/cast-public-vote.ts
@@ -29,6 +29,7 @@ export const castPublicVoteAction: GameAction = {
     // Only one execution per day — no voting once resolved
     if (ts.phase.executedToday !== undefined) return false;
 
+    if (!payload || typeof payload !== "object") return false;
     const { nomineeId, voted } = payload as {
       nomineeId?: unknown;
       voted?: unknown;
@@ -67,6 +68,7 @@ export const castPublicVoteAction: GameAction = {
     const ts = currentTurnState(game);
     if (ts?.phase.type !== ClocktowerPhase.Day) return;
 
+    if (!payload || typeof payload !== "object") return;
     const { nomineeId, voted } = payload as {
       nomineeId: string;
       voted: boolean;

--- a/src/lib/game/modes/clocktower/actions/confirm-night-target.ts
+++ b/src/lib/game/modes/clocktower/actions/confirm-night-target.ts
@@ -48,6 +48,7 @@ export const confirmNightTargetAction: GameAction = {
     if (!ts) return false;
     if (ts.phase.type !== ClocktowerPhase.Night) return false;
 
+    if (!payload || typeof payload !== "object") return false;
     const { roleId } = payload as { roleId?: unknown };
 
     const activeRoleId = resolveActingRoleId(
@@ -81,6 +82,7 @@ export const confirmNightTargetAction: GameAction = {
     if (!ts) return;
     if (ts.phase.type !== ClocktowerPhase.Night) return;
 
+    if (!payload || typeof payload !== "object") return;
     const { roleId } = payload as { roleId?: string };
 
     const activeRoleId = resolveActingRoleId(game, callerId, roleId);

--- a/src/lib/game/modes/clocktower/actions/nominate-player.ts
+++ b/src/lib/game/modes/clocktower/actions/nominate-player.ts
@@ -54,6 +54,7 @@ export const nominatePlayerAction: GameAction = {
     // Each player may only nominate once per day
     if (ts.phase.nominatedByPlayerIds.includes(callerId)) return false;
 
+    if (!payload || typeof payload !== "object") return false;
     const { nomineeId } = payload as { nomineeId?: unknown };
     if (typeof nomineeId !== "string") return false;
     // Cannot nominate yourself
@@ -77,6 +78,7 @@ export const nominatePlayerAction: GameAction = {
     const ts = currentTurnState(game);
     if (ts?.phase.type !== ClocktowerPhase.Day) return;
 
+    if (!payload || typeof payload !== "object") return;
     const { nomineeId } = payload as { nomineeId: string };
 
     // Virgin ability: if Virgin is nominated for the first time by a Townsfolk,

--- a/src/lib/game/modes/clocktower/actions/provide-information.ts
+++ b/src/lib/game/modes/clocktower/actions/provide-information.ts
@@ -81,6 +81,7 @@ export const provideInformationAction: GameAction = {
     if (!ts) return false;
     if (ts.phase.type !== ClocktowerPhase.Night) return false;
 
+    if (!payload || typeof payload !== "object") return false;
     const { roleId, information } = payload as {
       roleId?: unknown;
       information?: unknown;
@@ -104,6 +105,7 @@ export const provideInformationAction: GameAction = {
     if (!ts) return;
     if (ts.phase.type !== ClocktowerPhase.Night) return;
 
+    if (!payload || typeof payload !== "object") return;
     const { roleId, information } = payload as {
       roleId: string;
       information: ClocktowerNightInformation;

--- a/src/lib/game/modes/clocktower/actions/set-night-target.ts
+++ b/src/lib/game/modes/clocktower/actions/set-night-target.ts
@@ -50,6 +50,7 @@ export const setNightTargetAction: GameAction = {
     if (!ts) return false;
     if (ts.phase.type !== ClocktowerPhase.Night) return false;
 
+    if (!payload || typeof payload !== "object") return false;
     const { roleId, targetPlayerId, secondTargetPlayerId } = payload as {
       roleId?: unknown;
       targetPlayerId?: unknown;
@@ -99,6 +100,7 @@ export const setNightTargetAction: GameAction = {
     if (!ts) return;
     if (ts.phase.type !== ClocktowerPhase.Night) return;
 
+    if (!payload || typeof payload !== "object") return;
     const { roleId, targetPlayerId, secondTargetPlayerId } = payload as {
       roleId?: string;
       targetPlayerId?: string;

--- a/src/lib/game/modes/secret-villain/actions/call-special-election.ts
+++ b/src/lib/game/modes/secret-villain/actions/call-special-election.ts
@@ -15,6 +15,7 @@ export const callSpecialElectionAction: GameAction = {
     if (ts.phase.presidentId !== callerId) return false;
     if (ts.phase.resolved) return false;
 
+    if (!payload || typeof payload !== "object") return false;
     const { targetPlayerId } = payload as { targetPlayerId?: unknown };
     if (typeof targetPlayerId !== "string") return false;
     if (targetPlayerId === callerId) return false;
@@ -26,6 +27,7 @@ export const callSpecialElectionAction: GameAction = {
     const ts = currentTurnState(game);
     if (ts?.phase.type !== SecretVillainPhase.SpecialAction) return;
 
+    if (!payload || typeof payload !== "object") return;
     const { targetPlayerId } = payload as { targetPlayerId: string };
 
     // Set the special president — getNextPresidentId will return this player

--- a/src/lib/game/modes/secret-villain/actions/cast-election-vote.ts
+++ b/src/lib/game/modes/secret-villain/actions/cast-election-vote.ts
@@ -14,6 +14,7 @@ export const castElectionVoteAction: GameAction = {
     if (ts.eliminatedPlayerIds.includes(callerId)) return false;
     if (!game.players.some((p) => p.id === callerId)) return false;
 
+    if (!payload || typeof payload !== "object") return false;
     const { vote } = payload as { vote?: unknown };
     return (
       typeof vote === "string" && VALID_VOTES.includes(vote as ElectionVote)
@@ -24,6 +25,7 @@ export const castElectionVoteAction: GameAction = {
     const ts = currentTurnState(game);
     if (ts?.phase.type !== SecretVillainPhase.ElectionVote) return;
 
+    if (!payload || typeof payload !== "object") return;
     const { vote } = payload as { vote: ElectionVote };
 
     // Replace existing vote if the player already voted, otherwise append.

--- a/src/lib/game/modes/secret-villain/actions/chancellor-play.ts
+++ b/src/lib/game/modes/secret-villain/actions/chancellor-play.ts
@@ -18,6 +18,7 @@ export const chancellorPlayAction: GameAction = {
     if (ts.phase.chancellorId !== callerId) return false;
     if (ts.phase.playedCard !== undefined) return false;
 
+    if (!payload || typeof payload !== "object") return false;
     const { cardIndex } = payload as { cardIndex?: unknown };
     if (typeof cardIndex !== "number") return false;
     return cardIndex >= 0 && cardIndex < 2;
@@ -28,6 +29,7 @@ export const chancellorPlayAction: GameAction = {
     if (ts?.phase.type !== SecretVillainPhase.PolicyChancellor) return;
     if (ts.phase.chancellorId !== callerId) return;
 
+    if (!payload || typeof payload !== "object") return;
     const { cardIndex } = payload as { cardIndex: number };
     const remainingCards = [...ts.phase.remainingCards];
     const [played] = remainingCards.splice(cardIndex, 1);

--- a/src/lib/game/modes/secret-villain/actions/investigate-player.ts
+++ b/src/lib/game/modes/secret-villain/actions/investigate-player.ts
@@ -18,6 +18,7 @@ export const selectInvestigationTargetAction: GameAction = {
     if (ts.phase.presidentId !== callerId) return false;
     if (ts.phase.targetPlayerId !== undefined) return false;
 
+    if (!payload || typeof payload !== "object") return false;
     const { targetPlayerId } = payload as { targetPlayerId?: unknown };
     if (typeof targetPlayerId !== "string") return false;
     if (targetPlayerId === callerId) return false;
@@ -29,6 +30,7 @@ export const selectInvestigationTargetAction: GameAction = {
     const ts = currentTurnState(game);
     if (ts?.phase.type !== SecretVillainPhase.SpecialAction) return;
 
+    if (!payload || typeof payload !== "object") return;
     const { targetPlayerId } = payload as { targetPlayerId: string };
     ts.phase.targetPlayerId = targetPlayerId;
   },

--- a/src/lib/game/modes/secret-villain/actions/nominate-chancellor.ts
+++ b/src/lib/game/modes/secret-villain/actions/nominate-chancellor.ts
@@ -9,6 +9,7 @@ export const nominateChancellorAction: GameAction = {
     if (ts.phase.type !== SecretVillainPhase.ElectionNomination) return false;
     if (ts.phase.presidentId !== callerId) return false;
 
+    if (!payload || typeof payload !== "object") return false;
     const { chancellorId } = payload as { chancellorId?: unknown };
     if (typeof chancellorId !== "string") return false;
 
@@ -20,6 +21,7 @@ export const nominateChancellorAction: GameAction = {
     const ts = currentTurnState(game);
     if (ts?.phase.type !== SecretVillainPhase.ElectionNomination) return;
 
+    if (!payload || typeof payload !== "object") return;
     const { chancellorId } = payload as { chancellorId: string };
 
     ts.phase = {

--- a/src/lib/game/modes/secret-villain/actions/president-discard.ts
+++ b/src/lib/game/modes/secret-villain/actions/president-discard.ts
@@ -10,6 +10,7 @@ export const presidentDiscardAction: GameAction = {
     if (ts.phase.presidentId !== callerId) return false;
     if (ts.phase.discardedCard !== undefined) return false;
 
+    if (!payload || typeof payload !== "object") return false;
     const { cardIndex } = payload as { cardIndex?: unknown };
     if (typeof cardIndex !== "number") return false;
     return cardIndex >= 0 && cardIndex < 3;
@@ -20,6 +21,7 @@ export const presidentDiscardAction: GameAction = {
     if (ts?.phase.type !== SecretVillainPhase.PolicyPresident) return;
     if (ts.phase.presidentId !== callerId) return;
 
+    if (!payload || typeof payload !== "object") return;
     const { cardIndex } = payload as { cardIndex: number };
     const drawnCards = [...ts.phase.drawnCards];
     const [discarded] = drawnCards.splice(cardIndex, 1);

--- a/src/lib/game/modes/secret-villain/actions/shoot-player.ts
+++ b/src/lib/game/modes/secret-villain/actions/shoot-player.ts
@@ -21,6 +21,7 @@ export const shootPlayerAction: GameAction = {
     if (ts.phase.presidentId !== callerId) return false;
     if (ts.phase.resolved) return false;
 
+    if (!payload || typeof payload !== "object") return false;
     const { targetPlayerId } = payload as { targetPlayerId?: unknown };
     if (typeof targetPlayerId !== "string") return false;
     if (targetPlayerId === callerId) return false;
@@ -31,6 +32,7 @@ export const shootPlayerAction: GameAction = {
   apply(game: Game, payload: unknown) {
     const ts = currentTurnState(game);
     if (ts?.phase.type !== SecretVillainPhase.SpecialAction) return;
+    if (!payload || typeof payload !== "object") return;
 
     const { targetPlayerId } = payload as { targetPlayerId: string };
     ts.eliminatedPlayerIds = [...ts.eliminatedPlayerIds, targetPlayerId];

--- a/src/lib/game/modes/secret-villain/actions/veto.ts
+++ b/src/lib/game/modes/secret-villain/actions/veto.ts
@@ -40,6 +40,7 @@ export const respondVetoAction: GameAction = {
     if (!ts.phase.vetoProposed) return false;
     if (ts.phase.vetoResponse !== undefined) return false;
 
+    if (!payload || typeof payload !== "object") return false;
     const { consent } = payload as { consent?: unknown };
     return typeof consent === "boolean";
   },
@@ -48,6 +49,7 @@ export const respondVetoAction: GameAction = {
     const ts = currentTurnState(game);
     if (ts?.phase.type !== SecretVillainPhase.PolicyChancellor) return;
 
+    if (!payload || typeof payload !== "object") return;
     const { consent } = payload as { consent: boolean };
     ts.phase.vetoResponse = consent;
 

--- a/src/lib/game/modes/werewolf/actions/cast-vote.ts
+++ b/src/lib/game/modes/werewolf/actions/cast-vote.ts
@@ -31,6 +31,7 @@ export const castVoteAction: GameAction = {
     if (silencedIds.includes(callerId)) return false;
     // Hypnotized players cannot vote manually (their vote follows the Mummy)
     if (getHypnotizedPlayerId(ts) === callerId) return false;
+    if (!payload || typeof payload !== "object") return false;
     const { vote } = payload as { vote?: unknown };
     if (typeof vote !== "string" || !VALID_VOTES.includes(vote as DaytimeVote))
       return false;
@@ -60,6 +61,7 @@ export const castVoteAction: GameAction = {
     if (ts?.phase.type !== WerewolfPhase.Daytime) return;
     const { activeTrial } = ts.phase;
     if (!activeTrial) return;
+    if (!payload || typeof payload !== "object") return;
     const { vote } = payload as { vote: DaytimeVote };
     activeTrial.votes = [
       ...activeTrial.votes.filter((v) => v.playerId !== callerId),

--- a/src/lib/game/modes/werewolf/actions/kill-player.ts
+++ b/src/lib/game/modes/werewolf/actions/kill-player.ts
@@ -9,6 +9,7 @@ export const killPlayerAction: GameAction = {
     const ts = currentTurnState(game);
     if (!ts) return false;
     if (ts.phase.type !== WerewolfPhase.Daytime) return false;
+    if (!payload || typeof payload !== "object") return false;
     const { playerId } = payload as { playerId?: unknown };
     if (typeof playerId !== "string") return false;
     if (playerId === game.ownerPlayerId) return false;
@@ -18,6 +19,7 @@ export const killPlayerAction: GameAction = {
   apply(game: Game, payload: unknown) {
     const ts = currentTurnState(game);
     if (!ts) return;
+    if (!payload || typeof payload !== "object") return;
     const { playerId } = payload as { playerId: string };
     ts.deadPlayerIds = [...ts.deadPlayerIds, playerId];
     if (didWolfCubDie([playerId], game)) {

--- a/src/lib/game/modes/werewolf/actions/mark-player.ts
+++ b/src/lib/game/modes/werewolf/actions/mark-player.ts
@@ -7,6 +7,7 @@ export const markPlayerDeadAction: GameAction = {
     if (!isOwnerPlaying(game, callerId)) return false;
     const ts = currentTurnState(game);
     if (!ts) return false;
+    if (!payload || typeof payload !== "object") return false;
     const { playerId } = payload as { playerId?: unknown };
     if (typeof playerId !== "string") return false;
     if (playerId === game.ownerPlayerId) return false;
@@ -16,6 +17,7 @@ export const markPlayerDeadAction: GameAction = {
   apply(game: Game, payload: unknown) {
     const ts = currentTurnState(game);
     if (!ts) return;
+    if (!payload || typeof payload !== "object") return;
     const { playerId } = payload as { playerId: string };
     ts.deadPlayerIds = [...ts.deadPlayerIds, playerId];
     if (didWolfCubDie([playerId], game)) {
@@ -29,6 +31,7 @@ export const markPlayerAliveAction: GameAction = {
     if (!isOwnerPlaying(game, callerId)) return false;
     const ts = currentTurnState(game);
     if (!ts) return false;
+    if (!payload || typeof payload !== "object") return false;
     const { playerId } = payload as { playerId?: unknown };
     if (typeof playerId !== "string") return false;
     return ts.deadPlayerIds.includes(playerId);
@@ -36,6 +39,7 @@ export const markPlayerAliveAction: GameAction = {
   apply(game: Game, payload: unknown) {
     const ts = currentTurnState(game);
     if (!ts) return;
+    if (!payload || typeof payload !== "object") return;
     const { playerId } = payload as { playerId: string };
     ts.deadPlayerIds = ts.deadPlayerIds.filter((id) => id !== playerId);
   },

--- a/src/lib/game/modes/werewolf/actions/nominate-player.ts
+++ b/src/lib/game/modes/werewolf/actions/nominate-player.ts
@@ -26,6 +26,7 @@ export const nominatePlayerAction: GameAction = {
     // Silenced players cannot nominate
     const silencedIds = getSilencedPlayerIds(ts);
     if (silencedIds.includes(callerId)) return false;
+    if (!payload || typeof payload !== "object") return false;
     const { defendantId } = payload as { defendantId?: unknown };
     if (typeof defendantId !== "string") return false;
     // Cannot nominate yourself, the owner, or a dead player
@@ -42,6 +43,7 @@ export const nominatePlayerAction: GameAction = {
   apply(game: Game, payload: unknown, callerId: string) {
     const ts = currentTurnState(game);
     if (ts?.phase.type !== WerewolfPhase.Daytime) return;
+    if (!payload || typeof payload !== "object") return;
     const { defendantId } = payload as { defendantId: string };
 
     // Remove any prior nomination by this caller

--- a/src/lib/game/modes/werewolf/actions/reset-ability.ts
+++ b/src/lib/game/modes/werewolf/actions/reset-ability.ts
@@ -14,6 +14,7 @@ export const resetAbilityAction: GameAction = {
     if (!isOwnerPlaying(game, callerId)) return false;
     const ts = currentTurnState(game);
     if (!ts) return false;
+    if (!payload || typeof payload !== "object") return false;
     const { roleId } = payload as { roleId?: unknown };
     if (typeof roleId !== "string") return false;
     return roleId in RESETTABLE_ABILITIES;
@@ -21,6 +22,7 @@ export const resetAbilityAction: GameAction = {
   apply(game: Game, payload: unknown) {
     const ts = currentTurnState(game);
     if (!ts) return;
+    if (!payload || typeof payload !== "object") return;
     const { roleId } = payload as { roleId: string };
     const flagKey = RESETTABLE_ABILITIES[roleId];
     if (flagKey) {

--- a/src/lib/game/modes/werewolf/actions/resolve-hunter-revenge.ts
+++ b/src/lib/game/modes/werewolf/actions/resolve-hunter-revenge.ts
@@ -10,6 +10,7 @@ export const resolveHunterRevengeAction: GameAction = {
     if (!ts) return false;
     if (ts.phase.type !== WerewolfPhase.Daytime) return false;
     if (!ts.hunterRevengePlayerId) return false;
+    if (!payload || typeof payload !== "object") return false;
     const { targetPlayerId } = payload as { targetPlayerId?: unknown };
     if (typeof targetPlayerId !== "string") return false;
     return !ts.deadPlayerIds.includes(targetPlayerId);
@@ -17,6 +18,7 @@ export const resolveHunterRevengeAction: GameAction = {
   apply(game: Game, payload: unknown) {
     const ts = currentTurnState(game);
     if (!ts) return;
+    if (!payload || typeof payload !== "object") return;
 
     const { targetPlayerId } = payload as { targetPlayerId: string };
     ts.deadPlayerIds = [...ts.deadPlayerIds, targetPlayerId];

--- a/src/lib/game/modes/werewolf/actions/set-night-phase.ts
+++ b/src/lib/game/modes/werewolf/actions/set-night-phase.ts
@@ -9,6 +9,7 @@ export const setNightPhaseAction: GameAction = {
     if (!isOwnerPlaying(game, callerId)) return false;
     const ts = currentTurnState(game);
     if (ts?.phase.type !== WerewolfPhase.Nighttime) return false;
+    if (!payload || typeof payload !== "object") return false;
     const { phaseIndex } = payload as { phaseIndex?: unknown };
     return (
       typeof phaseIndex === "number" &&
@@ -19,6 +20,7 @@ export const setNightPhaseAction: GameAction = {
   apply(game: Game, payload: unknown) {
     const ts = currentTurnState(game);
     if (!ts) return;
+    if (!payload || typeof payload !== "object") return;
     const { phaseIndex } = payload as { phaseIndex: number };
     const phase = ts.phase as WerewolfNighttimePhase;
     game.status = {

--- a/src/lib/game/modes/werewolf/actions/set-night-target.ts
+++ b/src/lib/game/modes/werewolf/actions/set-night-target.ts
@@ -22,6 +22,7 @@ export const setNightTargetAction: GameAction = {
     if (ts.turn <= 1) return false;
 
     const phase = ts.phase;
+    if (!payload || typeof payload !== "object") return false;
     const { roleId: explicitPhaseKey, targetPlayerId } = payload as {
       roleId?: unknown;
       targetPlayerId?: unknown;
@@ -159,6 +160,7 @@ export const setNightTargetAction: GameAction = {
     if (ts?.phase.type !== WerewolfPhase.Nighttime) return;
 
     const phase = ts.phase;
+    if (!payload || typeof payload !== "object") return;
     const {
       roleId: explicitPhaseKey,
       targetPlayerId,

--- a/src/lib/game/modes/werewolf/actions/smite-player.ts
+++ b/src/lib/game/modes/werewolf/actions/smite-player.ts
@@ -7,6 +7,7 @@ export const smitePlayerAction: GameAction = {
     if (!isOwnerPlaying(game, callerId)) return false;
     const ts = currentTurnState(game);
     if (!ts) return false;
+    if (!payload || typeof payload !== "object") return false;
     const { playerId } = payload as { playerId?: unknown };
     if (typeof playerId !== "string") return false;
     if (playerId === game.ownerPlayerId) return false;
@@ -27,6 +28,7 @@ export const smitePlayerAction: GameAction = {
   apply(game: Game, payload: unknown) {
     const ts = currentTurnState(game);
     if (!ts) return;
+    if (!payload || typeof payload !== "object") return;
     const { playerId } = payload as { playerId: string };
     switch (ts.phase.type) {
       case WerewolfPhase.Nighttime:

--- a/src/lib/game/modes/werewolf/actions/start-trial.ts
+++ b/src/lib/game/modes/werewolf/actions/start-trial.ts
@@ -23,6 +23,7 @@ export const startTrialAction: GameAction = {
       (ts.phase.concludedTrialsCount ?? 0) >= trialsPerDay
     )
       return false;
+    if (!payload || typeof payload !== "object") return false;
     const { defendantId } = payload as { defendantId?: unknown };
     if (typeof defendantId !== "string") return false;
     if (defendantId === game.ownerPlayerId) return false;
@@ -32,6 +33,7 @@ export const startTrialAction: GameAction = {
   apply(game: Game, payload: unknown) {
     const ts = currentTurnState(game);
     if (ts?.phase.type !== WerewolfPhase.Daytime) return;
+    if (!payload || typeof payload !== "object") return;
     const { defendantId } = payload as { defendantId: string };
     const silencedIds = getSilencedPlayerIds(ts);
     const hypnotizedId = getHypnotizedPlayerId(ts);

--- a/src/lib/game/modes/werewolf/actions/unsmite-player.ts
+++ b/src/lib/game/modes/werewolf/actions/unsmite-player.ts
@@ -7,6 +7,7 @@ export const unsmitePlayerAction: GameAction = {
     if (!isOwnerPlaying(game, callerId)) return false;
     const ts = currentTurnState(game);
     if (!ts) return false;
+    if (!payload || typeof payload !== "object") return false;
     const { playerId } = payload as { playerId?: unknown };
     if (typeof playerId !== "string") return false;
     switch (ts.phase.type) {
@@ -21,6 +22,7 @@ export const unsmitePlayerAction: GameAction = {
   apply(game: Game, payload: unknown) {
     const ts = currentTurnState(game);
     if (!ts) return;
+    if (!payload || typeof payload !== "object") return;
     const { playerId } = payload as { playerId: string };
     switch (ts.phase.type) {
       case WerewolfPhase.Nighttime:


### PR DESCRIPTION
Add a defensive shape check (`if (!payload || typeof payload !== "object") return false`) before every `payload as { ... }` destructure in `GameAction.isValid` and `apply`. Without this guard, an API request with a missing or non-object payload would throw a `TypeError` at the destructuring site rather than returning a safe `false`.

28 action files across all three game modes (Avalon, Clocktower, Secret Villain, Werewolf) were updated. Only actions that actually destructure `payload` were touched; no-payload actions are unchanged.

Closes #570

---
*Created by Claude Sonnet 4.6*