### PR TITLE
ci!: pin pnpm version in CI to match packageManager field

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,8 +11,6 @@ runs:
   using: "composite"
   steps:
     - uses: pnpm/action-setup@v5
-      with:
-        version: 10
     - uses: actions/setup-node@v6
       with:
         node-version: 24.x

--- a/package.json
+++ b/package.json
@@ -104,5 +104,6 @@
     "vercel-deploy-scripts": "https://github.com/rmartz/vercel-deploy-scripts/archive/refs/tags/v3.1.0.tar.gz",
     "vite": "^8.0.14",
     "vitest": "^4.1.7"
-  }
+  },
+  "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800"
 }


### PR DESCRIPTION
`pnpm/action-setup@v5` with `version: 10` floats to the latest `10.x` patch on every CI run. When pnpm `10.34.x` tightened integrity enforcement for tarball URL dependencies, CI broke on all open branches while local (on `10.30.3`) stayed green — a silent divergence that required a manual lockfile repair ([#702](https://github.com/rmartz/hidden-role-game/pull/702)) to unblock.

Dropping `version: 10` from the setup action causes `pnpm/action-setup@v5` to read the exact version from the `packageManager` field in `package.json` instead. CI and local will always run the same pnpm, so any behavioral change from a pnpm upgrade is caught the moment `packageManager` is updated — before it can silently affect other branches.

---
*Created by Claude Sonnet 4.6*