### PR TITLE
chore(infra): add .git-worktrees to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,5 +2,6 @@ node_modules
 dist
 .next
 .claude
+.git-worktrees
 src/components/ui
 pnpm-lock.yaml


### PR DESCRIPTION
Adds `.git-worktrees` to `.prettierignore` so the PostToolUse Prettier hook skips all files inside agent worktrees, preventing spurious reformats of ShadCN UI components when sub-agents edit files at absolute worktree-rooted paths.

## Acceptance Criteria
- [x] `.git-worktrees` is present in `.prettierignore`, causing Prettier to skip all files under `.git-worktrees/` regardless of path depth.

## Tests
No tests added — this is a config-only change with no executable logic.

Closes #653

---
*Created by Claude Sonnet 4.5*