### PR TITLE
ci(storybook): automate story screenshots in PR descriptions

### DIFF
--- a/.github/scripts/generate-story-urls.ts
+++ b/.github/scripts/generate-story-urls.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Generate a screenshots.config.yml for auto-pr-screenshots-action.
+ *
+ * Usage:
+ *   pnpm tsx .github/scripts/generate-story-urls.ts [file1.stories.tsx ...]
+ *
+ * File paths should be relative to the repository root (as produced by
+ * `git diff --name-only`). When no files are passed the output is an empty
+ * screenshots list so the screenshots job exits cleanly without errors.
+ */
+import { readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+import { generateScreenshotsConfig } from "../../src/lib/storybook-screenshots/story-utils.js";
+
+const STORYBOOK_BASE_URL = "http://localhost:6006";
+const OUTPUT_PATH = join(process.cwd(), ".github", "screenshots.config.yml");
+
+const filePaths = process.argv.slice(2).filter(Boolean);
+
+if (filePaths.length === 0) {
+  console.log("No story files provided — writing empty config.");
+  writeFileSync(OUTPUT_PATH, "screenshots: []\n");
+  process.exit(0);
+}
+
+const files = filePaths.map((filePath) => ({
+  path: filePath,
+  content: readFileSync(filePath, "utf-8"),
+}));
+
+const config = generateScreenshotsConfig(files, STORYBOOK_BASE_URL);
+writeFileSync(OUTPUT_PATH, config);
+console.log(`Generated ${filePaths.length} story file(s) → ${OUTPUT_PATH}`);

--- a/.github/workflows/storybook-screenshots.yml
+++ b/.github/workflows/storybook-screenshots.yml
@@ -33,7 +33,9 @@ jobs:
           echo "files=${CHANGED}" >> "$GITHUB_OUTPUT"
 
       - name: Generate screenshots config
-        run: pnpm tsx .github/scripts/generate-story-urls.ts ${{ steps.stories.outputs.files }}
+        env:
+          CHANGED_FILES: ${{ steps.stories.outputs.files }}
+        run: pnpm tsx .github/scripts/generate-story-urls.ts $CHANGED_FILES
 
       - name: Build Storybook
         run: pnpm build-storybook --output-dir storybook-static

--- a/.github/workflows/storybook-screenshots.yml
+++ b/.github/workflows/storybook-screenshots.yml
@@ -1,0 +1,57 @@
+name: Storybook Screenshots
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "src/**/*.stories.tsx"
+      - "src/**/*.stories.ts"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  screenshots:
+    name: Capture Storybook Screenshots
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install chromium --with-deps
+
+      - name: Detect changed story files
+        id: stories
+        run: |
+          CHANGED=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD \
+            -- 'src/**/*.stories.tsx' 'src/**/*.stories.ts' | tr '\n' ' ')
+          echo "files=${CHANGED}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate screenshots config
+        run: pnpm tsx .github/scripts/generate-story-urls.ts ${{ steps.stories.outputs.files }}
+
+      - name: Build Storybook
+        run: pnpm build-storybook --output-dir storybook-static
+
+      - name: Serve Storybook
+        run: npx --yes serve storybook-static -l 6006 &
+
+      - name: Wait for Storybook
+        run: |
+          echo "Waiting for Storybook on port 6006…"
+          for i in $(seq 1 60); do
+            curl -sf http://localhost:6006 > /dev/null && echo "Ready." && exit 0
+            sleep 2
+          done
+          echo "Storybook did not start in time." && exit 1
+
+      - name: Capture screenshots
+        uses: yoavf/auto-pr-screenshots-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: .github/screenshots.config.yml

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -68,6 +68,17 @@ export default tseslint.config(
       "@typescript-eslint/no-non-null-assertion": "off",
     },
   },
