### PR TITLE
refactor(werewolf): namespace WerewolfTurnState per role and extract per-role Firebase serialization

### DIFF
--- a/docs/werewolf/data-flow.md
+++ b/docs/werewolf/data-flow.md
@@ -251,11 +251,11 @@ The Witch sees `nightStatus` with `effect: "attacked"` entries **only** when her
 
 ## Wolf Cub Special Case
 
-When the Wolf Cub is killed (via `start-day` resolution or `mark-player-dead`), `wolfCubDied: true` is set on `WerewolfTurnState`. The next time `start-night` is called, an extra Werewolf group phase with key `"werewolf-werewolf:2"` is appended to `nightPhaseOrder`, giving Werewolves two separate attack phases that night.
+When the Wolf Cub is killed (via `start-day` resolution or `mark-player-dead`), `roleState.wolfCub.died: true` is set on `WerewolfTurnState`. The next time `start-night` is called, an extra Werewolf group phase with key `"werewolf-werewolf:2"` is appended to `nightPhaseOrder`, giving Werewolves two separate attack phases that night.
 
 The second phase cannot target the same player that was the `suggestedTargetId` of the first phase (within-night exclusion). This is distinct from the cross-night `preventRepeatTarget` mechanism used by Bodyguard and Spellcaster, which prevents targeting the same player on consecutive nights (tracked via `lastTargets` in `WerewolfTurnState`).
 
-The `wolfCubDied` flag is cleared when `start-night` consumes it to generate the bonus phase.
+The `roleState.wolfCub.died` flag is cleared when `start-night` consumes it to generate the bonus phase.
 
 ## Old Man Timer
 

--- a/src/components/game/werewolf/OwnerGameNightScreen.tsx
+++ b/src/components/game/werewolf/OwnerGameNightScreen.tsx
@@ -155,7 +155,7 @@ export function OwnerGameNightScreen({
     : activeTargetConfirmed;
   const isWitchAbilitySkipped =
     isRoleActive(activePhaseKey, WerewolfRole.Witch) &&
-    turnState.witchAbilityUsed;
+    turnState.roleState?.witch?.abilityUsed;
 
   const activeRoleDef = modeConfig.roles[baseActivePhaseKey] as
     | WerewolfRoleDefinition
@@ -196,7 +196,7 @@ export function OwnerGameNightScreen({
     secondTargetName,
   );
 
-  const exposerRevealData = turnState.exposerReveal;
+  const exposerRevealData = turnState.roleState?.exposer?.reveal;
   const exposerRevealText = exposerRevealData
     ? WEREWOLF_COPY.narrator.exposerRevealLabel(
         getPlayerName(gameState.players, exposerRevealData.playerId) ??
@@ -325,7 +325,7 @@ export function OwnerGameNightScreen({
           )}
           {isRoleActive(activePhaseKey, WerewolfRole.Mirrorcaster) && (
             <p className="mb-3 text-sm text-muted-foreground italic">
-              {turnState.mirrorcasterCharged
+              {turnState.roleState?.mirrorcaster?.charged
                 ? WEREWOLF_COPY.mirrorcaster.narratorAttackMode
                 : WEREWOLF_COPY.mirrorcaster.narratorProtectMode}
             </p>

--- a/src/lib/firebase/schema/player-state/werewolf-roles.ts
+++ b/src/lib/firebase/schema/player-state/werewolf-roles.ts
@@ -1,0 +1,145 @@
+import type { Team } from "@/lib/types";
+import type { WerewolfPlayerGameState } from "@/lib/game/modes/werewolf/player-state";
+
+// ---------------------------------------------------------------------------
+// Role-specific Firebase player state
+// ---------------------------------------------------------------------------
+
+/**
+ * Firebase wire-format fields for role-specific Werewolf player state.
+ * Consumed by werewolfStateToFirebase / werewolfStateFromFirebase via delegation.
+ * Adding a new role adds fields only to this interface and the two helpers below.
+ */
+export interface FirebaseWerewolfRoleState {
+  witchAbilityUsed?: boolean;
+  morticianAbilityEnded?: boolean;
+  monarchKnightedPlayerIds?: string[];
+  monarchKnightingsUsed?: number;
+  priestWardActive?: boolean;
+  isSilenced?: boolean;
+  isHypnotized?: boolean;
+  executionerTargetId?: string;
+  mirrorcasterCharged?: boolean;
+  oneEyedSeerLockedTargetId?: string;
+  elusiveSeerVillagerIds?: string[];
+  illuminatiRoleAssignments?: {
+    playerId: string;
+    roleName: string;
+    team: string;
+  }[];
+  exposerReveal?: { playerName: string; roleName: string; team: string };
+  mySecondNightTarget?: string;
+  exposerAbilityUsed?: boolean;
+  hunterRevengePlayerId?: string;
+  hiddenRoleIds?: string[];
+  arsonistDousedPlayerIds?: string[];
+  pendingSmitePlayerIds?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Converters
+// ---------------------------------------------------------------------------
+
+export function werewolfRoleStateToFirebase(
+  state: WerewolfPlayerGameState,
+): FirebaseWerewolfRoleState {
+  const monarchKnightingsUsed = state.monarchKnightingsUsed;
+  return {
+    ...(state.witchAbilityUsed ? { witchAbilityUsed: true } : {}),
+    ...(state.morticianAbilityEnded ? { morticianAbilityEnded: true } : {}),
+    ...(state.monarchKnightedPlayerIds?.length
+      ? { monarchKnightedPlayerIds: state.monarchKnightedPlayerIds }
+      : {}),
+    ...((monarchKnightingsUsed ?? 0) > 0 ? { monarchKnightingsUsed } : {}),
+    ...(state.priestWardActive ? { priestWardActive: true } : {}),
+    ...(state.isSilenced ? { isSilenced: true } : {}),
+    ...(state.isHypnotized ? { isHypnotized: true } : {}),
+    ...(state.executionerTargetId
+      ? { executionerTargetId: state.executionerTargetId }
+      : {}),
+    ...(state.mirrorcasterCharged ? { mirrorcasterCharged: true } : {}),
+    ...(state.oneEyedSeerLockedTargetId
+      ? { oneEyedSeerLockedTargetId: state.oneEyedSeerLockedTargetId }
+      : {}),
+    ...(state.elusiveSeerVillagerIds?.length
+      ? { elusiveSeerVillagerIds: state.elusiveSeerVillagerIds }
+      : {}),
+    ...(state.illuminatiRoleAssignments?.length
+      ? { illuminatiRoleAssignments: state.illuminatiRoleAssignments }
+      : {}),
+    ...(state.exposerReveal ? { exposerReveal: state.exposerReveal } : {}),
+    ...(state.mySecondNightTarget
+      ? { mySecondNightTarget: state.mySecondNightTarget }
+      : {}),
+    ...(state.exposerAbilityUsed ? { exposerAbilityUsed: true } : {}),
+    ...(state.hunterRevengePlayerId
+      ? { hunterRevengePlayerId: state.hunterRevengePlayerId }
+      : {}),
+    ...(state.hiddenRoleIds?.length
+      ? { hiddenRoleIds: state.hiddenRoleIds }
+      : {}),
+    ...(state.arsonistDousedPlayerIds?.length
+      ? { arsonistDousedPlayerIds: state.arsonistDousedPlayerIds }
+      : {}),
+    ...(state.pendingSmitePlayerIds?.length
+      ? { pendingSmitePlayerIds: state.pendingSmitePlayerIds }
+      : {}),
+  };
+}
+
+export function werewolfRoleStateFromFirebase(
+  raw: FirebaseWerewolfRoleState,
+): Partial<WerewolfPlayerGameState> {
+  const monarchKnightingsUsed = raw.monarchKnightingsUsed;
+  return {
+    ...(raw.witchAbilityUsed ? { witchAbilityUsed: true } : {}),
+    ...(raw.morticianAbilityEnded ? { morticianAbilityEnded: true } : {}),
+    ...(raw.monarchKnightedPlayerIds?.length
+      ? { monarchKnightedPlayerIds: raw.monarchKnightedPlayerIds }
+      : {}),
+    ...((monarchKnightingsUsed ?? 0) > 0 ? { monarchKnightingsUsed } : {}),
+    ...(raw.priestWardActive ? { priestWardActive: true } : {}),
+    ...(raw.isSilenced ? { isSilenced: true } : {}),
+    ...(raw.isHypnotized ? { isHypnotized: true } : {}),
+    ...(raw.executionerTargetId
+      ? { executionerTargetId: raw.executionerTargetId }
+      : {}),
+    ...(raw.mirrorcasterCharged ? { mirrorcasterCharged: true } : {}),
+    ...(raw.oneEyedSeerLockedTargetId
+      ? { oneEyedSeerLockedTargetId: raw.oneEyedSeerLockedTargetId }
+      : {}),
+    ...(raw.elusiveSeerVillagerIds?.length
+      ? { elusiveSeerVillagerIds: raw.elusiveSeerVillagerIds }
+      : {}),
+    ...(raw.illuminatiRoleAssignments?.length
+      ? {
+          illuminatiRoleAssignments: raw.illuminatiRoleAssignments.map((a) => ({
+            ...a,
+            team: a.team as Team,
+          })),
+        }
+      : {}),
+    ...(raw.exposerReveal
+      ? {
+          exposerReveal: {
+            ...raw.exposerReveal,
+            team: raw.exposerReveal.team as Team,
+          },
+        }
+      : {}),
+    ...(raw.mySecondNightTarget
+      ? { mySecondNightTarget: raw.mySecondNightTarget }
+      : {}),
+    ...(raw.exposerAbilityUsed ? { exposerAbilityUsed: true } : {}),
+    ...(raw.hunterRevengePlayerId
+      ? { hunterRevengePlayerId: raw.hunterRevengePlayerId }
+      : {}),
+    ...(raw.hiddenRoleIds?.length ? { hiddenRoleIds: raw.hiddenRoleIds } : {}),
+    ...(raw.arsonistDousedPlayerIds?.length
+      ? { arsonistDousedPlayerIds: raw.arsonistDousedPlayerIds }
+      : {}),
+    ...(raw.pendingSmitePlayerIds?.length
+      ? { pendingSmitePlayerIds: raw.pendingSmitePlayerIds }
+      : {}),
+  };
+}

--- a/src/lib/firebase/schema/player-state/werewolf.ts
+++ b/src/lib/firebase/schema/player-state/werewolf.ts
@@ -1,5 +1,4 @@
 import { GameMode } from "@/lib/types";
-import type { Team } from "@/lib/types";
 import type { AnyNightAction, DaytimeVote } from "@/lib/game/modes/werewolf";
 import { TrialVerdict } from "@/lib/game/modes/werewolf";
 import type { NightStatusEntry } from "@/server/types";
@@ -9,12 +8,18 @@ import {
   baseStateToFirebase,
   baseStateFromFirebase,
 } from "./base";
+import {
+  type FirebaseWerewolfRoleState,
+  werewolfRoleStateToFirebase,
+  werewolfRoleStateFromFirebase,
+} from "./werewolf-roles";
 
 // ---------------------------------------------------------------------------
 // Werewolf-specific Firebase player state
 // ---------------------------------------------------------------------------
 
-export interface FirebaseWerewolfPlayerState extends FirebaseBasePlayerState {
+export interface FirebaseWerewolfPlayerState
+  extends FirebaseBasePlayerState, FirebaseWerewolfRoleState {
   nightActions?: Record<string, AnyNightAction>;
   myNightTarget?: string;
   /** True when the player has intentionally chosen to skip their night action. */
@@ -29,13 +34,6 @@ export interface FirebaseWerewolfPlayerState extends FirebaseBasePlayerState {
   nightStatus?: NightStatusEntry[];
   previousNightTargetId?: string;
   investigationResult?: { targetPlayerId: string; isWerewolfTeam: boolean };
-  witchAbilityUsed?: boolean;
-  morticianAbilityEnded?: boolean;
-  monarchKnightedPlayerIds?: string[];
-  monarchKnightingsUsed?: number;
-  priestWardActive?: boolean;
-  isSilenced?: boolean;
-  isHypnotized?: boolean;
   activeTrial?: {
     defendantId: string;
     startedAt: number;
@@ -57,26 +55,8 @@ export interface FirebaseWerewolfPlayerState extends FirebaseBasePlayerState {
   concludedTrialsCount?: number;
   revealProtections: boolean;
   autoRevealNightOutcome?: boolean;
-  executionerTargetId?: string;
   nominations?: { defendantId: string; nominatorIds: string[] }[];
   myNominatedDefendantId?: string;
-  pendingSmitePlayerIds?: string[];
-  mirrorcasterCharged?: boolean;
-  oneEyedSeerLockedTargetId?: string;
-  elusiveSeerVillagerIds?: string[];
-  illuminatiRoleAssignments?: {
-    playerId: string;
-    roleName: string;
-    team: string;
-  }[];
-  exposerReveal?: { playerName: string; roleName: string; team: string };
-  mySecondNightTarget?: string;
-  exposerAbilityUsed?: boolean;
-  hunterRevengePlayerId?: string;
-  /** Narrator-only hidden role IDs. Present only when hiddenRoleCount > 0. */
-  hiddenRoleIds?: string[];
-  /** Arsonist: player IDs that have been doused. */
-  arsonistDousedPlayerIds?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -86,7 +66,6 @@ export interface FirebaseWerewolfPlayerState extends FirebaseBasePlayerState {
 export function werewolfStateToFirebase(
   state: WerewolfPlayerGameState,
 ): FirebaseWerewolfPlayerState {
-  const monarchKnightingsUsed = state.monarchKnightingsUsed;
   return {
     ...baseStateToFirebase(state),
     ...(state.nightActions ? { nightActions: state.nightActions } : {}),
@@ -110,15 +89,6 @@ export function werewolfStateToFirebase(
     ...(state.investigationResult
       ? { investigationResult: state.investigationResult }
       : {}),
-    ...(state.witchAbilityUsed ? { witchAbilityUsed: true } : {}),
-    ...(state.morticianAbilityEnded ? { morticianAbilityEnded: true } : {}),
-    ...(state.monarchKnightedPlayerIds?.length
-      ? { monarchKnightedPlayerIds: state.monarchKnightedPlayerIds }
-      : {}),
-    ...((monarchKnightingsUsed ?? 0) > 0 ? { monarchKnightingsUsed } : {}),
-    ...(state.priestWardActive ? { priestWardActive: true } : {}),
-    ...(state.isSilenced ? { isSilenced: true } : {}),
-    ...(state.isHypnotized ? { isHypnotized: true } : {}),
     ...(state.activeTrial ? { activeTrial: state.activeTrial } : {}),
     nominationsEnabled: state.nominationsEnabled,
     ...(state.trialsPerDay !== undefined
@@ -129,47 +99,17 @@ export function werewolfStateToFirebase(
       : {}),
     revealProtections: state.revealProtections,
     autoRevealNightOutcome: state.autoRevealNightOutcome,
-    ...(state.executionerTargetId
-      ? { executionerTargetId: state.executionerTargetId }
-      : {}),
     ...(state.nominations?.length ? { nominations: state.nominations } : {}),
     ...(state.myNominatedDefendantId
       ? { myNominatedDefendantId: state.myNominatedDefendantId }
       : {}),
-    ...(state.pendingSmitePlayerIds?.length
-      ? { pendingSmitePlayerIds: state.pendingSmitePlayerIds }
-      : {}),
-    ...(state.mirrorcasterCharged ? { mirrorcasterCharged: true } : {}),
-    ...(state.oneEyedSeerLockedTargetId
-      ? { oneEyedSeerLockedTargetId: state.oneEyedSeerLockedTargetId }
-      : {}),
-    ...(state.elusiveSeerVillagerIds?.length
-      ? { elusiveSeerVillagerIds: state.elusiveSeerVillagerIds }
-      : {}),
-    ...(state.illuminatiRoleAssignments?.length
-      ? { illuminatiRoleAssignments: state.illuminatiRoleAssignments }
-      : {}),
-    ...(state.exposerReveal ? { exposerReveal: state.exposerReveal } : {}),
-    ...(state.mySecondNightTarget
-      ? { mySecondNightTarget: state.mySecondNightTarget }
-      : {}),
-    ...(state.exposerAbilityUsed ? { exposerAbilityUsed: true } : {}),
-    ...(state.hunterRevengePlayerId
-      ? { hunterRevengePlayerId: state.hunterRevengePlayerId }
-      : {}),
-    ...(state.hiddenRoleIds?.length
-      ? { hiddenRoleIds: state.hiddenRoleIds }
-      : {}),
-    ...(state.arsonistDousedPlayerIds?.length
-      ? { arsonistDousedPlayerIds: state.arsonistDousedPlayerIds }
-      : {}),
+    ...werewolfRoleStateToFirebase(state),
   };
 }
 
 export function werewolfStateFromFirebase(
   raw: FirebaseWerewolfPlayerState,
 ): WerewolfPlayerGameState {
-  const monarchKnightingsUsed = raw.monarchKnightingsUsed;
   return {
     ...baseStateFromFirebase(raw),
     gameMode: GameMode.Werewolf,
@@ -203,64 +143,16 @@ export function werewolfStateFromFirebase(
     ...(raw.investigationResult
       ? { investigationResult: raw.investigationResult }
       : {}),
-    ...(raw.witchAbilityUsed ? { witchAbilityUsed: true } : {}),
-    ...(raw.morticianAbilityEnded ? { morticianAbilityEnded: true } : {}),
-    ...(raw.monarchKnightedPlayerIds?.length
-      ? { monarchKnightedPlayerIds: raw.monarchKnightedPlayerIds }
-      : {}),
-    ...((monarchKnightingsUsed ?? 0) > 0 ? { monarchKnightingsUsed } : {}),
-    ...(raw.priestWardActive ? { priestWardActive: true } : {}),
-    ...(raw.isSilenced ? { isSilenced: true } : {}),
-    ...(raw.isHypnotized ? { isHypnotized: true } : {}),
     ...(raw.activeTrial
       ? {
           activeTrial:
             raw.activeTrial as WerewolfPlayerGameState["activeTrial"],
         }
       : {}),
-    ...(raw.executionerTargetId
-      ? { executionerTargetId: raw.executionerTargetId }
-      : {}),
     ...(raw.nominations?.length ? { nominations: raw.nominations } : {}),
     ...(raw.myNominatedDefendantId
       ? { myNominatedDefendantId: raw.myNominatedDefendantId }
       : {}),
-    ...(raw.pendingSmitePlayerIds?.length
-      ? { pendingSmitePlayerIds: raw.pendingSmitePlayerIds }
-      : {}),
-    ...(raw.mirrorcasterCharged ? { mirrorcasterCharged: true } : {}),
-    ...(raw.oneEyedSeerLockedTargetId
-      ? { oneEyedSeerLockedTargetId: raw.oneEyedSeerLockedTargetId }
-      : {}),
-    ...(raw.elusiveSeerVillagerIds?.length
-      ? { elusiveSeerVillagerIds: raw.elusiveSeerVillagerIds }
-      : {}),
-    ...(raw.illuminatiRoleAssignments?.length
-      ? {
-          illuminatiRoleAssignments: raw.illuminatiRoleAssignments.map((a) => ({
-            ...a,
-            team: a.team as Team,
-          })),
-        }
-      : {}),
-    ...(raw.exposerReveal
-      ? {
-          exposerReveal: {
-            ...raw.exposerReveal,
-            team: raw.exposerReveal.team as Team,
-          },
-        }
-      : {}),
-    ...(raw.mySecondNightTarget
-      ? { mySecondNightTarget: raw.mySecondNightTarget }
-      : {}),
-    ...(raw.exposerAbilityUsed ? { exposerAbilityUsed: true } : {}),
-    ...(raw.hunterRevengePlayerId
-      ? { hunterRevengePlayerId: raw.hunterRevengePlayerId }
-      : {}),
-    ...(raw.hiddenRoleIds?.length ? { hiddenRoleIds: raw.hiddenRoleIds } : {}),
-    ...(raw.arsonistDousedPlayerIds?.length
-      ? { arsonistDousedPlayerIds: raw.arsonistDousedPlayerIds }
-      : {}),
+    ...werewolfRoleStateFromFirebase(raw),
   } as WerewolfPlayerGameState;
 }

--- a/src/lib/game/modes/werewolf/actions/arsonist.spec.ts
+++ b/src/lib/game/modes/werewolf/actions/arsonist.spec.ts
@@ -54,7 +54,7 @@ describe("Arsonist — dousing", () => {
     const game = makeGameWithArsonist(ts);
     startDay.apply(game, null, "owner-1");
     const newTs = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(newTs.arsonistDousedPlayerIds).toEqual(["p2"]);
+    expect(newTs.roleState?.arsonist?.dousedPlayerIds).toEqual(["p2"]);
   });
 
   it("accumulates doused players across nights", () => {
@@ -64,12 +64,12 @@ describe("Arsonist — dousing", () => {
       },
     });
     // p2 was doused on a previous night
-    ts.arsonistDousedPlayerIds = ["p2"];
+    ts.roleState = { arsonist: { dousedPlayerIds: ["p2"] } };
     const game = makeGameWithArsonist(ts);
     startDay.apply(game, null, "owner-1");
     const newTs = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(newTs.arsonistDousedPlayerIds).toContain("p2");
-    expect(newTs.arsonistDousedPlayerIds).toContain("p3");
+    expect(newTs.roleState?.arsonist?.dousedPlayerIds).toContain("p2");
+    expect(newTs.roleState?.arsonist?.dousedPlayerIds).toContain("p3");
   });
 
   it("does not duplicate already-doused player", () => {
@@ -78,12 +78,12 @@ describe("Arsonist — dousing", () => {
         [WerewolfRole.Arsonist]: { targetPlayerId: "p2", confirmed: true },
       },
     });
-    ts.arsonistDousedPlayerIds = ["p2"];
+    ts.roleState = { arsonist: { dousedPlayerIds: ["p2"] } };
     const game = makeGameWithArsonist(ts);
     startDay.apply(game, null, "owner-1");
     const newTs = (game.status as { turnState: WerewolfTurnState }).turnState;
     expect(
-      newTs.arsonistDousedPlayerIds?.filter((id) => id === "p2"),
+      newTs.roleState?.arsonist?.dousedPlayerIds.filter((id) => id === "p2"),
     ).toHaveLength(1);
   });
 
@@ -101,7 +101,9 @@ describe("Arsonist — dousing", () => {
     const game = makeGameWithArsonist(ts);
     startDay.apply(game, null, "owner-1");
     const newTs = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(newTs.arsonistDousedPlayerIds ?? []).not.toContain("p2");
+    expect(newTs.roleState?.arsonist?.dousedPlayerIds ?? []).not.toContain(
+      "p2",
+    );
   });
 
   it("carries doused list forward through start-night", () => {
@@ -117,7 +119,7 @@ describe("Arsonist — dousing", () => {
     const startNight = WEREWOLF_ACTIONS[WerewolfAction.StartNight];
     startNight.apply(game, null, "owner-1");
     const nightTs = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(nightTs.arsonistDousedPlayerIds).toContain("p2");
+    expect(nightTs.roleState?.arsonist?.dousedPlayerIds).toContain("p2");
   });
 });
 
@@ -137,7 +139,7 @@ describe("Arsonist — ignite", () => {
         },
       },
     });
-    ts.arsonistDousedPlayerIds = ["p2", "p3"];
+    ts.roleState = { arsonist: { dousedPlayerIds: ["p2", "p3"] } };
     const game = makeGameWithArsonist(ts);
     startDay.apply(game, null, "owner-1");
     const newTs = (game.status as { turnState: WerewolfTurnState }).turnState;
@@ -154,11 +156,11 @@ describe("Arsonist — ignite", () => {
         },
       },
     });
-    ts.arsonistDousedPlayerIds = ["p2", "p3"];
+    ts.roleState = { arsonist: { dousedPlayerIds: ["p2", "p3"] } };
     const game = makeGameWithArsonist(ts);
     startDay.apply(game, null, "owner-1");
     const newTs = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(newTs.arsonistDousedPlayerIds ?? []).toHaveLength(0);
+    expect(newTs.roleState?.arsonist?.dousedPlayerIds ?? []).toHaveLength(0);
   });
 
   it("ignite with no doused players kills nobody", () => {
@@ -188,7 +190,7 @@ describe("Arsonist — ignite", () => {
         [WerewolfRole.Bodyguard]: { targetPlayerId: "p2", confirmed: true },
       },
     });
-    ts.arsonistDousedPlayerIds = ["p2"];
+    ts.roleState = { arsonist: { dousedPlayerIds: ["p2"] } };
     const game = makeGameWithArsonist(ts, [
       { playerId: "p5", roleDefinitionId: WerewolfRole.Bodyguard },
     ]);
@@ -213,9 +215,11 @@ describe("Arsonist — ignite", () => {
         },
       },
     });
-    ts.arsonistDousedPlayerIds = ["p2"];
-    // Priest has previously warded p2
-    ts.priestWards = { p2: "p5" };
+    ts.roleState = {
+      arsonist: { dousedPlayerIds: ["p2"] },
+      // Priest has previously warded p2
+      priest: { wards: { p2: "p5" } },
+    };
     const game = makeGameWithArsonist(ts, [
       { playerId: "p5", roleDefinitionId: WerewolfRole.Priest },
     ]);
@@ -241,7 +245,7 @@ describe("Arsonist — ignite", () => {
         [WerewolfRole.Witch]: { targetPlayerId: "p2", confirmed: true },
       },
     });
-    ts.arsonistDousedPlayerIds = ["p2"];
+    ts.roleState = { arsonist: { dousedPlayerIds: ["p2"] } };
     const game = makeGameWithArsonist(ts, [
       { playerId: "p5", roleDefinitionId: WerewolfRole.Witch },
     ]);
@@ -273,7 +277,7 @@ describe("Arsonist — ignite", () => {
         },
       },
     });
-    ts.arsonistDousedPlayerIds = ["p2"];
+    ts.roleState = { arsonist: { dousedPlayerIds: ["p2"] } };
     // Use a game with many Good players so wolves don't win after arsonist dies
     const game = makePlayingGame(ts, {
       players: [
@@ -305,7 +309,7 @@ describe("Arsonist — ignite", () => {
     // Arsonist died this night (killed by wolves) and ignited — list should still reset
     expect(newTs.deadPlayerIds).toContain("arsonist");
     expect(newTs.deadPlayerIds).toContain("p2");
-    expect(newTs.arsonistDousedPlayerIds ?? []).toHaveLength(0);
+    expect(newTs.roleState?.arsonist?.dousedPlayerIds ?? []).toHaveLength(0);
   });
 });
 
@@ -327,7 +331,7 @@ describe("Arsonist — win condition", () => {
       },
       deadPlayerIds: ["p1"], // werewolf already dead
     });
-    ts.arsonistDousedPlayerIds = ["p3", "p4"]; // kill p3 and p4 via ignite
+    ts.roleState = { arsonist: { dousedPlayerIds: ["p3", "p4"] } }; // kill p3 and p4 via ignite
     const game = makeGameWithArsonist(ts);
     startDay.apply(game, null, "owner-1");
     // p3 and p4 killed by ignite; only p2 (Good) and arsonist remain
@@ -348,7 +352,7 @@ describe("Arsonist — win condition", () => {
       deadPlayerIds: ["p1"], // werewolf already dead
     });
     // Douse p2, p3, p4 (all Good)
-    ts.arsonistDousedPlayerIds = ["p2", "p3", "p4"];
+    ts.roleState = { arsonist: { dousedPlayerIds: ["p2", "p3", "p4"] } };
     const game = makeGameWithArsonist(ts);
     startDay.apply(game, null, "owner-1");
     expect(game.status.type).toBe(GameStatus.Finished);
@@ -448,8 +452,8 @@ describe("Arsonist — win condition", () => {
     WEREWOLF_ACTIONS[WerewolfAction.StartNight].apply(game, null, "owner-1");
     const nightTs = (game.status as { turnState: WerewolfTurnState }).turnState;
     // Doused list from previous day should be in the next night's turn state
-    expect(nightTs.arsonistDousedPlayerIds).toEqual(
-      dayTs.arsonistDousedPlayerIds,
+    expect(nightTs.roleState?.arsonist?.dousedPlayerIds).toEqual(
+      dayTs.roleState?.arsonist?.dousedPlayerIds,
     );
   });
 });
@@ -471,11 +475,13 @@ describe("Arsonist — dead players removed from doused list", () => {
         },
       },
     });
-    ts.arsonistDousedPlayerIds = ["p2"];
+    ts.roleState = { arsonist: { dousedPlayerIds: ["p2"] } };
     const game = makeGameWithArsonist(ts);
     startDay.apply(game, null, "owner-1");
     const newTs = (game.status as { turnState: WerewolfTurnState }).turnState;
     // p2 died via wolves — should be removed from doused list
-    expect(newTs.arsonistDousedPlayerIds ?? []).not.toContain("p2");
+    expect(newTs.roleState?.arsonist?.dousedPlayerIds ?? []).not.toContain(
+      "p2",
+    );
   });
 });

