### PR TITLE
chore(werewolf): switch WerewolfRole to append-only ordering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ pnpm run secrets-check # Gitleaks secret scan (runs in pre-commit)
 - **No IIFEs.** Do not use immediately-invoked function expressions. Extract the logic into a named helper function or compute the value with a plain expression instead.
 - **No function-style imports.** Do not use inline `import("…").Type` syntax in type annotations. Use module-level `import type { … } from "…"` statements at the top of the file. Dynamic `await import("…")` for services that require conditional loading (e.g., Sentry instrumentation) is acceptable.
 - **No unnecessary helpers.** Do not extract logic into a helper function unless it separates significant logic or belongs in a different module. Three similar lines is better than a premature abstraction.
-- **Enums and constant objects** should be kept in alphabetical order to minimize merge conflicts.
+- **Enums and constant objects** should be kept in alphabetical order to minimize merge conflicts, **with the exception of high-churn enums** (e.g. `WerewolfRole`) which use append-only ordering for the same reason — alphabetical insertion causes merge conflicts when two role PRs target the same window. High-churn enums carry a comment marking them append-only.
 - **Prefer enums over string literal unions** for any domain concept with two or more named states (e.g., use `enum TrialPhase { Defense = "defense", Voting = "voting" }` rather than `"defense" | "voting"`). String enum values must match the current serialized schema (keep code and literals in sync); do not add compatibility shims for old serialized values. Export new enums from the module barrel.
 
 ## User-Facing Text

--- a/src/lib/game/modes/werewolf/roles.ts
+++ b/src/lib/game/modes/werewolf/roles.ts
@@ -41,6 +41,9 @@ export const WEREWOLF_ROLE_CATEGORY_LABELS: Record<
   [WerewolfRoleCategory.VillagerHandicap]: "Villager — Handicap",
 };
 
+// Append-only: add new roles at the end of this enum to avoid merge conflicts.
+// Two role PRs inserting into the same alphabetical window will collide;
+// appending avoids that class of conflict entirely (string values are stable serially).
 export enum WerewolfRole {
   Altruist = "werewolf-altruist",
   Arsonist = "werewolf-arsonist",


### PR DESCRIPTION
Adds an append-only convention for `WerewolfRole` and documents it in CLAUDE.md. Alphabetical insertion into this high-churn enum causes merge conflicts whenever two role PRs target the same alphabetical window — switching to append-only eliminates that class of conflict entirely since string literal values are stable regardless of declaration order.

No code behavior changes; TypeScript enum string values are unaffected by declaration order.

## Acceptance Criteria
- [x] `WerewolfRole` enum has a comment marking it append-only
- [x] `CLAUDE.md` / `AGENTS.md` document the append-only exception for high-churn enums
- [x] No behavior changes
- [x] All tests pass, lint/format/typecheck clean

## Tests
No new tests — pure structural/documentation change. All 1901 existing tests pass.

Closes #637

---
*Created by Claude Sonnet 4.6*