### PR TITLE
fix(werewolf): correct Village win-condition docstring for non-killer Neutrals

### DIFF
--- a/src/lib/game/modes/werewolf/utils/win-condition.spec.ts
+++ b/src/lib/game/modes/werewolf/utils/win-condition.spec.ts
@@ -65,6 +65,28 @@ describe("checkWinCondition", () => {
       const result = checkWinCondition(game, ["p1"]);
       expect(result?.winner).toBe(WerewolfWinner.Village);
     });
+
+    it("Village wins when all Bad are dead and a non-killer Neutral (Tanner) is still alive", () => {
+      // Non-killer Neutrals (Tanner, Executioner, Dracula, Zombie) are not a threat to
+      // Village win — only killer Neutrals (Chupacabra, Arsonist) delay the Village win.
+      const game = makeGame([
+        { playerId: "p1", roleDefinitionId: WerewolfRole.Werewolf },
+        { playerId: "p2", roleDefinitionId: WerewolfRole.Villager },
+        { playerId: "p3", roleDefinitionId: WerewolfRole.Tanner },
+      ]);
+      const result = checkWinCondition(game, ["p1"]);
+      expect(result?.winner).toBe(WerewolfWinner.Village);
+    });
+
+    it("Village wins when all Bad are dead and an Executioner is still alive alongside Good", () => {
+      const game = makeGame([
+        { playerId: "p1", roleDefinitionId: WerewolfRole.Werewolf },
+        { playerId: "p2", roleDefinitionId: WerewolfRole.Villager },
+        { playerId: "p3", roleDefinitionId: WerewolfRole.Executioner },
+      ]);
+      const result = checkWinCondition(game, ["p1"]);
+      expect(result?.winner).toBe(WerewolfWinner.Village);
+    });
   });
 
   describe("Werewolves win", () => {

--- a/src/lib/game/modes/werewolf/utils/win-condition.ts
+++ b/src/lib/game/modes/werewolf/utils/win-condition.ts
@@ -13,7 +13,8 @@ import { currentTurnState } from "./game-state";
  * 1. Chupacabra/Arsonist wins: exactly one neutral killer alive (Chupacabra or Arsonist)
  *    with ≤1 Good player alive
  * 2. Draw: no Bad, no Neutral, no Good players alive (everyone eliminated simultaneously)
- * 3. Village wins: no Bad and no Neutral players remain
+ * 3. Village wins: no Bad and no killer Neutral (Chupacabra/Arsonist) remain;
+ *    non-killer Neutrals (Tanner, Executioner, Dracula, Zombie) may still be alive
  *    (Chupacabra/Arsonist still alive with >1 Good → game continues)
  *
  * When badAlive > 0:
@@ -136,7 +137,7 @@ export function checkWinCondition(
       if (goodAlive === 0 && neutralAlive === 0) {
         winResult = { type: GameStatus.Finished, winner: WerewolfWinner.Draw };
       } else {
-        // Village wins: no Bad and no Neutral remain
+        // Village wins: no Bad and no killer Neutral remain (non-killer Neutrals may still be alive)
         winResult = {
           type: GameStatus.Finished,
           winner: WerewolfWinner.Village,


### PR DESCRIPTION
The JSDoc comment for `checkWinCondition` incorrectly stated Village wins only when "no Neutral players remain". The implementation has always correctly allowed non-killer Neutrals (Tanner, Executioner, Dracula, Zombie) to coexist with Good players while still triggering a Village win — only killer Neutrals (Chupacabra, Arsonist) delay it.

This PR corrects the function-level JSDoc and the inline comment to accurately describe the semantics, and adds two regression tests covering Tanner and Executioner remaining alongside Good players.

## Acceptance Criteria
- [x] Docstring in `win-condition.ts` accurately states Village wins when no Bad and no killer Neutral (Chupacabra/Arsonist) remain; non-killer Neutrals may still be alive
- [x] A test confirms non-killer Neutrals remaining alongside Good players do not prevent Village from winning

## Tests
2 tests added, all passing (58/58 total).

Closes #620

---
*Created by Claude Sonnet 4.5*