--- a/src/lib/game/modes/werewolf/actions/confirm-night-target-tests/witch.spec.ts
+++ b/src/lib/game/modes/werewolf/actions/confirm-night-target-tests/witch.spec.ts
@@ -42,7 +42,7 @@ describe("ConfirmNightTarget — sets witchAbilityUsed for Witch", () => {
 
     const resultTs = (game.status as { turnState: WerewolfTurnState })
       .turnState;
-    expect(resultTs.witchAbilityUsed).toBe(true);
+    expect(resultTs.roleState?.witch?.abilityUsed).toBe(true);
   });
 
   it("witchAbilityUsed is carried forward into the next night", () => {
@@ -61,7 +61,7 @@ describe("ConfirmNightTarget — sets witchAbilityUsed for Witch", () => {
         },
       },
       deadPlayerIds: [],
-      witchAbilityUsed: true,
+      roleState: { witch: { abilityUsed: true } },
     };
     // Werewolf added to prevent Village win after Witch kills p2
     const game = makePlayingGame(ts, {
@@ -83,6 +83,6 @@ describe("ConfirmNightTarget — sets witchAbilityUsed for Witch", () => {
     startNight.apply(game, null, "owner-1");
 
     const newTs = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(newTs.witchAbilityUsed).toBe(true);
+    expect(newTs.roleState?.witch?.abilityUsed).toBe(true);
   });
 });

--- a/src/lib/game/modes/werewolf/actions/dracula-zombie.spec.ts
+++ b/src/lib/game/modes/werewolf/actions/dracula-zombie.spec.ts
@@ -81,7 +81,7 @@ describe("Dracula night action", () => {
     const game = makeGameWithDracula(ts);
     startDay.apply(game, undefined, "owner-1");
     const newTs = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(newTs.draculaWives).toContain("p2");
+    expect(newTs.roleState?.dracula?.wives).toContain("p2");
   });
 
   it("accumulates wives across multiple nights", () => {
@@ -92,12 +92,12 @@ describe("Dracula night action", () => {
       },
     });
     // p2 was already a wife from the previous turn
-    ts.draculaWives = ["p2"];
+    ts.roleState = { dracula: { wives: ["p2"] } };
     const game = makeGameWithDracula(ts);
     startDay.apply(game, undefined, "owner-1");
     const newTs = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(newTs.draculaWives).toContain("p2");
-    expect(newTs.draculaWives).toContain("p3");
+    expect(newTs.roleState?.dracula?.wives).toContain("p2");
+    expect(newTs.roleState?.dracula?.wives).toContain("p3");
   });
 
   it("does not duplicate a wife if targeted again", () => {
@@ -107,11 +107,13 @@ describe("Dracula night action", () => {
         [WerewolfRole.Dracula]: { targetPlayerId: "p2", confirmed: true },
       },
     });
-    ts.draculaWives = ["p2"];
+    ts.roleState = { dracula: { wives: ["p2"] } };
     const game = makeGameWithDracula(ts);
     startDay.apply(game, undefined, "owner-1");
     const newTs = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(newTs.draculaWives?.filter((id) => id === "p2").length).toBe(1);
+    expect(
+      newTs.roleState?.dracula?.wives.filter((id) => id === "p2").length,
+    ).toBe(1);
   });
 
   it("removes a wife who died in the same night from draculaWives", () => {
@@ -127,11 +129,11 @@ describe("Dracula night action", () => {
       },
     });
     // p2 was a wife from before
-    ts.draculaWives = ["p2"];
+    ts.roleState = { dracula: { wives: ["p2"] } };
     const game = makeGameWithDracula(ts);
     startDay.apply(game, undefined, "owner-1");
     const newTs = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(newTs.draculaWives).not.toContain("p2");
+    expect(newTs.roleState?.dracula?.wives).not.toContain("p2");
   });
 });
 
