### PR TITLE
chore: exclude pnpm-lock.yaml from lint-staged Prettier and mark as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+pnpm-lock.yaml linguist-generated=true

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,0 +1,12 @@
+export default {
+  "*.{js,mjs,cjs,ts,tsx,jsx}": [
+    "eslint --fix --max-warnings 0 --no-warn-ignored",
+    "prettier --write",
+  ],
+  "*.{js,mjs,cjs,ts,tsx,jsx,json,md,yml,yaml}": (files) => {
+    const toFormat = files.filter((f) => !f.endsWith("pnpm-lock.yaml"));
+    return toFormat.length > 0
+      ? [`prettier --write ${toFormat.join(" ")}`]
+      : [];
+  },
+};

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -3,7 +3,7 @@ export default {
     "eslint --fix --max-warnings 0 --no-warn-ignored",
     "prettier --write",
   ],
-  "*.{js,mjs,cjs,ts,tsx,jsx,json,md,yml,yaml}": (files) => {
+  "*.{json,md,yml,yaml}": (files) => {
     const toFormat = files.filter((f) => !f.endsWith("pnpm-lock.yaml"));
     return toFormat.length > 0
       ? [`prettier --write ${toFormat.join(" ")}`]

--- a/package.json
+++ b/package.json
@@ -39,15 +39,6 @@
       "sharp"
     ]
   },
-  "lint-staged": {
-    "*.{js,mjs,cjs,ts,tsx,jsx}": [
-      "eslint --fix --max-warnings 0 --no-warn-ignored",
-      "prettier --write"
-    ],
-    "*.{json,md,yml,yaml}": [
-      "prettier --write"
-    ]
-  },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
     "@fluentui/react-icons": "^2.0.326",


### PR DESCRIPTION
`pnpm-lock.yaml` is autogenerated and should never be reformatted by tooling. `.prettierignore` already excludes it from `prettier --check .` (CI), but lint-staged's `*.yaml` glob passes it explicitly to `prettier --write`, bypassing the ignore file.

- **`lint-staged.config.mjs`**: extracts lint-staged config from `package.json` into a dedicated `.mjs` file (required to use function-based filtering), with a function filter on the non-JS glob that drops `pnpm-lock.yaml` before passing files to Prettier
- **`.gitattributes`**: marks `pnpm-lock.yaml` as `linguist-generated` so GitHub collapses its diffs in PRs and excludes it from language stats

---

_Created by Claude Sonnet 4.6_
