### PR TITLE
chore(infra): add pnpm install step to AGENTS.md worktree setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ pnpm run secrets-check # Gitleaks secret scan (runs in pre-commit)
 
 ## Worktree Setup
 
-After creating a git worktree (`git worktree add .git-worktrees/<name> -b <branch> origin/main`), run `pnpm install --frozen-lockfile` inside it before invoking any build or test commands. pnpm's `node-modules` linker creates per-directory `node_modules` trees; a fresh worktree has none. The global store is already populated so this step only creates hardlinks — it takes a few seconds and requires no network access.
+After creating a git worktree (`git worktree add .git-worktrees/<name> -b <branch> origin/main`), run `pnpm install --frozen-lockfile` inside it before invoking any build, test, lint, or typecheck commands. pnpm's `node-modules` linker creates per-directory `node_modules` trees; a fresh worktree has none. The global store is already populated so this step only creates hardlinks — it takes a few seconds and requires no network access.
 
 ## Secret Management
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,10 @@ pnpm run env:pull     # Pull .env.local from Vercel (requires vercel login)
 pnpm run secrets-check # Gitleaks secret scan (runs in pre-commit)
 ```
 
+## Worktree Setup
+
+After creating a git worktree (`git worktree add .git-worktrees/<name> -b <branch> origin/main`), run `pnpm install --frozen-lockfile` inside it before invoking any build or test commands. pnpm's `node-modules` linker creates per-directory `node_modules` trees; a fresh worktree has none. The global store is already populated so this step only creates hardlinks — it takes a few seconds and requires no network access.
+
 ## Secret Management
 
 - Pull `.env.local` for local development: `pnpm run env:pull` (requires `vercel login`)


### PR DESCRIPTION
Adds a "Worktree Setup" section to `AGENTS.md` immediately after "Common Commands", documenting that `pnpm install --frozen-lockfile` must be run inside a fresh worktree before any build, test, or lint command can succeed.

pnpm's `node-modules` linker creates per-directory `node_modules` trees — a fresh worktree has none, causing all toolchain commands to fail with misleading errors. The install is fast because the global content-addressable store is already populated; only hardlinks are created.

## Acceptance Criteria
- [x] `AGENTS.md` has a "Worktree Setup" section immediately after "Common Commands" that instructs agents to run `pnpm install --frozen-lockfile` before any build/test/lint command
- [x] The note clarifies that `pnpm install` in a fresh worktree is fast (hardlinks from global store, no network access)

## Tests
No automated tests — documentation-only change.

Closes #665

---
*Created by Claude Sonnet 4.5*