@@ -151,7 +153,7 @@ describe("Dracula win condition at start of night", () => {
         nightActions: {},
       },
       deadPlayerIds: [],
-      draculaWives: ["p2", "p3", "p4"],
+      roleState: { dracula: { wives: ["p2", "p3", "p4"] } },
     };
     const game = makeGameWithDracula(ts);
     startNight.apply(game, undefined, "owner-1");
@@ -170,7 +172,7 @@ describe("Dracula win condition at start of night", () => {
         nightActions: {},
       },
       deadPlayerIds: [],
-      draculaWives: ["p2", "p3"],
+      roleState: { dracula: { wives: ["p2", "p3"] } },
     };
     const game = makeGameWithDracula(ts);
     startNight.apply(game, undefined, "owner-1");
@@ -186,7 +188,7 @@ describe("Dracula win condition at start of night", () => {
         nightActions: {},
       },
       deadPlayerIds: ["p2"],
-      draculaWives: ["p2", "p3", "p4"],
+      roleState: { dracula: { wives: ["p2", "p3", "p4"] } },
     };
     const game = makeGameWithDracula(ts);
     startNight.apply(game, undefined, "owner-1");
@@ -202,7 +204,7 @@ describe("Dracula win condition at start of night", () => {
         nightActions: {},
       },
       deadPlayerIds: ["dracula"],
-      draculaWives: ["p2", "p3", "p4"],
+      roleState: { dracula: { wives: ["p2", "p3", "p4"] } },
     };
     const game = makeGameWithDracula(ts);
     startNight.apply(game, undefined, "owner-1");
@@ -218,7 +220,7 @@ describe("Dracula win condition at start of night", () => {
         nightActions: {},
       },
       deadPlayerIds: [],
-      draculaWives: ["p2", "p3", "p4"],
+      roleState: { dracula: { wives: ["p2", "p3", "p4"] } },
     };
     const game = makeGameWithDracula(ts);
     startNight.apply(game, undefined, "owner-1");
@@ -251,7 +253,7 @@ describe("Zombie night action", () => {
     const game = makeGameWithZombie(ts);
     startDay.apply(game, undefined, "owner-1");
     const newTs = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(newTs.zombieInfected).toContain("p2");
+    expect(newTs.roleState?.zombie?.infected).toContain("p2");
   });
 
   it("accumulates infections across multiple nights", () => {
@@ -261,12 +263,12 @@ describe("Zombie night action", () => {
         [WerewolfRole.Zombie]: { targetPlayerId: "p3", confirmed: true },
       },
     });
-    ts.zombieInfected = ["p2"];
+    ts.roleState = { zombie: { infected: ["p2"] } };
     const game = makeGameWithZombie(ts);
     startDay.apply(game, undefined, "owner-1");
     const newTs = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(newTs.zombieInfected).toContain("p2");
-    expect(newTs.zombieInfected).toContain("p3");
+    expect(newTs.roleState?.zombie?.infected).toContain("p2");
+    expect(newTs.roleState?.zombie?.infected).toContain("p3");
   });
 
   it("removes infected player who died this night from zombieInfected", () => {
@@ -281,12 +283,12 @@ describe("Zombie night action", () => {
         },
       },
     });
-    ts.zombieInfected = ["p2"];
+    ts.roleState = { zombie: { infected: ["p2"] } };
     const game = makeGameWithZombie(ts);
     startDay.apply(game, undefined, "owner-1");
     const newTs = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(newTs.zombieInfected).not.toContain("p2");
-    expect(newTs.zombieInfected).toContain("p3");
+    expect(newTs.roleState?.zombie?.infected).not.toContain("p2");
+    expect(newTs.roleState?.zombie?.infected).toContain("p3");
   });
 });
 
@@ -303,7 +305,7 @@ describe("Zombie setNightTarget validation", () => {
       nightPhaseOrder: [WerewolfRole.Zombie],
       currentPhaseIndex: 0,
     });
