### PR TITLE
docs: align docs/ reference pages with Open Knowledge Format (OKF)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ After creating a git worktree (`git worktree add .git-worktrees/<name> -b <branc
 ## Documentation
 
 - When adding or modifying roles, actions, game settings, or data flow in a game mode, update the corresponding docs in `docs/<game-mode>/` (`roles.md`, `actions.md`, `data-flow.md`).
+- Pages under `docs/` follow the [Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md): every page begins with YAML frontmatter. The required key is `type` (one of `Index`, `Guide`, `Reference`, `Roles`, `Actions`, `DataFlow`); also set `title` and `description`. Per-mode pages additionally set `gameMode` (the mode slug) and `resource` (relative path to the documented source). When you add a new page, include the frontmatter and link it from `docs/README.md` so the index stays complete.
 
 ## React / Next.js Standards
 

--- a/docs/GAME_MODES.md
+++ b/docs/GAME_MODES.md
@@ -1,3 +1,10 @@
+---
+type: Reference
+title: Game Mode Documentation
+description: Overview of every supported game mode and links to its roles, actions, and data-flow pages.
+tags: [game-modes, overview]
+---
+
 # Game Mode Documentation
 
 This directory contains documentation for each supported game mode.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,3 +1,10 @@
+---
+type: Guide
+title: Getting Started
+description: Onboarding guide for new developers — prerequisites, setup, and local development.
+tags: [onboarding, setup, guide]
+---
+
 # Getting Started
 
 A guide for new developers getting acquainted with the codebase.

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -1,3 +1,10 @@
+---
+type: Reference
+title: Project Structure
+description: Directory-by-directory breakdown of the codebase.
+tags: [architecture, structure, reference]
+---
+
 # Project Structure
 
 A directory-by-directory breakdown of the codebase.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,55 @@
+---
+type: Index
+title: Documentation Index
+description: Directory listing of all docs/ reference pages, grouped by kind.
+tags: [index, documentation]
+---
+
+# Documentation Index
+
+Curated reference knowledge for this codebase. Each page carries [Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) YAML frontmatter so agents can retrieve and traverse it before a task. This page is the OKF `index.md`-style directory listing.
+
+## Page types
+
+| Type        | Meaning                                                     |
+| ----------- | ----------------------------------------------------------- |
+| `Index`     | This directory listing.                                     |
+| `Guide`     | Task-oriented walkthrough (onboarding, how-to).             |
+| `Reference` | Structural reference not tied to a single game mode.        |
+| `Roles`     | A game mode's roles, teams, and visibility rules.           |
+| `Actions`   | A game mode's actions, payloads, and validation.            |
+| `DataFlow`  | A game mode's `PlayerGameState` fields and Firebase schema. |
+
+## General
+
+- [Getting Started](GETTING_STARTED.md) — onboarding guide for new developers.
+- [Project Structure](PROJECT_STRUCTURE.md) — directory-by-directory breakdown of the codebase.
+- [Game Mode Documentation](GAME_MODES.md) — overview of every supported game mode.
+
+## Game modes
+
+### Werewolf
+
+- [Roles](werewolf/roles.md)
+- [Actions](werewolf/actions.md)
+- [Data Flow](werewolf/data-flow.md)
+
+### Secret Villain
+
+- [Roles](secret-villain/roles.md)
+- [Actions](secret-villain/actions.md)
+- [Data Flow](secret-villain/data-flow.md)
+
+### Avalon
+
+- [Roles](avalon/roles.md)
+- [Actions](avalon/actions.md)
+- [Data Flow](avalon/data-flow.md)
+
+### Clocktower
+
+- [Actions](clocktower/actions.md)
+
+## Adding a page
+
+New pages under `docs/` must begin with OKF frontmatter — at minimum the required `type` key, plus `title` and `description`. Per-mode pages also set `gameMode` and a `resource` path to the documented source. After adding a page, link it from the relevant section above so the index stays complete.

--- a/docs/avalon/actions.md
+++ b/docs/avalon/actions.md
@@ -1,3 +1,12 @@
+---
+type: Actions
+title: Avalon — Actions
+description: Quest Leader and player actions; questing and voting happen outside the app.
+gameMode: avalon
+resource: src/lib/game/modes/avalon/actions
+tags: [avalon, actions]
+---
+
 # Avalon — Actions
 
 Actions are the mechanism by which the Quest Leader and players mutate game state. Each action has an `isValid` guard and an `apply` mutation.

--- a/docs/avalon/data-flow.md
+++ b/docs/avalon/data-flow.md
@@ -1,3 +1,12 @@
+---
+type: DataFlow
+title: Avalon — Data Flow
+description: PlayerGameState fields and visibility rules; no night-phase mechanics.
+gameMode: avalon
+resource: src/lib/game/modes/avalon
+tags: [avalon, data-flow, firebase]
+---
+
 # Avalon — Data Flow
 
 ## Overview

--- a/docs/avalon/roles.md
+++ b/docs/avalon/roles.md
@@ -1,3 +1,12 @@
+---
+type: Roles
+title: Avalon — Roles
+description: Three roles with asymmetric initial visibility set up by the app.
+gameMode: avalon
+resource: src/lib/game/modes/avalon
+tags: [avalon, roles, visibility]
+---
+
 # Avalon — Roles
 
 ## Overview

--- a/docs/clocktower/actions.md
+++ b/docs/clocktower/actions.md
@@ -1,3 +1,12 @@
+---
+type: Actions
+title: Clocktower — Actions
+description: Storyteller and player actions, payloads, and validation rules.
+gameMode: clocktower
+resource: src/lib/game/modes/clocktower/actions
+tags: [clocktower, actions]
+---
+
 # Clocktower — Actions
 
 Actions are the mechanism by which the Storyteller and players mutate game state. Each action has an `isValid` guard and an `apply` mutation.

--- a/docs/secret-villain/actions.md
+++ b/docs/secret-villain/actions.md
@@ -1,3 +1,12 @@
+---
+type: Actions
+title: Secret Villain — Actions
+description: All player actions across election, policy, and presidential special-action phases.
+gameMode: secret-villain
+resource: src/lib/game/modes/secret-villain/actions
+tags: [secret-villain, actions]
+---
+
 # Secret Villain — Actions
 
 Secret Villain is fully app-mediated. All gameplay flows through the actions listed below.

--- a/docs/secret-villain/data-flow.md
+++ b/docs/secret-villain/data-flow.md
@@ -1,3 +1,12 @@
+---
+type: DataFlow
+title: Secret Villain — Data Flow
+description: PlayerGameState fields by phase and role, Firebase schema, and phase transitions.
+gameMode: secret-villain
+resource: src/lib/game/modes/secret-villain
+tags: [secret-villain, data-flow, firebase]
+---
+
 # Secret Villain — Data Flow
 
 ## Overview

--- a/docs/secret-villain/roles.md
+++ b/docs/secret-villain/roles.md
@@ -1,3 +1,12 @@
+---
+type: Roles
+title: Secret Villain — Roles
+description: Three roles with deliberate visibility asymmetry around the Special Bad.
+gameMode: secret-villain
+resource: src/lib/game/modes/secret-villain
+tags: [secret-villain, roles, visibility]
+---
+
 # Secret Villain — Roles
 
 ## Overview

--- a/docs/werewolf/actions.md
+++ b/docs/werewolf/actions.md
@@ -1,3 +1,12 @@
+---
+type: Actions
+title: Werewolf — Actions
+description: Narrator and player actions, payloads, validation rules, and night resolution order.
+gameMode: werewolf
+resource: src/lib/game/modes/werewolf/actions
+tags: [werewolf, actions, night-phase]
+---
+
 # Werewolf — Actions
 
 Actions are the mechanism by which the Narrator and players mutate game state. Each action has an `isValid` guard and an `apply` mutation.

--- a/docs/werewolf/data-flow.md
+++ b/docs/werewolf/data-flow.md
@@ -1,3 +1,12 @@
+---
+type: DataFlow
+title: Werewolf — Data Flow
+description: PlayerGameState fields per player type, Firebase schema, and per-phase data flow.
+gameMode: werewolf
+resource: src/lib/game/modes/werewolf
+tags: [werewolf, data-flow, firebase]
+---
+
 # Werewolf — Data Flow
 
 ## Overview

--- a/docs/werewolf/roles.md
+++ b/docs/werewolf/roles.md
@@ -1,3 +1,12 @@
+---
+type: Roles
+title: Werewolf — Roles
+description: All Werewolf roles, their teams, night-waking behavior, night actions, and visibility rules.
+gameMode: werewolf
+resource: src/lib/game/modes/werewolf
+tags: [werewolf, roles, night-phase]
+---
+
 # Werewolf — Roles
 
 ## Overview


### PR DESCRIPTION
Adds [Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) YAML frontmatter to every page under `docs/` so the reference docs are reliably retrievable and traversable by agents. This is a metadata + index pass — no prose or page content was rewritten.

## Changes

- **Frontmatter on all 13 existing pages** — `type`, `title`, `description` everywhere; per-mode pages also carry `gameMode` (mode slug) and `resource` (path to the documented source under `src/lib/game/modes/<mode>`).
- **`type` vocabulary** — `Index`, `Guide`, `Reference`, `Roles`, `Actions`, `DataFlow`. Defined in a table on the new index page.
- **`docs/README.md`** — new OKF `index.md`-style directory listing linking every page, grouped by kind. `GAME_MODES.md` is kept as the game-mode overview (`type: Reference`); the README is the full index.
- **AGENTS.md directive** — the existing docs-authoring rule now requires the frontmatter on new pages and that they be linked from `docs/README.md`. (CLAUDE.md is a symlink to AGENTS.md, so both update together.)

## Technical notes

- Purely additive: frontmatter sits above each page's existing `# Heading`, so this rebases cleanly over content changes to the same files (e.g. werewolf docs touched by in-flight role PRs).
- Prettier-clean; `type` controlled vocabulary keeps the metadata machine-readable.

Closes #718

---
*Created by Claude Opus 4.8*