+  // CI scripts under .github/ run in Node.js; register node globals so `process`
+  // and `console` are recognised without typed linting (scripts are not in the
+  // app tsconfig project).
+  {
+    files: [".github/**/*.ts"],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
   // Storybook stories use loose patterns; skip strict type checking
   {
     files: ["src/**/*.stories.tsx"],

--- a/src/lib/storybook-screenshots/story-utils.spec.ts
+++ b/src/lib/storybook-screenshots/story-utils.spec.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  exportNameToStoryId,
+  extractStoryExportNames,
+  extractTitleFromContent,
+  filePathToAutoTitle,
+  generateScreenshotsConfig,
+  titleToComponentId,
+} from "./story-utils";
+
+describe("filePathToAutoTitle", () => {
+  it("capitalizes directory segments and strips .stories.tsx", () => {
+    expect(filePathToAutoTitle("src/components/HomeLink.stories.tsx")).toBe(
+      "Components/HomeLink",
+    );
+  });
+
+  it("handles nested paths", () => {
+    expect(
+      filePathToAutoTitle("src/components/lobby/ExpandedRoleList.stories.tsx"),
+    ).toBe("Components/Lobby/ExpandedRoleList");
+  });
+
+  it("handles app directory", () => {
+    expect(filePathToAutoTitle("src/app/HomePageView.stories.tsx")).toBe(
+      "App/HomePageView",
+    );
+  });
+
+  it("works without src/ prefix", () => {
+    expect(filePathToAutoTitle("components/HomeLink.stories.tsx")).toBe(
+      "Components/HomeLink",
+    );
+  });
+
+  it("handles .stories.ts extension", () => {
+    expect(filePathToAutoTitle("src/components/Foo.stories.ts")).toBe(
+      "Components/Foo",
+    );
+  });
+});
+
+describe("titleToComponentId", () => {
+  it("lowercases and replaces slashes with hyphens", () => {
+    expect(titleToComponentId("Components/HomeLink")).toBe(
+      "components-homelink",
+    );
+  });
+
+  it("handles deeply nested title", () => {
+    expect(titleToComponentId("Components/Lobby/ExpandedRoleList")).toBe(
+      "components-lobby-expandedrolelist",
+    );
+  });
+
+  it("handles a simple single-segment title", () => {
+    expect(titleToComponentId("HomeLink")).toBe("homelink");
+  });
+});
+
+describe("exportNameToStoryId", () => {
+  it("lowercases a simple single-word name", () => {
+    expect(exportNameToStoryId("Default")).toBe("default");
+  });
+
+  it("converts PascalCase to kebab-case", () => {
+    expect(exportNameToStoryId("FlatNoSearch")).toBe("flat-no-search");
+  });
+
+  it("converts two-word PascalCase", () => {
+    expect(exportNameToStoryId("ActiveSearch")).toBe("active-search");
+  });
+
+  it("converts multi-word PascalCase", () => {
+    expect(exportNameToStoryId("ActiveLobbyWithGame")).toBe(
+      "active-lobby-with-game",
+    );
+  });
+
+  it("converts ErrorState", () => {
+    expect(exportNameToStoryId("ErrorState")).toBe("error-state");
+  });
+});
+
+describe("extractTitleFromContent", () => {
+  it("returns the title when present with double quotes", () => {
+    const content = `const meta = { title: "Custom/Title", component: Foo } satisfies Meta<typeof Foo>;`;
+    expect(extractTitleFromContent(content)).toBe("Custom/Title");
+  });
+
+  it("returns the title when present with single quotes", () => {
+    const content = `const meta = { title: 'Lobby/Panel', component: Foo };`;
+    expect(extractTitleFromContent(content)).toBe("Lobby/Panel");
+  });
+
+  it("returns undefined when no title is set", () => {
+    const content = `const meta = { component: HomeLink } satisfies Meta<typeof HomeLink>;`;
+    expect(extractTitleFromContent(content)).toBeUndefined();
+  });
+});
+
+describe("extractStoryExportNames", () => {
+  it("extracts capitalized named exports", () => {
+    const content = `
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const Default: Story = {};
+export const FlatNoSearch: Story = { args: {} };
+    `;
+    expect(extractStoryExportNames(content)).toEqual([
+      "Default",
+      "FlatNoSearch",
+    ]);
+  });
+
+  it("excludes the default export", () => {
+    const content = `export default meta;`;
+    expect(extractStoryExportNames(content)).toEqual([]);
+  });
+
+  it("excludes lowercase exports", () => {
+    const content = `
+const meta = {};
+export default meta;
+export const Default: Story = {};
+    `;
+    expect(extractStoryExportNames(content)).toEqual(["Default"]);
+  });
+
+  it("returns empty array when no stories", () => {
+    const content = `export default meta;`;
+    expect(extractStoryExportNames(content)).toEqual([]);
+  });
+});
+
+describe("generateScreenshotsConfig", () => {
+  it("generates YAML with a single story URL", () => {
+    const files = [
+      {
+        path: "src/components/HomeLink.stories.tsx",
+        content: `
+const meta = { component: HomeLink } satisfies Meta<typeof HomeLink>;
+export default meta;
+export const Default: Story = {};
+        `,
+      },
+    ];
+    const result = generateScreenshotsConfig(files, "http://localhost:6006");
+    expect(result).toContain(
+      "http://localhost:6006/?path=/story/components-homelink--default",
+    );
+  });
+
+  it("generates entries for multiple stories in one file", () => {
+    const files = [
+      {
+        path: "src/components/lobby/ExpandedRoleList.stories.tsx",
+        content: `
+const meta = { component: ExpandedRoleList };
+export default meta;
+export const FlatNoSearch: Story = {};
+export const ActiveSearch: Story = {};
+        `,
+      },
+    ];
+    const result = generateScreenshotsConfig(files, "http://localhost:6006");
+    expect(result).toContain(
+      "components-lobby-expandedrolelist--flat-no-search",
+    );
+    expect(result).toContain(
+      "components-lobby-expandedrolelist--active-search",
+    );
+  });
+
+  it("uses explicit title over auto-title when present", () => {
+    const files = [
+      {
+        path: "src/components/HomeLink.stories.tsx",
+        content: `
+const meta = { title: "Custom/Title", component: HomeLink };
+export default meta;
+export const Default: Story = {};
+        `,
+      },
+    ];
+    const result = generateScreenshotsConfig(files, "http://localhost:6006");
+    expect(result).toContain("custom-title--default");
+    expect(result).not.toContain("components-homelink");
+  });
+
+  it("returns empty screenshots list when no files", () => {
+    const result = generateScreenshotsConfig([], "http://localhost:6006");
+    expect(result).toContain("screenshots: []");
+  });
+
+  it("returns empty screenshots list when files have no story exports", () => {
+    const files = [
+      {
+        path: "src/components/HomeLink.stories.tsx",
+        content: `export default meta;`,
+      },
+    ];
+    const result = generateScreenshotsConfig(files, "http://localhost:6006");
+    expect(result).toContain("screenshots: []");
+  });
+});

--- a/src/lib/storybook-screenshots/story-utils.spec.ts
+++ b/src/lib/storybook-screenshots/story-utils.spec.ts
@@ -98,6 +98,15 @@ describe("extractTitleFromContent", () => {
     const content = `const meta = { component: HomeLink } satisfies Meta<typeof HomeLink>;`;
     expect(extractTitleFromContent(content)).toBeUndefined();
   });
+
+  it("ignores title in story args (only reads meta block)", () => {
+    const content = `
+const meta = { component: RoleGlossaryDialog } satisfies Meta<typeof RoleGlossaryDialog>;
+export default meta;
+export const Default: Story = { args: { title: "Role Glossary" } };
+    `;
+    expect(extractTitleFromContent(content)).toBeUndefined();
+  });
 });
 
 describe("extractStoryExportNames", () => {

--- a/src/lib/storybook-screenshots/story-utils.ts
+++ b/src/lib/storybook-screenshots/story-utils.ts
@@ -1,0 +1,100 @@
+/** Derives a Storybook auto-title from a stories file path.
+ *
+ * Mirrors the Storybook 7+ auto-title convention: each path segment (relative
+ * to src/) has its first letter capitalised, then the segments are joined with
+ * "/".  The ".stories.tsx/.ts" extension is stripped.
+ *
+ * e.g. "src/components/lobby/ExpandedRoleList.stories.tsx"
+ *      → "Components/Lobby/ExpandedRoleList"
+ */
+export function filePathToAutoTitle(filePath: string): string {
+  const withoutSrc = filePath.startsWith("src/") ? filePath.slice(4) : filePath;
+  const withoutExt = withoutSrc.replace(/\.stories\.[tj]sx?$/, "");
+  return withoutExt
+    .split("/")
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join("/");
+}
+
+/** Converts a Storybook title string to a sanitised component ID.
+ *
+ * e.g. "Components/Lobby/ExpandedRoleList" → "components-lobby-expandedrolelist"
+ */
+export function titleToComponentId(title: string): string {
+  return sanitize(title.replace(/\//g, "-"));
+}
+
+/** Converts a PascalCase story export name to a kebab-case story ID.
+ *
+ * Mirrors Storybook's own `startCase` → sanitise pipeline:
+ * "FlatNoSearch" → "Flat No Search" → "flat-no-search"
+ */
+export function exportNameToStoryId(exportName: string): string {
+  const withSpaces = exportName.replace(/([a-z])([A-Z])/g, "$1 $2");
+  return sanitize(withSpaces);
+}
+
+/** Extracts the explicit `title` value from a story file's source, or
+ *  returns `undefined` when no title is set (auto-title mode). */
+export function extractTitleFromContent(content: string): string | undefined {
+  const match = /title:\s*["']([^"']+)["']/.exec(content);
+  return match?.[1];
+}
+
+/** Returns the names of all named story exports from a story file's source.
+ *
+ * Only capitalised exports are included (story names are PascalCase by
+ * convention); `default` and lowercase utility exports are excluded.
+ */
+export function extractStoryExportNames(content: string): string[] {
+  const matches = [...content.matchAll(/^export const ([A-Z]\w+)/gm)];
+  return matches
+    .map((m) => m[1])
+    .filter((name): name is string => name !== undefined);
+}
+
+/** Generates a `screenshots.config.yml` string for `auto-pr-screenshots-action`.
+ *
+ * Each story in each file becomes one entry with a Storybook `?path=/story/…`
+ * URL.  If no stories are found the output is `screenshots: []`.
+ */
+export function generateScreenshotsConfig(
+  files: { path: string; content: string }[],
+  baseUrl: string,
+): string {
+  const entries: { name: string; url: string }[] = [];
+
+  for (const file of files) {
+    const title =
+      extractTitleFromContent(file.content) ?? filePathToAutoTitle(file.path);
+    const componentId = titleToComponentId(title);
+    const storyNames = extractStoryExportNames(file.content);
+
+    for (const storyName of storyNames) {
+      const storyId = exportNameToStoryId(storyName);
+      entries.push({
+        name: `${title} - ${storyName}`,
+        url: `${baseUrl}/?path=/story/${componentId}--${storyId}`,
+      });
+    }
+  }
+
+  if (entries.length === 0) {
+    return "screenshots: []\n";
+  }
+
+  const lines = ["screenshots:"];
+  for (const entry of entries) {
+    lines.push(`  - name: "${entry.name}"`);
+    lines.push(`    url: "${entry.url}"`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+function sanitize(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/src/lib/storybook-screenshots/story-utils.ts
+++ b/src/lib/storybook-screenshots/story-utils.ts
@@ -37,7 +37,8 @@ export function exportNameToStoryId(exportName: string): string {
 /** Extracts the explicit `title` value from a story file's source, or
  *  returns `undefined` when no title is set (auto-title mode). */
 export function extractTitleFromContent(content: string): string | undefined {
-  const match = /title:\s*["']([^"']+)["']/.exec(content);
+  const metaBlock = content.split(/export\s+default\s+meta\b/)[0] ?? content;
+  const match = /title:\s*["']([^"']+)["']/.exec(metaBlock);
   return match?.[1];
 }
 
@@ -85,10 +86,14 @@ export function generateScreenshotsConfig(
 
   const lines = ["screenshots:"];
   for (const entry of entries) {
-    lines.push(`  - name: "${entry.name}"`);
-    lines.push(`    url: "${entry.url}"`);
+    lines.push(`  - name: ${yamlSingleQuote(entry.name)}`);
+    lines.push(`    url: ${yamlSingleQuote(entry.url)}`);
   }
   return lines.join("\n") + "\n";
+}
+
+function yamlSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
 }
 
 function sanitize(str: string): string {


### PR DESCRIPTION
Adds automated Storybook screenshot capture for PRs that touch `*.stories.tsx` files. When a PR modifies stories, the workflow builds Storybook, derives story URLs from the changed files, and uses `auto-pr-screenshots-action` to post a screenshot gallery as a PR comment — eliminating the manual step of opening Storybook locally to review UI changes.

The story-detection logic lives in `src/lib/storybook-screenshots/story-utils.ts` and is fully tested. A lightweight CLI wrapper at `.github/scripts/generate-story-urls.ts` calls it and writes `.github/screenshots.config.yml` for the action. Story IDs are derived from the file path (Storybook auto-title convention) when no explicit `title` is set in the meta, matching how Storybook 7+ generates IDs.

## Acceptance Criteria
- [x] A story-detection script maps changed `*.stories.tsx` files to Storybook story IDs/paths
- [x] The script outputs a `screenshots.config.yml` compatible with `auto-pr-screenshots-action`
- [x] A GitHub Actions workflow triggers on PRs when `*.stories.tsx` files change, builds Storybook, and runs the screenshot action

## Tests
25 tests added, all passing.

Closes #446

---
*Created by Claude Sonnet 4.5*