-    ts.zombieInfected = ["p2"];
+    ts.roleState = { zombie: { infected: ["p2"] } };
     const game = makeGameWithZombie(ts);
     expect(
       setTarget.isValid(game, "owner-1", {
@@ -319,7 +321,7 @@ describe("Zombie setNightTarget validation", () => {
       nightPhaseOrder: [WerewolfRole.Zombie],
       currentPhaseIndex: 0,
     });
-    ts.zombieInfected = ["p2"];
+    ts.roleState = { zombie: { infected: ["p2"] } };
     const game = makeGameWithZombie(ts);
     expect(
       setTarget.isValid(game, "owner-1", {
@@ -349,7 +351,7 @@ describe("Zombie win condition after deaths", () => {
         nightActions: {},
       },
       deadPlayerIds: ["p1", "p3"],
-      zombieInfected: ["p2"],
+      roleState: { zombie: { infected: ["p2"] } },
     };
     const game = makeGameWithZombie(ts);
     killPlayer.apply(game, { playerId: "p4" }, "owner-1");
@@ -370,7 +372,7 @@ describe("Zombie win condition after deaths", () => {
         nightActions: {},
       },
       deadPlayerIds: ["p3", "p4"],
-      zombieInfected: ["p1"],
+      roleState: { zombie: { infected: ["p1"] } },
     };
     const smallGame = makePlayingGame(smallTs, {
       players: [
@@ -406,7 +408,7 @@ describe("Zombie win condition after deaths", () => {
         nightActions: {},
       },
       deadPlayerIds: ["zombie"],
-      zombieInfected: ["p1", "p2"],
+      roleState: { zombie: { infected: ["p1", "p2"] } },
     };
     const game = makeGameWithZombie(ts);
     killPlayer.apply(game, { playerId: "p3" }, "owner-1");
@@ -432,14 +434,14 @@ describe("start-night state carry-forward", () => {
         nightActions: {},
       },
       deadPlayerIds: ["p2"],
-      draculaWives: ["p2", "p3"],
+      roleState: { dracula: { wives: ["p2", "p3"] } },
     };
     const game = makeGameWithDracula(ts);
     startNight.apply(game, undefined, "owner-1");
     if (game.status.type !== GameStatus.Playing) return; // guard for type safety
     const newTs = game.status.turnState as WerewolfTurnState;
-    expect(newTs.draculaWives).not.toContain("p2");
-    expect(newTs.draculaWives).toContain("p3");
+    expect(newTs.roleState?.dracula?.wives).not.toContain("p2");
+    expect(newTs.roleState?.dracula?.wives).toContain("p3");
   });
 
   it("carries zombieInfected forward into the next night turn state (pruning dead)", () => {
@@ -451,13 +453,13 @@ describe("start-night state carry-forward", () => {
         nightActions: {},
       },
       deadPlayerIds: ["p2"],
-      zombieInfected: ["p2", "p3"],
+      roleState: { zombie: { infected: ["p2", "p3"] } },
     };
     const game = makeGameWithZombie(ts);
     startNight.apply(game, undefined, "owner-1");
     if (game.status.type !== GameStatus.Playing) return;
     const newTs = game.status.turnState as WerewolfTurnState;
-    expect(newTs.zombieInfected).not.toContain("p2");
-    expect(newTs.zombieInfected).toContain("p3");
+    expect(newTs.roleState?.zombie?.infected).not.toContain("p2");
+    expect(newTs.roleState?.zombie?.infected).toContain("p3");
   });
 });

--- a/src/lib/game/modes/werewolf/actions/helpers.ts
+++ b/src/lib/game/modes/werewolf/actions/helpers.ts
@@ -18,13 +18,19 @@ export function cleanupAfterDaytimeKill(
   killedPlayerId: string,
   ts: WerewolfTurnState,
 ): void {
-  if (ts.oneEyedSeerLockedTargetId === killedPlayerId) {
-    ts.oneEyedSeerLockedTargetId = undefined;
+  const rs = ts.roleState;
+  if (rs?.oneEyedSeer?.lockedTargetId === killedPlayerId) {
+    ts.roleState = { ...rs, oneEyedSeer: undefined };
   }
-  if (ts.priestWards && killedPlayerId in ts.priestWards) {
+  const wards = ts.roleState?.priest?.wards;
+  if (wards && killedPlayerId in wards) {
     const remaining = Object.fromEntries(
-      Object.entries(ts.priestWards).filter(([id]) => id !== killedPlayerId),
+      Object.entries(wards).filter(([id]) => id !== killedPlayerId),
     );
-    ts.priestWards = Object.keys(remaining).length > 0 ? remaining : undefined;
+    ts.roleState = {
+      ...(ts.roleState ?? {}),
+      priest:
+        Object.keys(remaining).length > 0 ? { wards: remaining } : undefined,
+    };
   }
 }

--- a/src/lib/game/modes/werewolf/actions/kill-player.spec.ts
+++ b/src/lib/game/modes/werewolf/actions/kill-player.spec.ts
@@ -128,43 +128,43 @@ describe("WerewolfAction.KillPlayer", () => {
       });
       action.apply(game, { playerId: "p2" }, "owner-1");
       const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-      expect(ts.wolfCubDied).toBe(true);
+      expect(ts.roleState?.wolfCub?.died).toBe(true);
     });
 
     it("clears One-Eyed Seer lock when locked target is killed", () => {
       const ds = freshDayState();
-      ds.oneEyedSeerLockedTargetId = "p3";
+      ds.roleState = { oneEyedSeer: { lockedTargetId: "p3" } };
       const game = makePlayingGame(ds);
       action.apply(game, { playerId: "p3" }, "owner-1");
       const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-      expect(ts.oneEyedSeerLockedTargetId).toBeUndefined();
+      expect(ts.roleState?.oneEyedSeer?.lockedTargetId).toBeUndefined();
     });
 
     it("preserves One-Eyed Seer lock when a different player is killed", () => {
       const ds = freshDayState();
-      ds.oneEyedSeerLockedTargetId = "p4";
+      ds.roleState = { oneEyedSeer: { lockedTargetId: "p4" } };
       const game = makePlayingGame(ds);
       action.apply(game, { playerId: "p3" }, "owner-1");
       const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-      expect(ts.oneEyedSeerLockedTargetId).toBe("p4");
+      expect(ts.roleState?.oneEyedSeer?.lockedTargetId).toBe("p4");
     });
 
     it("consumes priest ward when warded player is killed", () => {
       const ds = freshDayState();
-      ds.priestWards = { p3: "priest1", p4: "priest1" };
+      ds.roleState = { priest: { wards: { p3: "priest1", p4: "priest1" } } };
       const game = makePlayingGame(ds);
       action.apply(game, { playerId: "p3" }, "owner-1");
       const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-      expect(ts.priestWards).toEqual({ p4: "priest1" });
+      expect(ts.roleState?.priest?.wards).toEqual({ p4: "priest1" });
     });
 
     it("clears priestWards entirely when last ward is consumed", () => {
       const ds = freshDayState();
-      ds.priestWards = { p3: "priest1" };
+      ds.roleState = { priest: { wards: { p3: "priest1" } } };
       const game = makePlayingGame(ds);
       action.apply(game, { playerId: "p3" }, "owner-1");
       const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-      expect(ts.priestWards).toBeUndefined();
+      expect(ts.roleState?.priest?.wards).toBeUndefined();
     });
   });
 

--- a/src/lib/game/modes/werewolf/actions/kill-player.ts
+++ b/src/lib/game/modes/werewolf/actions/kill-player.ts
@@ -23,7 +23,7 @@ export const killPlayerAction: GameAction = {
     const { playerId } = payload as { playerId: string };
     ts.deadPlayerIds = [...ts.deadPlayerIds, playerId];
     if (didWolfCubDie([playerId], game)) {
-      ts.wolfCubDied = true;
+      ts.roleState = { ...(ts.roleState ?? {}), wolfCub: { died: true } };
     }
     cleanupAfterDaytimeKill(playerId, ts);
     const winResult = checkWinCondition(game, ts.deadPlayerIds);

--- a/src/lib/game/modes/werewolf/actions/mark-player.ts
+++ b/src/lib/game/modes/werewolf/actions/mark-player.ts
@@ -21,7 +21,7 @@ export const markPlayerDeadAction: GameAction = {
     const { playerId } = payload as { playerId: string };
     ts.deadPlayerIds = [...ts.deadPlayerIds, playerId];
     if (didWolfCubDie([playerId], game)) {
-      ts.wolfCubDied = true;
+      ts.roleState = { ...(ts.roleState ?? {}), wolfCub: { died: true } };
     }
   },
 };

--- a/src/lib/game/modes/werewolf/actions/reset-ability.spec.ts
+++ b/src/lib/game/modes/werewolf/actions/reset-ability.spec.ts
@@ -25,6 +25,17 @@ describe("WerewolfAction.ResetAbility", () => {
     expect(ts.roleState?.exposer?.abilityUsed).toBeUndefined();
   });
 
+  it("preserves exposer reveal when resetting abilityUsed", () => {
+    const reveal = { playerId: "p2", roleId: WerewolfRole.Werewolf };
+    const ns = makeNightState({ turn: 2 });
+    ns.roleState = { exposer: { abilityUsed: true, reveal } };
+    const game = makePlayingGame(ns);
+    action.apply(game, { roleId: WerewolfRole.Exposer }, "owner-1");
+    const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
+    expect(ts.roleState?.exposer?.abilityUsed).toBeUndefined();
+    expect(ts.roleState?.exposer?.reveal).toEqual(reveal);
+  });
+
   it("isValid returns true for known ability role", () => {
     const game = makePlayingGame(makeNightState({ turn: 2 }));
     expect(

--- a/src/lib/game/modes/werewolf/actions/reset-ability.spec.ts
+++ b/src/lib/game/modes/werewolf/actions/reset-ability.spec.ts
@@ -9,20 +9,20 @@ describe("WerewolfAction.ResetAbility", () => {
 
   it("resets witchAbilityUsed", () => {
     const ns = makeNightState({ turn: 2 });
-    ns.witchAbilityUsed = true;
+    ns.roleState = { witch: { abilityUsed: true } };
     const game = makePlayingGame(ns);
     action.apply(game, { roleId: WerewolfRole.Witch }, "owner-1");
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(ts.witchAbilityUsed).toBeUndefined();
+    expect(ts.roleState?.witch?.abilityUsed).toBeUndefined();
   });
 
   it("resets exposerAbilityUsed", () => {
     const ns = makeNightState({ turn: 2 });
-    ns.exposerAbilityUsed = true;
+    ns.roleState = { exposer: { abilityUsed: true } };
     const game = makePlayingGame(ns);
     action.apply(game, { roleId: WerewolfRole.Exposer }, "owner-1");
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(ts.exposerAbilityUsed).toBeUndefined();
+    expect(ts.roleState?.exposer?.abilityUsed).toBeUndefined();
   });
 
   it("isValid returns true for known ability role", () => {
@@ -55,7 +55,7 @@ describe("Narrator bypasses once-per-game restrictions in SetNightTarget", () =>
       turn: 2,
       nightPhaseOrder: [WerewolfRole.Witch],
     });
-    ns.witchAbilityUsed = true;
+    ns.roleState = { witch: { abilityUsed: true } };
     const game = makePlayingGame(ns, {
       roleAssignments: [
         { playerId: "p1", roleDefinitionId: WerewolfRole.Werewolf },
@@ -77,7 +77,7 @@ describe("Narrator bypasses once-per-game restrictions in SetNightTarget", () =>
       nightPhaseOrder: [WerewolfRole.Witch],
       currentPhaseIndex: 0,
     });
-    ns.witchAbilityUsed = true;
+    ns.roleState = { witch: { abilityUsed: true } };
     const game = makePlayingGame(ns, {
       roleAssignments: [
         { playerId: "p1", roleDefinitionId: WerewolfRole.Werewolf },

--- a/src/lib/game/modes/werewolf/actions/reset-ability.ts
+++ b/src/lib/game/modes/werewolf/actions/reset-ability.ts
@@ -2,12 +2,12 @@ import type { Game, GameAction } from "@/lib/types";
 import { currentTurnState, isOwnerPlaying } from "../utils";
 import { WerewolfRole } from "../roles";
 
-/** Ability flags the narrator can reset. */
-const RESETTABLE_ABILITIES: Record<string, string> = {
-  [WerewolfRole.Witch]: "witchAbilityUsed",
-  [WerewolfRole.Exposer]: "exposerAbilityUsed",
-  [WerewolfRole.Mortician]: "morticianAbilityEnded",
-};
+/** Role IDs whose once-per-game abilities the narrator can reset. */
+const RESETTABLE_ROLE_IDS = new Set<string>([
+  WerewolfRole.Witch,
+  WerewolfRole.Exposer,
+  WerewolfRole.Mortician,
+]);
 
 export const resetAbilityAction: GameAction = {
   isValid(game: Game, callerId: string, payload: unknown) {
@@ -17,16 +17,22 @@ export const resetAbilityAction: GameAction = {
     if (!payload || typeof payload !== "object") return false;
     const { roleId } = payload as { roleId?: unknown };
     if (typeof roleId !== "string") return false;
-    return roleId in RESETTABLE_ABILITIES;
+    return RESETTABLE_ROLE_IDS.has(roleId);
   },
   apply(game: Game, payload: unknown) {
     const ts = currentTurnState(game);
     if (!ts) return;
     if (!payload || typeof payload !== "object") return;
     const { roleId } = payload as { roleId: string };
-    const flagKey = RESETTABLE_ABILITIES[roleId];
-    if (flagKey) {
-      (ts as unknown as Record<string, unknown>)[flagKey] = undefined;
+    const rs = ts.roleState ?? {};
+    if (roleId === (WerewolfRole.Witch as string)) {
+      ts.roleState = { ...rs, witch: undefined };
+    } else if (roleId === (WerewolfRole.Exposer as string)) {
+      // Clear abilityUsed but preserve reveal if present.
+      const { reveal } = rs.exposer ?? {};
+      ts.roleState = { ...rs, exposer: reveal ? { reveal } : undefined };
+    } else if (roleId === (WerewolfRole.Mortician as string)) {
+      ts.roleState = { ...rs, mortician: undefined };
     }
   },
 };

--- a/src/lib/game/modes/werewolf/actions/resolve-hunter-revenge.spec.ts
+++ b/src/lib/game/modes/werewolf/actions/resolve-hunter-revenge.spec.ts
@@ -20,7 +20,7 @@ function makeDayWithHunterRevenge(): WerewolfTurnState {
       nightActions: {},
     },
     deadPlayerIds: ["p2"],
-    hunterRevengePlayerId: "p2",
+    roleState: { hunter: { revengePlayerId: "p2" } },
   };
 }
 
@@ -71,7 +71,7 @@ describe("WerewolfAction.ResolveHunterRevenge", () => {
     resolveRevenge.apply(game, { targetPlayerId: "p3" }, "owner-1");
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
     expect(ts.deadPlayerIds).toContain("p3");
-    expect(ts.hunterRevengePlayerId).toBeUndefined();
+    expect(ts.roleState?.hunter?.revengePlayerId).toBeUndefined();
   });
 
   it("Hunter revenge on the last wolf triggers Village win", () => {

--- a/src/lib/game/modes/werewolf/actions/resolve-hunter-revenge.ts
+++ b/src/lib/game/modes/werewolf/actions/resolve-hunter-revenge.ts
@@ -9,7 +9,7 @@ export const resolveHunterRevengeAction: GameAction = {
     const ts = currentTurnState(game);
     if (!ts) return false;
     if (ts.phase.type !== WerewolfPhase.Daytime) return false;
-    if (!ts.hunterRevengePlayerId) return false;
+    if (!ts.roleState?.hunter?.revengePlayerId) return false;
     if (!payload || typeof payload !== "object") return false;
     const { targetPlayerId } = payload as { targetPlayerId?: unknown };
     if (typeof targetPlayerId !== "string") return false;
@@ -24,11 +24,11 @@ export const resolveHunterRevengeAction: GameAction = {
     ts.deadPlayerIds = [...ts.deadPlayerIds, targetPlayerId];
 
     if (didWolfCubDie([targetPlayerId], game)) {
-      ts.wolfCubDied = true;
+      ts.roleState = { ...(ts.roleState ?? {}), wolfCub: { died: true } };
     }
     cleanupAfterDaytimeKill(targetPlayerId, ts);
 
-    ts.hunterRevengePlayerId = undefined;
+    ts.roleState = { ...(ts.roleState ?? {}), hunter: undefined };
 
     const winResult = checkWinCondition(game, ts.deadPlayerIds);
     if (winResult) {

--- a/src/lib/game/modes/werewolf/actions/resolve-trial.spec.ts
+++ b/src/lib/game/modes/werewolf/actions/resolve-trial.spec.ts
@@ -199,9 +199,9 @@ describe("WerewolfAction.ResolveTrial", () => {
           ],
         },
       );
-      (
-        game.status as { turnState: WerewolfTurnState }
-      ).turnState.monarchKnightedPlayerIds = ["p2"];
+      (game.status as { turnState: WerewolfTurnState }).turnState.roleState = {
+        monarch: { knightedPlayerIds: ["p2"], knightingsUsed: 0 },
+      };
       action.apply(game, {}, "owner-1");
       const ts = (
         game.status as {
@@ -241,12 +241,12 @@ describe("WerewolfAction.ResolveTrial", () => {
         { playerId: "p4", vote: DaytimeVote.Guilty },
         { playerId: "p5", vote: DaytimeVote.Guilty },
       ]);
-      ts.oneEyedSeerLockedTargetId = "p3";
+      ts.roleState = { oneEyedSeer: { lockedTargetId: "p3" } };
       const game = makePlayingGame(ts);
       action.apply(game, {}, "owner-1");
       const result = (game.status as { turnState: WerewolfTurnState })
         .turnState;
-      expect(result.oneEyedSeerLockedTargetId).toBeUndefined();
+      expect(result.roleState?.oneEyedSeer?.lockedTargetId).toBeUndefined();
     });
 
     it("consumes priest ward when warded player is eliminated by trial", () => {
@@ -254,12 +254,12 @@ describe("WerewolfAction.ResolveTrial", () => {
         { playerId: "p4", vote: DaytimeVote.Guilty },
         { playerId: "p5", vote: DaytimeVote.Guilty },
       ]);
-      ts.priestWards = { p3: "p2", p4: "p2" };
+      ts.roleState = { priest: { wards: { p3: "p2", p4: "p2" } } };
       const game = makePlayingGame(ts);
       action.apply(game, {}, "owner-1");
       const result = (game.status as { turnState: WerewolfTurnState })
         .turnState;
-      expect(result.priestWards).toEqual({ p4: "p2" });
+      expect(result.roleState?.priest?.wards).toEqual({ p4: "p2" });
     });
 
     it("sets hunterRevengePlayerId when Hunter is eliminated by trial", () => {
@@ -281,7 +281,7 @@ describe("WerewolfAction.ResolveTrial", () => {
       action.apply(game, {}, "owner-1");
       expect(game.status.type).toBe(GameStatus.Playing);
       const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-      expect(ts.hunterRevengePlayerId).toBe("p2");
+      expect(ts.roleState?.hunter?.revengePlayerId).toBe("p2");
       expect(ts.deadPlayerIds).toContain("p2");
     });
 
@@ -309,7 +309,7 @@ describe("WerewolfAction.ResolveTrial", () => {
       // Game should still be playing — not finished
       expect(game.status.type).toBe(GameStatus.Playing);
       const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-      expect(ts.hunterRevengePlayerId).toBe("p2");
+      expect(ts.roleState?.hunter?.revengePlayerId).toBe("p2");
     });
 
     it("Tanner voted out at trial ends game with Tanner winner", () => {
@@ -340,7 +340,7 @@ describe("WerewolfAction.ResolveTrial", () => {
         { playerId: "p3", vote: DaytimeVote.Guilty },
         { playerId: "p4", vote: DaytimeVote.Guilty },
       ]);
-      ts.executionerTargetId = "p2";
+      ts.roleState = { executioner: { targetId: "p2" } };
       const game = makePlayingGame(ts, {
         roleAssignments: [
           { playerId: "p1", roleDefinitionId: WerewolfRole.Werewolf },
@@ -362,7 +362,7 @@ describe("WerewolfAction.ResolveTrial", () => {
         { playerId: "p2", vote: DaytimeVote.Guilty },
         { playerId: "p3", vote: DaytimeVote.Guilty },
       ]);
-      ts.executionerTargetId = "p2";
+      ts.roleState = { executioner: { targetId: "p2" } };
       const game = makePlayingGame(ts, {
         roleAssignments: [
           { playerId: "p1", roleDefinitionId: WerewolfRole.Werewolf },

--- a/src/lib/game/modes/werewolf/actions/resolve-trial.ts
+++ b/src/lib/game/modes/werewolf/actions/resolve-trial.ts
@@ -30,7 +30,9 @@ export function applyTrialVerdict(
     )?.roleDefinitionId;
     const extraVoteWeight =
       Number(roleId === WerewolfRole.Mayor) +
-      Number((ts.monarchKnightedPlayerIds ?? []).includes(v.playerId));
+      Number(
+        (ts.roleState?.monarch?.knightedPlayerIds ?? []).includes(v.playerId),
+      );
     if (extraVoteWeight === 0) continue;
     if (v.vote === DaytimeVote.Guilty) guiltyCount += extraVoteWeight;
     else innocentCount += extraVoteWeight;
@@ -54,7 +56,7 @@ export function applyTrialVerdict(
     if (!ts.deadPlayerIds.includes(defendantId)) {
       ts.deadPlayerIds = [...ts.deadPlayerIds, defendantId];
       if (didWolfCubDie([defendantId], game)) {
-        ts.wolfCubDied = true;
+        ts.roleState = { ...(ts.roleState ?? {}), wolfCub: { died: true } };
       }
       cleanupAfterDaytimeKill(defendantId, ts);
     }
@@ -84,7 +86,7 @@ export const resolveTrialAction: GameAction = {
 
       // Executioner wins if their target was eliminated and the Executioner is alive.
       // Check Executioner before Tanner (if target is also the Tanner, Executioner wins).
-      if (ts.executionerTargetId === defendantId) {
+      if (ts.roleState?.executioner?.targetId === defendantId) {
         const executionerAssignment = game.roleAssignments.find(
           (a) => a.roleDefinitionId === (WerewolfRole.Executioner as string),
         );
@@ -117,7 +119,10 @@ export const resolveTrialAction: GameAction = {
         (a) => a.playerId === defendantId,
       )?.roleDefinitionId;
       if (eliminatedRole === (WerewolfRole.Hunter as string)) {
-        ts.hunterRevengePlayerId = defendantId;
+        ts.roleState = {
+          ...(ts.roleState ?? {}),
+          hunter: { revengePlayerId: defendantId },
+        };
         return;
       }
     }

--- a/src/lib/game/modes/werewolf/actions/set-night-target-tests/bodyguard-witch.spec.ts
+++ b/src/lib/game/modes/werewolf/actions/set-night-target-tests/bodyguard-witch.spec.ts
@@ -81,7 +81,9 @@ describe("SetNightTarget — Witch once-per-game restriction", () => {
         nightActions: {},
       },
       deadPlayerIds: [],
-      ...(witchAbilityUsed ? { witchAbilityUsed: true } : {}),
+      ...(witchAbilityUsed
+        ? { roleState: { witch: { abilityUsed: true } } }
+        : {}),
     };
     return makePlayingGame(ts, {
       players: [
@@ -231,7 +233,7 @@ describe("SetNightTarget — Witch cannot self-attack", () => {
       },
       deadPlayerIds: [],
       // p2 (Witch) is in the doused list
-      arsonistDousedPlayerIds: ["p2"],
+      roleState: { arsonist: { dousedPlayerIds: ["p2"] } },
     };
     const game = makePlayingGame(ts, {
       players: [

--- a/src/lib/game/modes/werewolf/actions/set-night-target-tests/doctor-priest.spec.ts
+++ b/src/lib/game/modes/werewolf/actions/set-night-target-tests/doctor-priest.spec.ts
@@ -69,7 +69,7 @@ describe("SetNightTarget — Priest ward blocking", () => {
       turn: 2,
       nightPhaseOrder: [WerewolfRole.Priest],
     });
-    nightState.priestWards = { p2: "p1" };
+    nightState.roleState = { priest: { wards: { p2: "p1" } } };
     const game = makePriestGame(nightState);
     expect(action.isValid(game, "p1", { targetPlayerId: "p3" })).toBe(false);
   });
@@ -80,7 +80,7 @@ describe("SetNightTarget — Priest ward blocking", () => {
       nightPhaseOrder: [WerewolfRole.Priest],
       deadPlayerIds: ["p2"],
     });
-    nightState.priestWards = { p2: "p1" };
+    nightState.roleState = { priest: { wards: { p2: "p1" } } };
     const game = makePriestGame(nightState);
     expect(action.isValid(game, "p1", { targetPlayerId: "p3" })).toBe(true);
   });

--- a/src/lib/game/modes/werewolf/actions/set-night-target-tests/solo-validation.spec.ts
+++ b/src/lib/game/modes/werewolf/actions/set-night-target-tests/solo-validation.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import type { WerewolfTurnState } from "../../types";
 import { WerewolfRole } from "../../roles";
 import { WerewolfAction, WEREWOLF_ACTIONS } from "../index";
 import {
@@ -141,9 +142,11 @@ describe("WerewolfAction.SetNightTarget", () => {
       );
       (
         game.status as {
-          turnState: { monarchKnightingsUsed?: number };
+          turnState: WerewolfTurnState;
         }
-      ).turnState.monarchKnightingsUsed = 3;
+      ).turnState.roleState = {
+        monarch: { knightedPlayerIds: [], knightingsUsed: 3 },
+      };
       expect(action.isValid(game, "p2", { targetPlayerId: "p3" })).toBe(false);
     });
 
@@ -166,9 +169,11 @@ describe("WerewolfAction.SetNightTarget", () => {
       );
       (
         game.status as {
-          turnState: { monarchKnightedPlayerIds?: string[] };
+          turnState: WerewolfTurnState;
         }
-      ).turnState.monarchKnightedPlayerIds = ["p3"];
+      ).turnState.roleState = {
+        monarch: { knightedPlayerIds: ["p3"], knightingsUsed: 0 },
+      };
       expect(action.isValid(game, "p2", { targetPlayerId: "p3" })).toBe(false);
     });
   });

--- a/src/lib/game/modes/werewolf/actions/set-night-target.ts
+++ b/src/lib/game/modes/werewolf/actions/set-night-target.ts
@@ -48,18 +48,24 @@ export const setNightTargetAction: GameAction = {
 
     // Once-per-game ability restrictions — narrator can bypass these.
     if (!isOwner) {
-      if (isRoleActive(phaseKey, WerewolfRole.Witch) && ts.witchAbilityUsed)
+      if (
+        isRoleActive(phaseKey, WerewolfRole.Witch) &&
+        ts.roleState?.witch?.abilityUsed
+      )
         return false;
-      if (isRoleActive(phaseKey, WerewolfRole.Exposer) && ts.exposerAbilityUsed)
+      if (
+        isRoleActive(phaseKey, WerewolfRole.Exposer) &&
+        ts.roleState?.exposer?.abilityUsed
+      )
         return false;
       if (
         isRoleActive(phaseKey, WerewolfRole.Mortician) &&
-        ts.morticianAbilityEnded
+        ts.roleState?.mortician?.abilityEnded
       )
         return false;
       if (
         isRoleActive(phaseKey, WerewolfRole.Monarch) &&
-        (ts.monarchKnightingsUsed ?? 0) >= 3
+        (ts.roleState?.monarch?.knightingsUsed ?? 0) >= 3
       )
         return false;
     }
@@ -73,7 +79,7 @@ export const setNightTargetAction: GameAction = {
     if (ts.deadPlayerIds.includes(targetPlayerId)) return false;
     if (
       isRoleActive(phaseKey, WerewolfRole.Monarch) &&
-      (ts.monarchKnightedPlayerIds ?? []).includes(targetPlayerId)
+      (ts.roleState?.monarch?.knightedPlayerIds ?? []).includes(targetPlayerId)
     )
       return false;
 
@@ -101,14 +107,17 @@ export const setNightTargetAction: GameAction = {
     // One-Eyed Seer cannot target when locked onto a living player.
     if (
       isRoleActive(phaseKey, WerewolfRole.OneEyedSeer) &&
-      ts.oneEyedSeerLockedTargetId &&
-      !ts.deadPlayerIds.includes(ts.oneEyedSeerLockedTargetId)
+      ts.roleState?.oneEyedSeer?.lockedTargetId &&
+      !ts.deadPlayerIds.includes(ts.roleState.oneEyedSeer.lockedTargetId)
     )
       return false;
 
     // Priest cannot target when they have an active ward on a living player.
-    if (isRoleActive(phaseKey, WerewolfRole.Priest) && ts.priestWards) {
-      const hasActiveWard = Object.keys(ts.priestWards).some(
+    if (
+      isRoleActive(phaseKey, WerewolfRole.Priest) &&
+      ts.roleState?.priest?.wards
+    ) {
+      const hasActiveWard = Object.keys(ts.roleState.priest.wards).some(
         (wardedId) => !ts.deadPlayerIds.includes(wardedId),
       );
       if (hasActiveWard) return false;
@@ -132,7 +141,7 @@ export const setNightTargetAction: GameAction = {
 
     // Zombie cannot infect an already-infected player.
     if (isRoleActive(phaseKey, WerewolfRole.Zombie)) {
-      if (ts.zombieInfected?.includes(targetPlayerId)) return false;
+      if (ts.roleState?.zombie?.infected.includes(targetPlayerId)) return false;
     }
 
     // Witch cannot self-target unless under attack (self-protect is OK,
@@ -145,9 +154,9 @@ export const setNightTargetAction: GameAction = {
         phase.nightActions,
         game.roleAssignments,
         ts.deadPlayerIds,
-        ts.priestWards,
-        ts.mirrorcasterCharged,
-        ts.arsonistDousedPlayerIds,
+        ts.roleState?.priest?.wards,
+        ts.roleState?.mirrorcaster?.charged,
+        ts.roleState?.arsonist?.dousedPlayerIds,
       );
       if (!attacked.includes(callerId)) return false;
     }

--- a/src/lib/game/modes/werewolf/actions/start-day.mirrorcaster.spec.ts
+++ b/src/lib/game/modes/werewolf/actions/start-day.mirrorcaster.spec.ts
@@ -38,7 +38,7 @@ describe("WerewolfAction.StartDay — Mirrorcaster charge tracking", () => {
     action.apply(game, null, "owner-1");
 
     const ts = getTurnState(game);
-    expect(ts.mirrorcasterCharged).toBe(true);
+    expect(ts.roleState?.mirrorcaster?.charged).toBe(true);
     expect(ts.deadPlayerIds).not.toContain("p3");
   });
 
@@ -60,7 +60,7 @@ describe("WerewolfAction.StartDay — Mirrorcaster charge tracking", () => {
     action.apply(game, null, "owner-1");
 
     const ts = getTurnState(game);
-    expect(ts.mirrorcasterCharged).toBeUndefined();
+    expect(ts.roleState?.mirrorcaster?.charged).toBeUndefined();
   });
 
   it("charge is consumed when attack is used", () => {
@@ -71,14 +71,14 @@ describe("WerewolfAction.StartDay — Mirrorcaster charge tracking", () => {
       nightPhaseOrder: [WerewolfRole.Mirrorcaster],
     });
     const game = makePlayingGame(
-      { ...baseState, mirrorcasterCharged: true },
+      { ...baseState, roleState: { mirrorcaster: { charged: true } } },
       { roleAssignments: mcRoleAssignments },
     );
 
     action.apply(game, null, "owner-1");
 
     const ts = getTurnState(game);
-    expect(ts.mirrorcasterCharged).toBeUndefined();
+    expect(ts.roleState?.mirrorcaster?.charged).toBeUndefined();
   });
 
   it("charge persists when Mirrorcaster skips their attack", () => {
@@ -87,14 +87,14 @@ describe("WerewolfAction.StartDay — Mirrorcaster charge tracking", () => {
       nightPhaseOrder: [WerewolfRole.Mirrorcaster],
     });
     const game = makePlayingGame(
-      { ...baseState, mirrorcasterCharged: true },
+      { ...baseState, roleState: { mirrorcaster: { charged: true } } },
       { roleAssignments: mcRoleAssignments },
     );
 
     action.apply(game, null, "owner-1");
 
     const ts = getTurnState(game);
-    expect(ts.mirrorcasterCharged).toBe(true);
+    expect(ts.roleState?.mirrorcaster?.charged).toBe(true);
   });
 
   it("charged Mirrorcaster attack kills unprotected target", () => {
@@ -105,7 +105,7 @@ describe("WerewolfAction.StartDay — Mirrorcaster charge tracking", () => {
       nightPhaseOrder: [WerewolfRole.Mirrorcaster],
     });
     const game = makePlayingGame(
-      { ...baseState, mirrorcasterCharged: true },
+      { ...baseState, roleState: { mirrorcaster: { charged: true } } },
       { roleAssignments: mcRoleAssignments },
     );
 
@@ -113,6 +113,6 @@ describe("WerewolfAction.StartDay — Mirrorcaster charge tracking", () => {
 
     const ts = getTurnState(game);
     expect(ts.deadPlayerIds).toContain("p3");
-    expect(ts.mirrorcasterCharged).toBeUndefined();
+    expect(ts.roleState?.mirrorcaster?.charged).toBeUndefined();
   });
 });

--- a/src/lib/game/modes/werewolf/actions/start-day.protection.spec.ts
+++ b/src/lib/game/modes/werewolf/actions/start-day.protection.spec.ts
@@ -90,7 +90,7 @@ describe("WerewolfAction.StartDay — protections", () => {
     );
     action.apply(game, null, "owner-1");
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(ts.priestWards).toEqual({ p2: "p3" });
+    expect(ts.roleState?.priest?.wards).toEqual({ p2: "p3" });
   });
 
   it("Priest ward is consumed when warded player IS attacked", () => {
@@ -117,7 +117,7 @@ describe("WerewolfAction.StartDay — protections", () => {
     );
     action.apply(game, null, "owner-1");
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(ts.priestWards).toBeUndefined();
+    expect(ts.roleState?.priest?.wards).toBeUndefined();
     expect(ts.deadPlayerIds).not.toContain("p2");
   });
 
@@ -144,7 +144,7 @@ describe("WerewolfAction.StartDay — protections", () => {
     action.apply(game, null, "owner-1");
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
     expect(ts.deadPlayerIds).not.toContain("p2");
-    expect(ts.toughGuyHitIds).toContain("p2");
+    expect(ts.roleState?.toughGuy?.hitIds).toContain("p2");
   });
 
   it("Tough Guy dies on second attack when toughGuyHitIds already contains them", () => {
@@ -156,7 +156,7 @@ describe("WerewolfAction.StartDay — protections", () => {
         },
       },
     });
-    nightState.toughGuyHitIds = ["p2"];
+    nightState.roleState = { toughGuy: { hitIds: ["p2"] } };
     const game = makePlayingGame(nightState, {
       roleAssignments: [
         { playerId: "p1", roleDefinitionId: WerewolfRole.Werewolf },
@@ -181,8 +181,9 @@ describe("WerewolfAction.StartDay — protections", () => {
       },
       nightPhaseOrder: [WerewolfRole.Werewolf],
     });
-    nightState.monarchKnightedPlayerIds = ["p3"];
-    nightState.monarchKnightingsUsed = 1;
+    nightState.roleState = {
+      monarch: { knightedPlayerIds: ["p3"], knightingsUsed: 1 },
+    };
     const game = makePlayingGame(nightState, {
       roleAssignments: [
         { playerId: "p1", roleDefinitionId: WerewolfRole.Werewolf },
@@ -208,8 +209,9 @@ describe("WerewolfAction.StartDay — protections", () => {
       },
       nightPhaseOrder: [WerewolfRole.Werewolf, WerewolfRole.Altruist],
     });
-    nightState.monarchKnightedPlayerIds = ["p4"];
-    nightState.monarchKnightingsUsed = 1;
+    nightState.roleState = {
+      monarch: { knightedPlayerIds: ["p4"], knightingsUsed: 1 },
+    };
     const game = makePlayingGame(nightState, {
       roleAssignments: [
         { playerId: "p1", roleDefinitionId: WerewolfRole.Werewolf },
@@ -242,8 +244,9 @@ describe("WerewolfAction.StartDay — protections", () => {
       },
       nightPhaseOrder: [WerewolfRole.Werewolf],
     });
-    nightState.monarchKnightedPlayerIds = ["p1"];
-    nightState.monarchKnightingsUsed = 1;
+    nightState.roleState = {
+      monarch: { knightedPlayerIds: ["p1"], knightingsUsed: 1 },
+    };
     const game = makePlayingGame(nightState, {
       roleAssignments: [
         { playerId: "p1", roleDefinitionId: WerewolfRole.Werewolf },
@@ -271,8 +274,9 @@ describe("WerewolfAction.StartDay — protections", () => {
       },
       nightPhaseOrder: [WerewolfRole.Werewolf],
     });
-    nightState.monarchKnightedPlayerIds = ["p3"];
-    nightState.monarchKnightingsUsed = 1;
+    nightState.roleState = {
+      monarch: { knightedPlayerIds: ["p3"], knightingsUsed: 1 },
+    };
     const game = makePlayingGame(nightState, {
       roleAssignments: [
         { playerId: "p1", roleDefinitionId: WerewolfRole.Werewolf },
@@ -294,8 +298,9 @@ describe("WerewolfAction.StartDay — protections", () => {
       },
       nightPhaseOrder: [WerewolfRole.Mortician],
     });
-    nightState.monarchKnightedPlayerIds = ["p3"];
-    nightState.monarchKnightingsUsed = 1;
+    nightState.roleState = {
+      monarch: { knightedPlayerIds: ["p3"], knightingsUsed: 1 },
+    };
     const game = makePlayingGame(nightState, {
       roleAssignments: [
         { playerId: "p1", roleDefinitionId: WerewolfRole.Werewolf },
@@ -334,8 +339,8 @@ describe("WerewolfAction.StartDay — protections", () => {
     );
     action.apply(game, null, "owner-1");
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(ts.monarchKnightedPlayerIds).toContain("p3");
-    expect(ts.monarchKnightingsUsed).toBe(1);
+    expect(ts.roleState?.monarch?.knightedPlayerIds).toContain("p3");
+    expect(ts.roleState?.monarch?.knightingsUsed).toBe(1);
     expect(ts.deadPlayerIds).toContain("p3");
   });
 
@@ -350,8 +355,9 @@ describe("WerewolfAction.StartDay — protections", () => {
       },
       nightPhaseOrder: [WerewolfRole.Werewolf, WerewolfRole.Monarch],
     });
-    nightState.monarchKnightedPlayerIds = ["p3"];
-    nightState.monarchKnightingsUsed = 1;
+    nightState.roleState = {
+      monarch: { knightedPlayerIds: ["p3"], knightingsUsed: 1 },
+    };
 
     const game = makePlayingGame(nightState, {
       roleAssignments: [
@@ -365,8 +371,8 @@ describe("WerewolfAction.StartDay — protections", () => {
 
     action.apply(game, null, "owner-1");
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(ts.monarchKnightedPlayerIds).toEqual(["p3"]);
-    expect(ts.monarchKnightingsUsed).toBe(1);
+    expect(ts.roleState?.monarch?.knightedPlayerIds).toEqual(["p3"]);
+    expect(ts.roleState?.monarch?.knightingsUsed).toBe(1);
     expect(ts.phase.type).toBe(WerewolfPhase.Daytime);
     if (ts.phase.type === WerewolfPhase.Daytime) {
       expect(ts.phase.knightedPlayerId).toBeUndefined();

--- a/src/lib/game/modes/werewolf/actions/start-day.spec.ts
+++ b/src/lib/game/modes/werewolf/actions/start-day.spec.ts
@@ -287,7 +287,7 @@ describe("WerewolfAction.StartDay — protection roles", () => {
     );
     action.apply(game, null, "owner-1");
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(ts.priestWards).toEqual({ p2: "p3" });
+    expect(ts.roleState?.priest?.wards).toEqual({ p2: "p3" });
   });
 
   it("Priest ward is consumed when warded player IS attacked", () => {
@@ -314,7 +314,7 @@ describe("WerewolfAction.StartDay — protection roles", () => {
     );
     action.apply(game, null, "owner-1");
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(ts.priestWards).toBeUndefined();
+    expect(ts.roleState?.priest?.wards).toBeUndefined();
     expect(ts.deadPlayerIds).not.toContain("p2");
   });
 
@@ -341,7 +341,7 @@ describe("WerewolfAction.StartDay — protection roles", () => {
     action.apply(game, null, "owner-1");
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
     expect(ts.deadPlayerIds).not.toContain("p2");
-    expect(ts.toughGuyHitIds).toContain("p2");
+    expect(ts.roleState?.toughGuy?.hitIds).toContain("p2");
   });
 
   it("Tough Guy dies on second attack when toughGuyHitIds already contains them", () => {
@@ -353,7 +353,7 @@ describe("WerewolfAction.StartDay — protection roles", () => {
         },
       },
     });
-    nightState.toughGuyHitIds = ["p2"];
+    nightState.roleState = { toughGuy: { hitIds: ["p2"] } };
     const game = makePlayingGame(nightState, {
       roleAssignments: [
         { playerId: "p1", roleDefinitionId: WerewolfRole.Werewolf },
@@ -399,7 +399,7 @@ describe("WerewolfAction.StartDay — Hunter and Vigilante", () => {
       );
       action.apply(game, null, "owner-1");
       const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-      expect(ts.hunterRevengePlayerId).toBe("p2");
+      expect(ts.roleState?.hunter?.revengePlayerId).toBe("p2");
       expect(ts.deadPlayerIds).toContain("p2");
     });
 
@@ -437,7 +437,7 @@ describe("WerewolfAction.StartDay — Hunter and Vigilante", () => {
       const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
       // Game should still be playing (not finished), pending Hunter revenge
       expect(ts.phase.type).toBe(WerewolfPhase.Daytime);
-      expect(ts.hunterRevengePlayerId).toBe("p2");
+      expect(ts.roleState?.hunter?.revengePlayerId).toBe("p2");
     });
 
     it("does not set hunterRevengePlayerId when Hunter is not killed", () => {
@@ -454,7 +454,7 @@ describe("WerewolfAction.StartDay — Hunter and Vigilante", () => {
       );
       action.apply(game, null, "owner-1");
       const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-      expect(ts.hunterRevengePlayerId).toBeUndefined();
+      expect(ts.roleState?.hunter?.revengePlayerId).toBeUndefined();
     });
   });
 

--- a/src/lib/game/modes/werewolf/actions/start-day.ts
+++ b/src/lib/game/modes/werewolf/actions/start-day.ts
@@ -5,6 +5,7 @@ import type {
   AttackNightResolutionEvent,
   ToughGuyAbsorbedNightResolutionEvent,
   WerewolfNighttimePhase,
+  WerewolfRoleTurnState,
 } from "../types";
 import {
   currentTurnState,
@@ -28,11 +29,12 @@ export const startDayAction: GameAction = {
     if (!ts) return;
     const nightPhase = ts.phase as WerewolfNighttimePhase;
 
+    const rs = ts.roleState ?? {};
     // Build priest wards: carry forward existing wards and add any new ward
     // from this night's Priest action BEFORE resolution so the ward protects
     // the target on the same night it is placed.
     const priestWardsForResolution: Record<string, string> = {
-      ...(ts.priestWards ?? {}),
+      ...(rs.priest?.wards ?? {}),
     };
     const priestAction = nightPhase.nightActions[WerewolfRole.Priest];
     if (
@@ -70,8 +72,9 @@ export const startDayAction: GameAction = {
       monarchAction.targetPlayerId !== undefined
         ? monarchAction.targetPlayerId
         : undefined;
-    const previousMonarchKnightingsUsed = ts.monarchKnightingsUsed ?? 0;
-    const previousMonarchKnightedPlayerIds = ts.monarchKnightedPlayerIds ?? [];
+    const previousMonarchKnightingsUsed = rs.monarch?.knightingsUsed ?? 0;
+    const previousMonarchKnightedPlayerIds =
+      rs.monarch?.knightedPlayerIds ?? [];
     const monarchCanKnight =
       targetKnightedTonight !== undefined &&
       previousMonarchKnightingsUsed < 3 &&
@@ -102,9 +105,9 @@ export const startDayAction: GameAction = {
       nightPhase.smitedPlayerIds,
       {
         priestWards: priestWardsForResolution,
-        toughGuyHitIds: ts.toughGuyHitIds,
+        toughGuyHitIds: rs.toughGuy?.hitIds,
         ...(oldManTimerPlayerId ? { oldManTimerPlayerId } : {}),
-        ...(ts.mirrorcasterCharged ? { mirrorcasterCharged: true } : {}),
+        ...(rs.mirrorcaster?.charged ? { mirrorcasterCharged: true } : {}),
         ...(monarchPlayerId
           ? {
               monarchProtection: {
@@ -113,8 +116,8 @@ export const startDayAction: GameAction = {
               },
             }
           : {}),
-        ...(ts.arsonistDousedPlayerIds?.length
-          ? { arsonistDousedPlayerIds: ts.arsonistDousedPlayerIds }
+        ...(rs.arsonist?.dousedPlayerIds.length
+          ? { arsonistDousedPlayerIds: rs.arsonist.dousedPlayerIds }
           : {}),
       },
     );
@@ -132,7 +135,10 @@ export const startDayAction: GameAction = {
           e.type === "tough-guy-absorbed",
       )
       .map((e) => e.targetPlayerId);
-    const toughGuyHitIds = [...(ts.toughGuyHitIds ?? []), ...newToughGuyHitIds];
+    const toughGuyHitIds = [
+      ...(rs.toughGuy?.hitIds ?? []),
+      ...newToughGuyHitIds,
+    ];
 
     // Consume priest wards for any warded player who was attacked this night,
     // regardless of whether other protections also saved them.
@@ -152,7 +158,7 @@ export const startDayAction: GameAction = {
 
     // One-Eyed Seer lock: if the OES investigated a werewolf this night, lock them on.
     // If the OES's locked target died this night, the lock is cleared (handled below).
-    let oneEyedSeerLockedTargetId = ts.oneEyedSeerLockedTargetId;
+    let oneEyedSeerLockedTargetId = rs.oneEyedSeer?.lockedTargetId;
     const oesAction =
       nightPhase.nightActions[WerewolfRole.OneEyedSeer as string];
     if (
@@ -180,7 +186,7 @@ export const startDayAction: GameAction = {
     }
 
     // Exposer reveal: if the Exposer confirmed a target this night, store the reveal.
-    let exposerReveal = ts.exposerReveal;
+    let exposerReveal = rs.exposer?.reveal;
     const exposerAction =
       nightPhase.nightActions[WerewolfRole.Exposer as string];
     if (
@@ -242,7 +248,7 @@ export const startDayAction: GameAction = {
     }
 
     // Mortician ability: check if the Mortician killed a Werewolf this night.
-    let morticianAbilityEnded = ts.morticianAbilityEnded === true;
+    let morticianAbilityEnded = rs.mortician?.abilityEnded === true;
     if (!morticianAbilityEnded) {
       const morticianAction = nightPhase.nightActions[WerewolfRole.Mortician];
       if (
@@ -281,7 +287,7 @@ export const startDayAction: GameAction = {
     // (player confirm, narrator override) in one place.
     const witchAction = nightPhase.nightActions[WerewolfRole.Witch as string];
     const witchAbilityUsed =
-      ts.witchAbilityUsed === true ||
+      rs.witch?.abilityUsed === true ||
       (witchAction !== undefined &&
         !isTeamNightAction(witchAction) &&
         witchAction.targetPlayerId !== undefined);
@@ -289,7 +295,7 @@ export const startDayAction: GameAction = {
     const exposerNightAction =
       nightPhase.nightActions[WerewolfRole.Exposer as string];
     const exposerAbilityUsed =
-      ts.exposerAbilityUsed === true ||
+      rs.exposer?.abilityUsed === true ||
       (exposerNightAction !== undefined &&
         !isTeamNightAction(exposerNightAction) &&
         exposerNightAction.targetPlayerId !== undefined);
@@ -298,7 +304,7 @@ export const startDayAction: GameAction = {
     // - If uncharged and the protected target was attacked → gain charge
     // - If charged → charge is consumed (attack was used this night)
     let mirrorcasterCharged = false;
-    if (ts.mirrorcasterCharged) {
+    if (rs.mirrorcaster?.charged) {
       // Charge is consumed by attacking this night.
       const mcAction =
         nightPhase.nightActions[WerewolfRole.Mirrorcaster as string];
@@ -339,19 +345,21 @@ export const startDayAction: GameAction = {
       draculaAction.targetPlayerId &&
       !updatedDeadIds.includes(draculaAction.targetPlayerId)
         ? [
-            ...(ts.draculaWives ?? []).filter(
+            ...(rs.dracula?.wives ?? []).filter(
               (id) => !updatedDeadIds.includes(id),
             ),
-            ...(ts.draculaWives?.includes(draculaAction.targetPlayerId)
+            ...(rs.dracula?.wives.includes(draculaAction.targetPlayerId)
               ? []
               : [draculaAction.targetPlayerId]),
           ]
-        : (ts.draculaWives ?? []).filter((id) => !updatedDeadIds.includes(id));
+        : (rs.dracula?.wives ?? []).filter(
+            (id) => !updatedDeadIds.includes(id),
+          );
 
     // Zombie: add the night's infection target to the accumulated list (if not already infected).
     // Exclude the target if they died the same night they were infected.
     const zombieAction = nightPhase.nightActions[WerewolfRole.Zombie];
-    const existingInfected = (ts.zombieInfected ?? []).filter(
+    const existingInfected = (rs.zombie?.infected ?? []).filter(
       (id) => !updatedDeadIds.includes(id),
     );
     const zombieInfected =
@@ -370,7 +378,7 @@ export const startDayAction: GameAction = {
       (a) => a.roleDefinitionId === (WerewolfRole.Arsonist as string),
     );
     const arsonistAction = nightPhase.nightActions[WerewolfRole.Arsonist];
-    let arsonistDousedPlayerIds = (ts.arsonistDousedPlayerIds ?? []).filter(
+    let arsonistDousedPlayerIds = (rs.arsonist?.dousedPlayerIds ?? []).filter(
       (id) => !updatedDeadIds.includes(id),
     );
     if (
@@ -396,10 +404,56 @@ export const startDayAction: GameAction = {
     }
 
     const wolfCubDied =
-      ts.wolfCubDied === true || didWolfCubDie(newDeadIds, game);
+      rs.wolfCub?.died === true || didWolfCubDie(newDeadIds, game);
     const revealedPlayerIds = getWerewolfModeConfig(game).autoRevealNightOutcome
       ? getOrderedAffectedPlayerIds(nightResolution)
       : [];
+
+    const newRoleState: WerewolfRoleTurnState = {
+      ...(witchAbilityUsed ? { witch: { abilityUsed: true } } : {}),
+      ...(wolfCubDied ? { wolfCub: { died: true } } : {}),
+      ...(Object.keys(priestWards).length > 0
+        ? { priest: { wards: priestWards } }
+        : {}),
+      ...(toughGuyHitIds.length > 0
+        ? { toughGuy: { hitIds: toughGuyHitIds } }
+        : {}),
+      ...(oneEyedSeerLockedTargetId
+        ? { oneEyedSeer: { lockedTargetId: oneEyedSeerLockedTargetId } }
+        : {}),
+      ...(exposerAbilityUsed || exposerReveal
+        ? {
+            exposer: {
+              ...(exposerAbilityUsed ? { abilityUsed: true as const } : {}),
+              ...(exposerReveal ? { reveal: exposerReveal } : {}),
+            },
+          }
+        : {}),
+      ...(hunterDiedThisNight
+        ? { hunter: { revengePlayerId: hunterAssignment.playerId } }
+        : {}),
+      ...(morticianAbilityEnded ? { mortician: { abilityEnded: true } } : {}),
+      ...(monarchKnightedPlayerIds.length > 0 || monarchKnightingsUsed > 0
+        ? {
+            monarch: {
+              knightedPlayerIds: monarchKnightedPlayerIds,
+              knightingsUsed: monarchKnightingsUsed,
+            },
+          }
+        : {}),
+      ...(rs.executioner?.targetId
+        ? { executioner: { targetId: rs.executioner.targetId } }
+        : {}),
+      ...(mirrorcasterCharged ? { mirrorcaster: { charged: true } } : {}),
+      ...(draculaWives.length > 0 ? { dracula: { wives: draculaWives } } : {}),
+      ...(zombieInfected.length > 0
+        ? { zombie: { infected: zombieInfected } }
+        : {}),
+      ...(arsonistDousedPlayerIds.length > 0
+        ? { arsonist: { dousedPlayerIds: arsonistDousedPlayerIds } }
+        : {}),
+    };
+
     game.status = {
       type: GameStatus.Playing,
       turnState: {
@@ -416,30 +470,9 @@ export const startDayAction: GameAction = {
             : {}),
         },
         deadPlayerIds: updatedDeadIds,
-        ...(witchAbilityUsed ? { witchAbilityUsed: true } : {}),
         ...(Object.keys(lastTargets).length > 0 ? { lastTargets } : {}),
-        ...(wolfCubDied ? { wolfCubDied: true } : {}),
-        ...(Object.keys(priestWards).length > 0 ? { priestWards } : {}),
-        ...(toughGuyHitIds.length > 0 ? { toughGuyHitIds } : {}),
-        ...(oneEyedSeerLockedTargetId ? { oneEyedSeerLockedTargetId } : {}),
-        ...(exposerAbilityUsed ? { exposerAbilityUsed: true } : {}),
-        ...(exposerReveal ? { exposerReveal } : {}),
-        ...(hunterDiedThisNight
-          ? { hunterRevengePlayerId: hunterAssignment.playerId }
-          : {}),
-        ...(morticianAbilityEnded ? { morticianAbilityEnded: true } : {}),
-        ...(monarchKnightedPlayerIds.length > 0
-          ? { monarchKnightedPlayerIds }
-          : {}),
-        ...(monarchKnightingsUsed > 0 ? { monarchKnightingsUsed } : {}),
-        ...(ts.executionerTargetId
-          ? { executionerTargetId: ts.executionerTargetId }
-          : {}),
-        ...(mirrorcasterCharged ? { mirrorcasterCharged: true } : {}),
-        ...(draculaWives.length > 0 ? { draculaWives } : {}),
-        ...(zombieInfected.length > 0 ? { zombieInfected } : {}),
-        ...(arsonistDousedPlayerIds.length > 0
-          ? { arsonistDousedPlayerIds }
+        ...(Object.keys(newRoleState).length > 0
+          ? { roleState: newRoleState }
           : {}),
       },
     };

--- a/src/lib/game/modes/werewolf/actions/start-night.spec.ts
+++ b/src/lib/game/modes/werewolf/actions/start-night.spec.ts
@@ -338,12 +338,12 @@ describe("StartNight — Mirrorcaster charge persistence", () => {
   it("carries mirrorcasterCharged forward to the next night", () => {
     const game = makePlayingGame({
       ...dayTurnState,
-      mirrorcasterCharged: true,
+      roleState: { mirrorcaster: { charged: true } },
     });
     startNightAction.apply(game, null, "owner-1");
 
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(ts.mirrorcasterCharged).toBe(true);
+    expect(ts.roleState?.mirrorcaster?.charged).toBe(true);
   });
 
   it("does not carry mirrorcasterCharged when it is false/undefined", () => {
@@ -351,18 +351,18 @@ describe("StartNight — Mirrorcaster charge persistence", () => {
     startNightAction.apply(game, null, "owner-1");
 
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(ts.mirrorcasterCharged).toBeUndefined();
+    expect(ts.roleState?.mirrorcaster?.charged).toBeUndefined();
   });
 
   it("carries morticianAbilityEnded forward to next night", () => {
     const game = makePlayingGame({
       ...dayTurnState,
-      morticianAbilityEnded: true,
+      roleState: { mortician: { abilityEnded: true } },
     });
     startNightAction.apply(game, null, "owner-1");
 
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(ts.morticianAbilityEnded).toBe(true);
+    expect(ts.roleState?.mortician?.abilityEnded).toBe(true);
   });
 
   it("does not carry morticianAbilityEnded when it is false/undefined", () => {
@@ -370,20 +370,21 @@ describe("StartNight — Mirrorcaster charge persistence", () => {
     startNightAction.apply(game, null, "owner-1");
 
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(ts.morticianAbilityEnded).toBeUndefined();
+    expect(ts.roleState?.mortician?.abilityEnded).toBeUndefined();
   });
 
   it("carries Monarch knighting fields forward to next night", () => {
     const game = makePlayingGame({
       ...dayTurnState,
-      monarchKnightedPlayerIds: ["p2", "p3"],
-      monarchKnightingsUsed: 2,
+      roleState: {
+        monarch: { knightedPlayerIds: ["p2", "p3"], knightingsUsed: 2 },
+      },
     });
     startNightAction.apply(game, null, "owner-1");
 
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(ts.monarchKnightedPlayerIds).toEqual(["p2", "p3"]);
-    expect(ts.monarchKnightingsUsed).toBe(2);
+    expect(ts.roleState?.monarch?.knightedPlayerIds).toEqual(["p2", "p3"]);
+    expect(ts.roleState?.monarch?.knightingsUsed).toBe(2);
   });
 
   it("does not carry Monarch knighting fields when absent", () => {
@@ -391,7 +392,7 @@ describe("StartNight — Mirrorcaster charge persistence", () => {
     startNightAction.apply(game, null, "owner-1");
 
     const ts = (game.status as { turnState: WerewolfTurnState }).turnState;
-    expect(ts.monarchKnightedPlayerIds).toBeUndefined();
-    expect(ts.monarchKnightingsUsed).toBeUndefined();
+    expect(ts.roleState?.monarch?.knightedPlayerIds).toBeUndefined();
+    expect(ts.roleState?.monarch?.knightingsUsed).toBeUndefined();
   });
 });

--- a/src/lib/game/modes/werewolf/actions/start-night.ts
+++ b/src/lib/game/modes/werewolf/actions/start-night.ts
@@ -1,7 +1,7 @@
 import { GameStatus } from "@/lib/types";
 import type { Game, GameAction } from "@/lib/types";
 import { WerewolfPhase } from "../types";
-import type { WerewolfDaytimePhase } from "../types";
+import type { WerewolfDaytimePhase, WerewolfRoleTurnState } from "../types";
 import {
   buildNightPhaseOrder,
   currentTurnState,
@@ -17,7 +17,7 @@ export const startNightAction: GameAction = {
     const ts = currentTurnState(game);
     if (ts?.phase.type !== WerewolfPhase.Daytime) return false;
     // Cannot advance to night while Hunter revenge is pending
-    if (ts.hunterRevengePlayerId) return false;
+    if (ts.roleState?.hunter?.revengePlayerId) return false;
     // Cannot advance to night while a trial is actively ongoing
     if (ts.phase.activeTrial && !ts.phase.activeTrial.verdict) return false;
     return true;
@@ -27,11 +27,12 @@ export const startNightAction: GameAction = {
     if (!ts) return;
     const dayPhase = ts.phase as WerewolfDaytimePhase;
     const nextTurn = ts.turn + 1;
+    const rs = ts.roleState ?? {};
     // If a Wolf Cub died last turn, Werewolves get an extra phase this night.
     // Use a suffixed key so the second phase has its own nightActions entry.
     const wolfCubBonusPhaseKey =
       WerewolfRole.Werewolf + GROUP_PHASE_KEY_SEPARATOR + "2";
-    const extraGroupPhaseKeys = ts.wolfCubDied ? [wolfCubBonusPhaseKey] : [];
+    const extraGroupPhaseKeys = rs.wolfCub?.died ? [wolfCubBonusPhaseKey] : [];
     const nightPhaseOrder = buildNightPhaseOrder(
       nextTurn,
       game.roleAssignments,
@@ -47,20 +48,46 @@ export const startNightAction: GameAction = {
     // Dracula: carry forward wives (filtering out the dead) and check win condition.
     // Dracula wins if alive and ≥3 wives are alive at the start of any night
     // (after the first full day-and-night cycle, i.e. turn > 1).
-    const aliveWives = (ts.draculaWives ?? []).filter(
+    const aliveWives = (rs.dracula?.wives ?? []).filter(
       (id) => !ts.deadPlayerIds.includes(id),
     );
 
     // Zombie: carry forward infected list (filtering out the dead).
-    const aliveInfected = (ts.zombieInfected ?? []).filter(
+    const aliveInfected = (rs.zombie?.infected ?? []).filter(
       (id) => !ts.deadPlayerIds.includes(id),
     );
-    const monarchKnightingsUsed = ts.monarchKnightingsUsed;
 
     // Arsonist: carry forward doused list (filtering out the dead).
-    const aliveDousedPlayerIds = (ts.arsonistDousedPlayerIds ?? []).filter(
+    const aliveDousedPlayerIds = (rs.arsonist?.dousedPlayerIds ?? []).filter(
       (id) => !ts.deadPlayerIds.includes(id),
     );
+
+    // Build the new roleState: carry forward persistent role state, reset wolfCub.
+    // One-Eyed Seer lock is dropped if the locked target is now dead.
+    const newRoleState: WerewolfRoleTurnState = {
+      ...(rs.witch?.abilityUsed ? { witch: rs.witch } : {}),
+      ...(rs.priest?.wards ? { priest: rs.priest } : {}),
+      ...(rs.toughGuy?.hitIds.length ? { toughGuy: rs.toughGuy } : {}),
+      ...(rs.oneEyedSeer?.lockedTargetId &&
+      !ts.deadPlayerIds.includes(rs.oneEyedSeer.lockedTargetId)
+        ? { oneEyedSeer: rs.oneEyedSeer }
+        : {}),
+      ...(rs.exposer?.abilityUsed || rs.exposer?.reveal
+        ? { exposer: rs.exposer }
+        : {}),
+      ...(rs.mortician?.abilityEnded ? { mortician: rs.mortician } : {}),
+      ...(rs.monarch ? { monarch: rs.monarch } : {}),
+      ...(rs.executioner?.targetId ? { executioner: rs.executioner } : {}),
+      ...(rs.mirrorcaster?.charged ? { mirrorcaster: rs.mirrorcaster } : {}),
+      ...(aliveWives.length > 0 ? { dracula: { wives: aliveWives } } : {}),
+      ...(aliveInfected.length > 0
+        ? { zombie: { infected: aliveInfected } }
+        : {}),
+      ...(aliveDousedPlayerIds.length > 0
+        ? { arsonist: { dousedPlayerIds: aliveDousedPlayerIds } }
+        : {}),
+      // wolfCub.died is intentionally NOT carried forward — consumed by this night's bonus phase
+    };
 
     game.status = {
       type: GameStatus.Playing,
@@ -75,32 +102,9 @@ export const startNightAction: GameAction = {
           ...(pendingSmites?.length ? { smitedPlayerIds: pendingSmites } : {}),
         },
         deadPlayerIds: ts.deadPlayerIds,
-        ...(ts.witchAbilityUsed ? { witchAbilityUsed: true } : {}),
         ...(ts.lastTargets ? { lastTargets: ts.lastTargets } : {}),
-        ...(ts.priestWards ? { priestWards: ts.priestWards } : {}),
-        ...(ts.toughGuyHitIds?.length
-          ? { toughGuyHitIds: ts.toughGuyHitIds }
-          : {}),
-        // One-Eyed Seer: carry forward lock unless the locked target is now dead.
-        ...(ts.oneEyedSeerLockedTargetId &&
-        !ts.deadPlayerIds.includes(ts.oneEyedSeerLockedTargetId)
-          ? { oneEyedSeerLockedTargetId: ts.oneEyedSeerLockedTargetId }
-          : {}),
-        ...(ts.exposerAbilityUsed ? { exposerAbilityUsed: true } : {}),
-        ...(ts.morticianAbilityEnded ? { morticianAbilityEnded: true } : {}),
-        ...(ts.monarchKnightedPlayerIds?.length
-          ? { monarchKnightedPlayerIds: ts.monarchKnightedPlayerIds }
-          : {}),
-        ...((monarchKnightingsUsed ?? 0) > 0 ? { monarchKnightingsUsed } : {}),
-        ...(ts.exposerReveal ? { exposerReveal: ts.exposerReveal } : {}),
-        ...(ts.executionerTargetId
-          ? { executionerTargetId: ts.executionerTargetId }
-          : {}),
-        ...(ts.mirrorcasterCharged ? { mirrorcasterCharged: true } : {}),
-        ...(aliveWives.length > 0 ? { draculaWives: aliveWives } : {}),
-        ...(aliveInfected.length > 0 ? { zombieInfected: aliveInfected } : {}),
-        ...(aliveDousedPlayerIds.length > 0
-          ? { arsonistDousedPlayerIds: aliveDousedPlayerIds }
+        ...(Object.keys(newRoleState).length > 0
+          ? { roleState: newRoleState }
           : {}),
       },
     };

--- a/src/lib/game/modes/werewolf/roles/turn-state-types.ts
+++ b/src/lib/game/modes/werewolf/roles/turn-state-types.ts
@@ -1,0 +1,84 @@
+/**
+ * Per-role persistent state types stored within WerewolfTurnState.roleState.
+ *
+ * These interfaces are intentionally free of imports from sibling modules to
+ * avoid circular dependencies — types.ts imports from this file, and role
+ * files import from types.ts.
+ *
+ * Each role file re-exports its own type from here so callers can import the
+ * type directly from the role's module.
+ */
+
+export interface ArsonistTurnState {
+  /** Player IDs that have been doused. Accumulated across nights; reset after an ignite. */
+  dousedPlayerIds: string[];
+}
+
+export interface DraculaTurnState {
+  /** Player IDs claimed as wives. Accumulated across nights. */
+  wives: string[];
+}
+
+export interface ExecutionerTurnState {
+  /** The player ID the Executioner must get eliminated at trial to win. */
+  targetId: string;
+}
+
+export interface ExposerTurnState {
+  /** True once the Exposer has used their once-per-game ability. */
+  abilityUsed?: true;
+  /** The role publicly revealed by the Exposer. */
+  reveal?: { playerId: string; roleId: string };
+}
+
+export interface HunterTurnState {
+  /** Set when the Hunter dies — blocks win-condition checks until resolved. */
+  revengePlayerId: string;
+}
+
+export interface MirrorcasterTurnState {
+  /** True when charged from a successful protection (Attack mode active). */
+  charged: boolean;
+}
+
+export interface MonarchTurnState {
+  /** Public list of players knighted by the Monarch. */
+  knightedPlayerIds: string[];
+  /** Number of times the Monarch has knighted a player (max 3). */
+  knightingsUsed: number;
+}
+
+export interface MorticianTurnState {
+  /** True once the Mortician has successfully killed a Werewolf. */
+  abilityEnded: boolean;
+}
+
+export interface OneEyedSeerTurnState {
+  /** Locked onto this player ID after detecting a Werewolf. */
+  lockedTargetId: string;
+}
+
+export interface PriestTurnState {
+  /** Warded player IDs mapped to the Priest who placed the ward. */
+  wards: Record<string, string>;
+}
+
+export interface ToughGuyTurnState {
+  /** Player IDs that have already survived one attack. */
+  hitIds: string[];
+}
+
+export interface WitchTurnState {
+  /** True once the Witch has used their once-per-game ability. */
+  abilityUsed: boolean;
+}
+
+export interface WolfCubTurnState {
+  /** True if the Wolf Cub died this turn — Werewolves get two phases the following night. */
+  died: boolean;
+}
+
+export interface ZombieTurnState {
+  /** Player IDs that have been infected. Accumulated across nights. */
+  infected: string[];
+}

--- a/src/lib/game/modes/werewolf/roles/turn-state-types.ts
+++ b/src/lib/game/modes/werewolf/roles/turn-state-types.ts
@@ -5,8 +5,8 @@
  * avoid circular dependencies — types.ts imports from this file, and role
  * files import from types.ts.
  *
- * Each role file re-exports its own type from here so callers can import the
- * type directly from the role's module.
+ * All types are re-exported from types.ts so callers can import them from
+ * the main Werewolf types barrel.
  */
 
 export interface ArsonistTurnState {

--- a/src/lib/game/modes/werewolf/services-tests/nighttime-helpers.ts
+++ b/src/lib/game/modes/werewolf/services-tests/nighttime-helpers.ts
@@ -27,7 +27,9 @@ export function makeNighttimeGame(
       nightActions: nightActions as Record<string, AnyNightAction>,
     },
     deadPlayerIds: [],
-    ...(witchAbilityUsed ? { witchAbilityUsed: true } : {}),
+    ...(witchAbilityUsed
+      ? { roleState: { witch: { abilityUsed: true } } }
+      : {}),
   };
   return {
     id: "game-1",

--- a/src/lib/game/modes/werewolf/services/index.ts
+++ b/src/lib/game/modes/werewolf/services/index.ts
@@ -66,7 +66,7 @@ function extractNonOwnerState(
   const daytimeNightState = extractDaytimeNightSummary(game, callerId);
   const daytimePlayerState = extractDaytimePlayerState(game, callerId);
   const ts = currentTurnState(game);
-  const monarchKnightingsUsed = ts?.monarchKnightingsUsed;
+  const monarchKnightingsUsed = ts?.roleState?.monarch?.knightingsUsed;
 
   const amDead = deadPlayerIds.includes(callerId);
   const visibleDeadPlayerIds = extractVisibleDeadPlayerIds(game, callerId);
@@ -92,8 +92,8 @@ function extractNonOwnerState(
     ...(visibleDeadPlayerIds.length > 0
       ? { deadPlayerIds: visibleDeadPlayerIds }
       : {}),
-    ...(ts?.monarchKnightedPlayerIds?.length
-      ? { monarchKnightedPlayerIds: ts.monarchKnightedPlayerIds }
+    ...(ts?.roleState?.monarch?.knightedPlayerIds.length
+      ? { monarchKnightedPlayerIds: ts.roleState.monarch.knightedPlayerIds }
       : {}),
     ...((monarchKnightingsUsed ?? 0) > 0 ? { monarchKnightingsUsed } : {}),
     ...executionerState,

--- a/src/lib/game/modes/werewolf/services/initialization.ts
+++ b/src/lib/game/modes/werewolf/services/initialization.ts
@@ -52,6 +52,8 @@ export function buildInitialTurnState(
     turn: 1,
     phase,
     deadPlayerIds: [],
-    ...(executionerTargetId ? { executionerTargetId } : {}),
+    ...(executionerTargetId
+      ? { roleState: { executioner: { targetId: executionerTargetId } } }
+      : {}),
   };
 }

--- a/src/lib/game/modes/werewolf/services/owner-state.ts
+++ b/src/lib/game/modes/werewolf/services/owner-state.ts
@@ -45,7 +45,7 @@ function extractDeadPlayerIds(game: Game): string[] {
 /** Extracts the Hunter revenge player ID (narrator-only). */
 function extractHunterRevengePlayerId(game: Game): string | undefined {
   const ts = currentTurnState(game);
-  return ts?.hunterRevengePlayerId;
+  return ts?.roleState?.hunter?.revengePlayerId;
 }
 
 /**
@@ -123,8 +123,8 @@ export function extractDaytimeNightSummary(
   };
 
   // Exposer reveal: show the publicly revealed role to all players.
-  if (ts.exposerReveal) {
-    const exposerReveal = ts.exposerReveal;
+  if (ts.roleState?.exposer?.reveal) {
+    const exposerReveal = ts.roleState.exposer.reveal;
     const revealedPlayer = game.players.find(
       (p) => p.id === exposerReveal.playerId,
     );
@@ -184,8 +184,8 @@ export function extractDaytimePlayerState(
       a.playerId === callerId &&
       a.roleDefinitionId === (WerewolfRole.Executioner as string),
   );
-  if (callerExecutionerAssignment && ts.executionerTargetId) {
-    result.executionerTargetId = ts.executionerTargetId;
+  if (callerExecutionerAssignment && ts.roleState?.executioner?.targetId) {
+    result.executionerTargetId = ts.roleState.executioner.targetId;
   }
 
   // Silenced / hypnotized.
@@ -281,7 +281,7 @@ export function extractOwnerState(
   const nightActions = extractNightActions(game);
   const deadPlayerIds = extractDeadPlayerIds(game);
   const hunterRevengePlayerId = extractHunterRevengePlayerId(game);
-  const monarchKnightingsUsed = ts?.monarchKnightingsUsed;
+  const monarchKnightingsUsed = ts?.roleState?.monarch?.knightingsUsed;
   const callerId = game.ownerPlayerId ?? "";
   const daytimeNightState = extractDaytimeNightSummary(game, callerId);
 
@@ -299,8 +299,8 @@ export function extractOwnerState(
     ...(game.executionerTargetId
       ? { executionerTargetId: game.executionerTargetId }
       : {}),
-    ...(ts?.monarchKnightedPlayerIds?.length
-      ? { monarchKnightedPlayerIds: ts.monarchKnightedPlayerIds }
+    ...(ts?.roleState?.monarch?.knightedPlayerIds.length
+      ? { monarchKnightedPlayerIds: ts.roleState.monarch.knightedPlayerIds }
       : {}),
     ...((monarchKnightingsUsed ?? 0) > 0 ? { monarchKnightingsUsed } : {}),
     ...(hiddenRoleIds ? { hiddenRoleIds } : {}),

--- a/src/lib/game/modes/werewolf/services/player-night-state.ts
+++ b/src/lib/game/modes/werewolf/services/player-night-state.ts
@@ -15,8 +15,8 @@ import { WerewolfRole, getWerewolfRole } from "../roles";
 import { WEREWOLF_COPY } from "../copy";
 
 function hasPriestActiveWard(ts: WerewolfTurnState | undefined): boolean {
-  if (!ts?.priestWards) return false;
-  return Object.keys(ts.priestWards).some(
+  if (!ts?.roleState?.priest?.wards) return false;
+  return Object.keys(ts.roleState.priest.wards).some(
     (wardedId) => !ts.deadPlayerIds.includes(wardedId),
   );
 }
@@ -153,7 +153,7 @@ function extractRoleSpecificState(
     return {
       myNightTarget: soloAction?.skipped ? null : soloAction?.targetPlayerId,
       myNightTargetConfirmed: soloAction?.confirmed ?? false,
-      exposerAbilityUsed: ts?.exposerAbilityUsed ?? false,
+      exposerAbilityUsed: ts?.roleState?.exposer?.abilityUsed ?? false,
     };
   }
 
@@ -166,7 +166,7 @@ function extractRoleSpecificState(
     return {
       myNightTarget: soloAction?.skipped ? null : soloAction?.targetPlayerId,
       myNightTargetConfirmed: soloAction?.confirmed ?? false,
-      morticianAbilityEnded: ts?.morticianAbilityEnded ?? false,
+      morticianAbilityEnded: ts?.roleState?.mortician?.abilityEnded ?? false,
     };
   }
 
@@ -192,7 +192,7 @@ function extractRoleSpecificState(
     return {
       myNightTarget: soloAction?.skipped ? null : soloAction?.targetPlayerId,
       myNightTargetConfirmed: soloAction?.confirmed ?? false,
-      mirrorcasterCharged: ts?.mirrorcasterCharged ?? false,
+      mirrorcasterCharged: ts?.roleState?.mirrorcaster?.charged ?? false,
     };
   }
 
@@ -200,8 +200,8 @@ function extractRoleSpecificState(
     return {
       myNightTarget: undefined,
       myNightTargetConfirmed: false,
-      ...(ts?.executionerTargetId
-        ? { executionerTargetId: ts.executionerTargetId }
+      ...(ts?.roleState?.executioner?.targetId
+        ? { executionerTargetId: ts.roleState.executioner.targetId }
         : {}),
     };
   }
@@ -215,21 +215,19 @@ function extractRoleSpecificState(
     return {
       myNightTarget: soloAction?.skipped ? null : soloAction?.targetPlayerId,
       myNightTargetConfirmed: soloAction?.confirmed ?? false,
-      ...(ts?.arsonistDousedPlayerIds?.length
-        ? { arsonistDousedPlayerIds: ts.arsonistDousedPlayerIds }
+      ...(ts?.roleState?.arsonist?.dousedPlayerIds.length
+        ? { arsonistDousedPlayerIds: ts.roleState.arsonist.dousedPlayerIds }
         : {}),
     };
   }
 
   if (myRole.id === WerewolfRole.OneEyedSeer) {
-    if (
-      ts?.oneEyedSeerLockedTargetId &&
-      !ts.deadPlayerIds.includes(ts.oneEyedSeerLockedTargetId)
-    ) {
+    const lockedTargetId = ts?.roleState?.oneEyedSeer?.lockedTargetId;
+    if (lockedTargetId && !ts.deadPlayerIds.includes(lockedTargetId)) {
       return {
         myNightTarget: undefined,
         myNightTargetConfirmed: false,
-        oneEyedSeerLockedTargetId: ts.oneEyedSeerLockedTargetId,
+        oneEyedSeerLockedTargetId: lockedTargetId,
       };
     }
   }
@@ -289,16 +287,16 @@ function extractWitchState(
   const result: Partial<WerewolfPlayerGameState> = {
     myNightTarget: soloAction?.skipped ? null : soloAction?.targetPlayerId,
     myNightTargetConfirmed: soloAction?.confirmed ?? false,
-    witchAbilityUsed: ts?.witchAbilityUsed ?? false,
+    witchAbilityUsed: ts?.roleState?.witch?.abilityUsed ?? false,
   };
-  if (!ts?.witchAbilityUsed) {
+  if (!ts?.roleState?.witch?.abilityUsed) {
     const attacked = getInterimAttackedPlayerIds(
       nightActions,
       game.roleAssignments,
       deadPlayerIds,
-      ts?.priestWards,
-      ts?.mirrorcasterCharged,
-      ts?.arsonistDousedPlayerIds,
+      ts?.roleState?.priest?.wards,
+      ts?.roleState?.mirrorcaster?.charged,
+      ts?.roleState?.arsonist?.dousedPlayerIds,
     );
     if (attacked.length > 0) {
       result.nightStatus = attacked.map(
@@ -333,9 +331,9 @@ function extractAltruistState(
     nightActions,
     game.roleAssignments,
     deadPlayerIds,
-    ts?.priestWards,
-    ts?.mirrorcasterCharged,
-    ts?.arsonistDousedPlayerIds,
+    ts?.roleState?.priest?.wards,
+    ts?.roleState?.mirrorcaster?.charged,
+    ts?.roleState?.arsonist?.dousedPlayerIds,
   ).filter((id) => id !== callerId && id !== witchProtectedId);
   const result: Partial<WerewolfPlayerGameState> = {
     myNightTarget: soloAction?.skipped ? null : soloAction?.targetPlayerId,

--- a/src/lib/game/modes/werewolf/types.ts
+++ b/src/lib/game/modes/werewolf/types.ts
@@ -1,3 +1,37 @@
+import type {
+  ArsonistTurnState,
+  DraculaTurnState,
+  ExecutionerTurnState,
+  ExposerTurnState,
+  HunterTurnState,
+  MirrorcasterTurnState,
+  MonarchTurnState,
+  MorticianTurnState,
+  OneEyedSeerTurnState,
+  PriestTurnState,
+  ToughGuyTurnState,
+  WitchTurnState,
+  WolfCubTurnState,
+  ZombieTurnState,
+} from "./roles/turn-state-types";
+
+export type {
+  ArsonistTurnState,
+  DraculaTurnState,
+  ExecutionerTurnState,
+  ExposerTurnState,
+  HunterTurnState,
+  MirrorcasterTurnState,
+  MonarchTurnState,
+  MorticianTurnState,
+  OneEyedSeerTurnState,
+  PriestTurnState,
+  ToughGuyTurnState,
+  WitchTurnState,
+  WolfCubTurnState,
+  ZombieTurnState,
+};
+
 export enum WerewolfPhase {
   Nighttime = "nighttime",
   Daytime = "daytime",
@@ -166,52 +200,41 @@ export interface WerewolfDaytimePhase {
 
 export type WerewolfTurnPhase = WerewolfNighttimePhase | WerewolfDaytimePhase;
 
+/**
+ * Namespaced per-role persistent state stored within WerewolfTurnState.
+ * Adding a new role adds one optional key here; no other turn-state field changes.
+ * Each role's state type is defined in roles/turn-state-types.ts.
+ */
+export interface WerewolfRoleTurnState {
+  arsonist?: ArsonistTurnState;
+  dracula?: DraculaTurnState;
+  executioner?: ExecutionerTurnState;
+  exposer?: ExposerTurnState;
+  hunter?: HunterTurnState;
+  mirrorcaster?: MirrorcasterTurnState;
+  monarch?: MonarchTurnState;
+  mortician?: MorticianTurnState;
+  oneEyedSeer?: OneEyedSeerTurnState;
+  priest?: PriestTurnState;
+  toughGuy?: ToughGuyTurnState;
+  witch?: WitchTurnState;
+  wolfCub?: WolfCubTurnState;
+  zombie?: ZombieTurnState;
+}
+
 export interface WerewolfTurnState {
   turn: number;
   phase: WerewolfTurnPhase;
   /** Player IDs that have been marked as dead by the narrator. */
   deadPlayerIds: string[];
-  /** True once the Witch has used her once-per-game special ability. */
-  witchAbilityUsed?: boolean;
   /**
    * Maps phase key → player ID that was targeted last night.
    * Used to prevent roles with preventRepeatTarget from targeting the same
    * player on consecutive nights.
    */
   lastTargets?: Record<string, string>;
-  /** True if a Wolf Cub died this turn — Werewolves get two phases the following night. */
-  wolfCubDied?: boolean;
-  /** Maps warded player ID → Priest player ID. Ward persists until the warded player is attacked. */
-  priestWards?: Record<string, string>;
-  /** Player IDs of Tough Guys who have already survived one attack. */
-  toughGuyHitIds?: string[];
-  /**
-   * One-Eyed Seer is locked onto this player ID after detecting a Werewolf.
-   * Cleared when the locked target is eliminated.
-   */
-  oneEyedSeerLockedTargetId?: string;
-  /** Set when the Hunter dies — blocks win-condition checks and game advancement until resolved. */
-  hunterRevengePlayerId?: string;
-  /** True once the Exposer has used their once-per-game ability. */
-  exposerAbilityUsed?: boolean;
-  /** The role publicly revealed by the Exposer. Persists for the rest of the game. */
-  exposerReveal?: { playerId: string; roleId: string };
-  /** True once the Mortician has successfully killed a Werewolf. */
-  morticianAbilityEnded?: boolean;
-  /** Player IDs that have been knighted by the Monarch. Public information. */
-  monarchKnightedPlayerIds?: string[];
-  /** Number of times the Monarch has used their knighting ability (max 3). */
-  monarchKnightingsUsed?: number;
-  /** The player ID that the Executioner must get eliminated at trial to win. */
-  executionerTargetId?: string;
-  /** True when the Mirrorcaster has gained a charge from a successful protection. */
-  mirrorcasterCharged?: boolean;
-  /** Player IDs that Dracula has claimed as wives. Accumulated across nights. */
-  draculaWives?: string[];
-  /** Player IDs that the Zombie has infected. Accumulated across nights. */
-  zombieInfected?: string[];
-  /** Player IDs that the Arsonist has doused. Accumulated across nights; reset after an ignite. */
-  arsonistDousedPlayerIds?: string[];
+  /** Namespaced per-role persistent state. One optional key per role. */
+  roleState?: WerewolfRoleTurnState;
 }
 
 export interface TargetablePlayer {

--- a/src/lib/game/modes/werewolf/utils/win-condition.spec.ts
+++ b/src/lib/game/modes/werewolf/utils/win-condition.spec.ts
@@ -330,7 +330,9 @@ describe("checkWinCondition", () => {
   describe("Zombie", () => {
     it("Zombie wins when infected alive outnumber healthy alive", () => {
       // zombie + p1 (infected) + p2 (infected) + p3 (healthy): 2 infected > 1 healthy
-      const ts = makeDayTurnState({ zombieInfected: ["p1", "p2"] });
+      const ts = makeDayTurnState({
+        roleState: { zombie: { infected: ["p1", "p2"] } },
+      });
       const game = makeGame(
         [
           { playerId: "zombie", roleDefinitionId: WerewolfRole.Zombie },
@@ -345,7 +347,9 @@ describe("checkWinCondition", () => {
     });
 
     it("game continues when infected equals healthy", () => {
-      const ts = makeDayTurnState({ zombieInfected: ["p1"] });
+      const ts = makeDayTurnState({
+        roleState: { zombie: { infected: ["p1"] } },
+      });
       const game = makeGame(
         [
           { playerId: "zombie", roleDefinitionId: WerewolfRole.Zombie },
@@ -359,7 +363,9 @@ describe("checkWinCondition", () => {
     });
 
     it("Zombie does not win when dead", () => {
-      const ts = makeDayTurnState({ zombieInfected: ["p1", "p2"] });
+      const ts = makeDayTurnState({
+        roleState: { zombie: { infected: ["p1", "p2"] } },
+      });
       const game = makeGame(
         [
           { playerId: "zombie", roleDefinitionId: WerewolfRole.Zombie },
@@ -376,7 +382,9 @@ describe("checkWinCondition", () => {
     it("dead infected players are not counted for Zombie win", () => {
       // zombie + p1 (infected, dead) + p2 (infected) + p3 (healthy)
       // alive: 1 infected vs 1 healthy → no win
-      const ts = makeDayTurnState({ zombieInfected: ["p1", "p2"] });
+      const ts = makeDayTurnState({
+        roleState: { zombie: { infected: ["p1", "p2"] } },
+      });
       const game = makeGame(
         [
           { playerId: "zombie", roleDefinitionId: WerewolfRole.Zombie },

--- a/src/lib/game/modes/werewolf/utils/win-condition.ts
+++ b/src/lib/game/modes/werewolf/utils/win-condition.ts
@@ -42,9 +42,9 @@ export function checkWinCondition(
   if (
     zombieAssignment &&
     !deadSet.has(zombieAssignment.playerId) &&
-    ts?.zombieInfected?.length
+    ts?.roleState?.zombie?.infected.length
   ) {
-    const infectedSet = new Set(ts.zombieInfected);
+    const infectedSet = new Set(ts.roleState.zombie.infected);
     const infectedAlive = aliveAssignments.filter((a) =>
       infectedSet.has(a.playerId),
     ).length;


### PR DESCRIPTION
Eliminates the flat bag of 16+ role-specific optional fields in `WerewolfTurnState` and the monolithic Firebase player state serializer, replacing both with an extensible namespaced structure.

Key structural changes:
- `WerewolfTurnState` gains `roleState?: WerewolfRoleTurnState` in place of all flat role fields; adding a new role now touches one line here
- Named per-role turn state types (`ArsonistTurnState`, `WitchTurnState`, etc.) are defined in `roles/turn-state-types.ts` and re-exported from `types.ts`
- `FirebaseWerewolfRoleState` and its two converters (`werewolfRoleStateToFirebase` / `werewolfRoleStateFromFirebase`) are extracted to `werewolf-roles.ts`; `FirebaseWerewolfPlayerState` extends this interface and both converters delegate to it — new roles only touch `werewolf-roles.ts`
- All action, service, spec, and component files updated to use the new `roleState.*` paths

## Acceptance Criteria
- [x] `WerewolfTurnState` contains no role-specific optional fields; all role state is under `roleState`
- [x] Each role's turn state type is defined in `roles/turn-state-types.ts` (named exports, re-exported from `types.ts`)
- [x] `FirebaseWerewolfPlayerState` and the two converters contain no role-specific fields; role serialization is delegated to `werewolf-roles.ts`
- [x] All existing role logic reads/writes state via the new namespaced paths
- [x] Firebase round-trip tests pass (1901/1901 tests green)
- [x] Lint and typecheck clean
- [x] No behavior changes — pure structural refactor

## Tests
1901 tests, all passing. No new tests needed — this is a pure structural refactor with no logic changes.

Closes #636

---
*Created by Claude Sonnet 4.5*