### PR TITLE
ci: add 1-minute timeout to typecheck job

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -38,6 +38,7 @@ jobs:
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup


### PR DESCRIPTION
Adds `timeout-minutes: 1` to the `typecheck` job in `ci-actions.yml`.

`pnpm tsc` on this codebase consistently completes in under 30 seconds. The timeout is a safety net against a rare runaway execution (e.g. a plugin or tsconfig misconfiguration that causes tsc to loop) hanging the job indefinitely and blocking the PR queue.

This is a tightening change — adding a constraint where none existed.

---
*Created by Claude Sonnet 4.6*