### PR TITLE
ci: add Storybook screenshot capture for changed stories on PRs

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -52,6 +52,71 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm build
 
+  storybook-build:
+    name: Storybook Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+      - run: pnpm build-storybook
+
+  storybook-screenshots:
+    name: Storybook Screenshots
+    if: github.event_name == 'pull_request'
+    timeout-minutes: 3
+    concurrency:
+      group: storybook-screenshots-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup
+      - name: Generate changed files list
+        run: |
+          git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.sha }}" > changed-files.txt
+      - id: screenshot-config
+        name: Generate screenshot config for changed stories
+        run: |
+          node scripts/generate-storybook-screenshots-config.mjs \
+            --changed-files=changed-files.txt \
+            --output=.github/screenshots.dynamic.yml \
+            --github-output="$GITHUB_OUTPUT"
+      - name: Install Playwright Chromium
+        if: steps.screenshot-config.outputs.has_stories == 'true'
+        run: pnpm exec playwright install chromium
+      - name: Start Storybook
+        if: steps.screenshot-config.outputs.has_stories == 'true'
+        run: pnpm storybook --ci --port 6006 &
+      - name: Wait for Storybook
+        if: steps.screenshot-config.outputs.has_stories == 'true'
+        run: |
+          # Max wait: 2 minutes, checking every 2 seconds.
+          TIMEOUT_SECONDS=120
+          RETRY_INTERVAL=2
+          MAX_ATTEMPTS=$((TIMEOUT_SECONDS / RETRY_INTERVAL))
+
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            if curl --silent --show-error --fail http://127.0.0.1:6006 >/dev/null; then
+              echo "Storybook is ready."
+              exit 0
+            fi
+            sleep "$RETRY_INTERVAL"
+          done
+          echo "Storybook did not start in time." >&2
+          exit 1
+      - name: Capture Storybook screenshots
+        if: steps.screenshot-config.outputs.has_stories == 'true'
+        uses: yoavf/auto-pr-screenshots-action@v1.4.0-beta
+        with:
+          config-file: .github/screenshots.dynamic.yml
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
   sentry-release:
     name: Sentry Release
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ tsconfig.tsbuildinfo
 .env.sentry-build-plugin
 storybook-static
 pnpm-workspace.yaml
+
+# CI-generated Storybook screenshot artifacts (written during the workflow run)
+changed-files.txt
+.github/screenshots.dynamic.yml

--- a/scripts/generate-storybook-screenshots-config.mjs
+++ b/scripts/generate-storybook-screenshots-config.mjs
@@ -1,0 +1,351 @@
+#!/usr/bin/env node
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+
+import { storyNameFromExport, toId } from "storybook/internal/csf";
+import ts from "typescript";
+
+const DEFAULT_OUTPUT_PATH = ".github/screenshots.dynamic.yml";
+const STORYBOOK_BASE_URL = "http://127.0.0.1:6006";
+
+function parseArgs(argv) {
+  const args = {
+    changedFilesPath: undefined,
+    githubOutputPath: undefined,
+    outputPath: DEFAULT_OUTPUT_PATH,
+  };
+
+  for (const arg of argv) {
+    if (arg.startsWith("--changed-files=")) {
+      args.changedFilesPath = arg.slice("--changed-files=".length);
+      continue;
+    }
+
+    if (arg.startsWith("--output=")) {
+      args.outputPath = arg.slice("--output=".length);
+      continue;
+    }
+
+    if (arg.startsWith("--github-output=")) {
+      args.githubOutputPath = arg.slice("--github-output=".length);
+    }
+  }
+
+  if (!args.changedFilesPath) {
+    throw new Error("Missing required --changed-files=<path> argument.");
+  }
+
+  return args;
+}
+
+function toKebabCase(value) {
+  return value
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+}
+
+function getNamedStringProperty(objectLiteral, propertyName) {
+  for (const property of objectLiteral.properties) {
+    if (!ts.isPropertyAssignment(property)) {
+      continue;
+    }
+
+    if (
+      !ts.isIdentifier(property.name) ||
+      property.name.text !== propertyName
+    ) {
+      continue;
+    }
+
+    const initializer = property.initializer;
+    if (
+      ts.isStringLiteral(initializer) ||
+      ts.isNoSubstitutionTemplateLiteral(initializer)
+    ) {
+      return initializer.text;
+    }
+  }
+
+  return undefined;
+}
+
+function hasModifier(node, kind) {
+  return node.modifiers?.some((modifier) => modifier.kind === kind) ?? false;
+}
+
+function getDefaultExportObjectLiteral(sourceFile) {
+  const objectLiteralsByIdentifier = new Map();
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) {
+      continue;
+    }
+
+    for (const declaration of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || !declaration.initializer) {
+        continue;
+      }
+
+      if (ts.isObjectLiteralExpression(declaration.initializer)) {
+        objectLiteralsByIdentifier.set(
+          declaration.name.text,
+          declaration.initializer,
+        );
+      }
+
+      if (
+        ts.isSatisfiesExpression(declaration.initializer) &&
+        ts.isObjectLiteralExpression(declaration.initializer.expression)
+      ) {
+        objectLiteralsByIdentifier.set(
+          declaration.name.text,
+          declaration.initializer.expression,
+        );
+      }
+    }
+  }
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isExportAssignment(statement)) {
+      continue;
+    }
+
+    if (ts.isObjectLiteralExpression(statement.expression)) {
+      return statement.expression;
+    }
+
+    if (ts.isIdentifier(statement.expression)) {
+      return objectLiteralsByIdentifier.get(statement.expression.text);
+    }
+  }
+
+  return undefined;
+}
+
+function extractStoryExports(sourceFile) {
+  const exports = [];
+
+  for (const statement of sourceFile.statements) {
+    if (
+      ts.isVariableStatement(statement) &&
+      hasModifier(statement, ts.SyntaxKind.ExportKeyword)
+    ) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name)) {
+          exports.push(declaration.name.text);
+        }
+      }
+      continue;
+    }
+
+    if (
+      (ts.isFunctionDeclaration(statement) ||
+        ts.isClassDeclaration(statement)) &&
+      statement.name &&
+      hasModifier(statement, ts.SyntaxKind.ExportKeyword)
+    ) {
+      exports.push(statement.name.text);
+    }
+  }
+
+  return exports.filter((name) => !name.startsWith("__"));
+}
+
+function parseStoryFile(storyFilePath) {
+  const storySource = readFileSync(storyFilePath, "utf8");
+  const sourceFile = ts.createSourceFile(
+    storyFilePath,
+    storySource,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+
+  const defaultExportObjectLiteral = getDefaultExportObjectLiteral(sourceFile);
+  if (!defaultExportObjectLiteral) {
+    return [];
+  }
+
+  const metaId = getNamedStringProperty(defaultExportObjectLiteral, "id");
+  const metaTitle = getNamedStringProperty(defaultExportObjectLiteral, "title");
+  if (!metaId && !metaTitle) {
+    return [];
+  }
+
+  const componentName = metaTitle?.split("/").filter(Boolean).at(-1) || metaId;
+  const titleBase = metaId ?? metaTitle;
+  const storyExports = extractStoryExports(sourceFile);
+
+  return storyExports.map((storyExportName) => {
+    // Story ID must match Storybook's own computation exactly. Storybook
+    // sanitizes the title (lowercase, no camelCase split) but startCases the
+    // export name, so a single kebab transform would not reproduce it — use
+    // Storybook's own toId/storyNameFromExport. The kebab `name` below is only
+    // a human-readable screenshot label and need not match the ID.
+    return {
+      componentName,
+      name: `${toKebabCase(componentName)}-${toKebabCase(storyExportName)}`,
+      storyExportName,
+      storyId: toId(titleBase, storyNameFromExport(storyExportName)),
+    };
+  });
+}
+
+function resolveStoryFileForChangedFile(repoRoot, changedFilePath) {
+  const normalizedPath = changedFilePath.replace(/\\/g, "/").trim();
+  if (!normalizedPath) {
+    return undefined;
+  }
+
+  const absolutePath = join(repoRoot, normalizedPath);
+
+  if (
+    normalizedPath.endsWith(".stories.tsx") ||
+    normalizedPath.endsWith(".stories.ts")
+  ) {
+    return existsSync(absolutePath) ? normalizedPath : undefined;
+  }
+
+  if (!/\.(tsx?|jsx?)$/.test(normalizedPath)) {
+    return undefined;
+  }
+
+  if (
+    normalizedPath.endsWith(".spec.ts") ||
+    normalizedPath.endsWith(".spec.tsx")
+  ) {
+    return undefined;
+  }
+
+  const withoutExtension = normalizedPath.replace(/\.[^.]+$/, "");
+  const storyCandidates = [
+    `${withoutExtension}.stories.tsx`,
+    `${withoutExtension}.stories.ts`,
+  ];
+
+  for (const candidate of storyCandidates) {
+    if (existsSync(join(repoRoot, candidate))) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+function buildConfigYaml(screenshots) {
+  if (screenshots.length === 0) {
+    return "version: 1\nscreenshots: []\n";
+  }
+
+  const screenshotEntries = screenshots
+    .map((screenshot) => {
+      return [
+        `  - name: "${screenshot.name}"`,
+        `    url: "${STORYBOOK_BASE_URL}/?path=/story/${screenshot.storyId}"`,
+      ].join("\n");
+    })
+    .join("\n");
+
+  return [
+    "version: 1",
+    "screenshots:",
+    screenshotEntries,
+    "output:",
+    "  branch: gh-screenshots",
+    "  comment:",
+    "    template: default",
+    "",
+  ].join("\n");
+}
+
+function appendGithubOutput(githubOutputPath, screenshotCount) {
+  if (!githubOutputPath) {
+    return;
+  }
+
+  const hasStories = screenshotCount > 0 ? "true" : "false";
+  const output = `story_count=${screenshotCount}\nhas_stories=${hasStories}\n`;
+  try {
+    writeFileSync(githubOutputPath, output, { flag: "a" });
+  } catch (error) {
+    throw new Error(
+      `Failed to write GitHub Action outputs to ${githubOutputPath}. Check that the output file path exists and is writable.`,
+      { cause: error },
+    );
+  }
+}
+
+function readChangedFiles(repoRoot, changedFilesPath) {
+  try {
+    return readFileSync(join(repoRoot, changedFilesPath), "utf8")
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  } catch (error) {
+    throw new Error(
+      `Failed to read changed files list from ${changedFilesPath}. Ensure the file exists and contains one file path per line.`,
+      { cause: error },
+    );
+  }
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const { changedFilesPath, githubOutputPath, outputPath } = parseArgs(
+    process.argv.slice(2),
+  );
+
+  const changedFiles = readChangedFiles(repoRoot, changedFilesPath);
+
+  const storyFiles = new Set();
+  for (const changedFilePath of changedFiles) {
+    const storyFile = resolveStoryFileForChangedFile(repoRoot, changedFilePath);
+    if (storyFile) {
+      storyFiles.add(storyFile);
+    }
+  }
+
+  const screenshotConfigs = Array.from(storyFiles)
+    .sort((a, b) => a.localeCompare(b))
+    .flatMap((storyFile) => {
+      const storyFilePath = join(repoRoot, storyFile);
+      let details;
+      try {
+        details = parseStoryFile(storyFilePath);
+      } catch (error) {
+        throw new Error(
+          `Failed to parse Storybook story file at ${storyFile}. Check the file syntax and Storybook metadata exports.`,
+          { cause: error },
+        );
+      }
+      return details.map((detail) => ({
+        ...detail,
+        storyFile,
+      }));
+    })
+    .sort((a, b) => {
+      const byComponent = a.componentName.localeCompare(b.componentName);
+      if (byComponent !== 0) {
+        return byComponent;
+      }
+
+      return a.storyExportName.localeCompare(b.storyExportName);
+    });
+
+  const outputAbsolutePath = join(repoRoot, outputPath);
+  mkdirSync(dirname(outputAbsolutePath), { recursive: true });
+  writeFileSync(outputAbsolutePath, buildConfigYaml(screenshotConfigs));
+
+  appendGithubOutput(githubOutputPath, screenshotConfigs.length);
+
+  const configPathForLog = relative(repoRoot, outputAbsolutePath);
+  console.log(
+    `Generated ${configPathForLog} with ${screenshotConfigs.length} screenshot(s).`,
+  );
+}
+
+main();

--- a/src/app/HomePageView.stories.tsx
+++ b/src/app/HomePageView.stories.tsx
@@ -8,6 +8,7 @@ import { HomePageView } from "./HomePageView";
 const noop = fn();
 
 const meta = {
+  title: "app/HomePageView",
   component: HomePageView,
   args: {
     playerName: "Alice",

--- a/src/components/HomeLink.stories.tsx
+++ b/src/components/HomeLink.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { HomeLink } from "./HomeLink";
 
 const meta = {
+  title: "components/HomeLink",
   component: HomeLink,
 } satisfies Meta<typeof HomeLink>;
 

--- a/src/components/game/GameRolesList.stories.tsx
+++ b/src/components/game/GameRolesList.stories.tsx
@@ -6,6 +6,7 @@ import type { RoleInPlay } from "@/server/types";
 import { GameRolesList } from "./GameRolesList";
 
 const meta = {
+  title: "components/game/GameRolesList",
   component: GameRolesList,
 } satisfies Meta<typeof GameRolesList>;
 

--- a/src/components/game/GameTimer.stories.tsx
+++ b/src/components/game/GameTimer.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { GameTimer } from "./GameTimer";
 
 const meta = {
+  title: "components/game/GameTimer",
   component: GameTimer,
 } satisfies Meta<typeof GameTimer>;
 

--- a/src/components/game/PlayersRoleList.stories.tsx
+++ b/src/components/game/PlayersRoleList.stories.tsx
@@ -6,6 +6,7 @@ import type { VisibleTeammate } from "@/server/types";
 import { PlayersRoleList } from "./PlayersRoleList";
 
 const meta = {
+  title: "components/game/PlayersRoleList",
   component: PlayersRoleList,
 } satisfies Meta<typeof PlayersRoleList>;
 

--- a/src/components/game/RoleGlossaryDialog.stories.tsx
+++ b/src/components/game/RoleGlossaryDialog.stories.tsx
@@ -11,6 +11,7 @@ import { GameMode, Team } from "@/lib/types";
 import { RoleGlossaryDialog } from "./RoleGlossaryDialog";
 
 const meta = {
+  title: "components/game/RoleGlossaryDialog",
   component: RoleGlossaryDialog,
 } satisfies Meta<typeof RoleGlossaryDialog>;
 

--- a/src/components/game/VisibilityGroupCard.stories.tsx
+++ b/src/components/game/VisibilityGroupCard.stories.tsx
@@ -7,6 +7,7 @@ import type { VisibleTeammate } from "@/server/types";
 import { VisibilityGroupCard } from "./VisibilityGroupCard";
 
 const meta = {
+  title: "components/game/VisibilityGroupCard",
   component: VisibilityGroupCard,
 } satisfies Meta<typeof VisibilityGroupCard>;
 

--- a/src/components/game/secret-villain/ActionGateView.stories.tsx
+++ b/src/components/game/secret-villain/ActionGateView.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { ActionGateView } from "./ActionGateView";
 
 const meta = {
+  title: "components/game/secret-villain/ActionGateView",
   component: ActionGateView,
 } satisfies Meta<typeof ActionGateView>;
 

--- a/src/components/game/secret-villain/BoardDisplay.stories.tsx
+++ b/src/components/game/secret-villain/BoardDisplay.stories.tsx
@@ -15,6 +15,7 @@ const MEDIUM_POWER_TABLE = [
 ];
 
 const meta = {
+  title: "components/game/secret-villain/BoardDisplay",
   component: BoardDisplay,
 } satisfies Meta<typeof BoardDisplay>;
 

--- a/src/components/game/secret-villain/BoardScreen.stories.tsx
+++ b/src/components/game/secret-villain/BoardScreen.stories.tsx
@@ -46,6 +46,7 @@ const baseGameState: SecretVillainPlayerGameState = {
 };
 
 const meta = {
+  title: "components/game/secret-villain/BoardScreen",
   component: BoardScreen,
 } satisfies Meta<typeof BoardScreen>;
 

--- a/src/components/game/secret-villain/ElectionNominationView.stories.tsx
+++ b/src/components/game/secret-villain/ElectionNominationView.stories.tsx
@@ -10,6 +10,7 @@ const eligiblePlayers = [
 ];
 
 const meta = {
+  title: "components/game/secret-villain/ElectionNominationView",
   component: ElectionNominationView,
   args: {
     onSelectPlayer: fn(),

--- a/src/components/game/secret-villain/ElectionResultView.stories.tsx
+++ b/src/components/game/secret-villain/ElectionResultView.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from "storybook/test";
 import { ElectionResultView } from "./ElectionResultView";
 
 const meta = {
+  title: "components/game/secret-villain/ElectionResultView",
   component: ElectionResultView,
   args: {
     onContinue: fn(),

--- a/src/components/game/secret-villain/ElectionVoteView.stories.tsx
+++ b/src/components/game/secret-villain/ElectionVoteView.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from "storybook/test";
 import { ElectionVoteView } from "./ElectionVoteView";
 
 const meta = {
+  title: "components/game/secret-villain/ElectionVoteView",
   component: ElectionVoteView,
   args: {
     onVote: fn(),

--- a/src/components/game/secret-villain/InvestigationConsentView.stories.tsx
+++ b/src/components/game/secret-villain/InvestigationConsentView.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from "storybook/test";
 import { InvestigationConsentView } from "./InvestigationConsentView";
 
 const meta = {
+  title: "components/game/secret-villain/InvestigationConsentView",
   component: InvestigationConsentView,
   args: {
     presidentName: "Alice",

--- a/src/components/game/secret-villain/PlayerSelectionView.stories.tsx
+++ b/src/components/game/secret-villain/PlayerSelectionView.stories.tsx
@@ -10,6 +10,7 @@ const players = [
 ];
 
 const meta = {
+  title: "components/game/secret-villain/PlayerSelectionView",
   component: PlayerSelectionView,
   args: {
     heading: "Select a Player",

--- a/src/components/game/secret-villain/PolicyChancellorView.stories.tsx
+++ b/src/components/game/secret-villain/PolicyChancellorView.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from "storybook/test";
 import { PolicyChancellorView } from "./PolicyChancellorView";
 
 const meta = {
+  title: "components/game/secret-villain/PolicyChancellorView",
   component: PolicyChancellorView,
   args: {
     onSelectCard: fn(),

--- a/src/components/game/secret-villain/PolicyPeekView.stories.tsx
+++ b/src/components/game/secret-villain/PolicyPeekView.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from "storybook/test";
 import { PolicyPeekView } from "./PolicyPeekView";
 
 const meta = {
+  title: "components/game/secret-villain/PolicyPeekView",
   component: PolicyPeekView,
   args: {
     peekedCards: ["bad", "good", "bad"],

--- a/src/components/game/secret-villain/PolicyPresidentView.stories.tsx
+++ b/src/components/game/secret-villain/PolicyPresidentView.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from "storybook/test";
 import { PolicyPresidentView } from "./PolicyPresidentView";
 
 const meta = {
+  title: "components/game/secret-villain/PolicyPresidentView",
   component: PolicyPresidentView,
   args: {
     onSelectCard: fn(),

--- a/src/components/game/secret-villain/SecretVillainGameOverView.stories.tsx
+++ b/src/components/game/secret-villain/SecretVillainGameOverView.stories.tsx
@@ -10,6 +10,7 @@ import { GameMode, GameStatus, Team } from "@/lib/types";
 import { SecretVillainGameOverView } from "./SecretVillainGameOverView";
 
 const meta = {
+  title: "components/game/secret-villain/SecretVillainGameOverView",
   component: SecretVillainGameOverView,
   args: {
     onReturnToLobby: fn(),

--- a/src/components/game/secret-villain/SecretVillainStartingView.stories.tsx
+++ b/src/components/game/secret-villain/SecretVillainStartingView.stories.tsx
@@ -8,6 +8,7 @@ import { GameMode, GameStatus, Team } from "@/lib/types";
 import { SecretVillainStartingView } from "./SecretVillainStartingView";
 
 const meta = {
+  title: "components/game/secret-villain/SecretVillainStartingView",
   component: SecretVillainStartingView,
 } satisfies Meta<typeof SecretVillainStartingView>;
 

--- a/src/components/game/secret-villain/SpecialActionView.stories.tsx
+++ b/src/components/game/secret-villain/SpecialActionView.stories.tsx
@@ -12,6 +12,7 @@ const players = [
 ];
 
 const meta = {
+  title: "components/game/secret-villain/SpecialActionView",
   component: SpecialActionView,
   args: {
     onSelectPlayer: fn(),

--- a/src/components/game/secret-villain/SpecialBadRevealView.stories.tsx
+++ b/src/components/game/secret-villain/SpecialBadRevealView.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from "storybook/test";
 import { SpecialBadRevealView } from "./SpecialBadRevealView";
 
 const meta = {
+  title: "components/game/secret-villain/SpecialBadRevealView",
   component: SpecialBadRevealView,
   args: {
     chancellorName: "Alice",

--- a/src/components/game/secret-villain/VetoPromptView.stories.tsx
+++ b/src/components/game/secret-villain/VetoPromptView.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from "storybook/test";
 import { VetoPromptView } from "./VetoPromptView";
 
 const meta = {
+  title: "components/game/secret-villain/VetoPromptView",
   component: VetoPromptView,
   args: {
     onAccept: fn(),

--- a/src/components/game/werewolf/ConfirmTargetButtonView.stories.tsx
+++ b/src/components/game/werewolf/ConfirmTargetButtonView.stories.tsx
@@ -6,6 +6,7 @@ import { WerewolfRole } from "@/lib/game/modes/werewolf/roles";
 import { ConfirmTargetButtonView } from "./ConfirmTargetButtonView";
 
 const meta = {
+  title: "components/game/werewolf/ConfirmTargetButtonView",
   component: ConfirmTargetButtonView,
   args: {
     onConfirm: fn(),

--- a/src/components/game/werewolf/GameOverScreenView.stories.tsx
+++ b/src/components/game/werewolf/GameOverScreenView.stories.tsx
@@ -9,6 +9,7 @@ import { GameMode, GameStatus, Team } from "@/lib/types";
 import { GameOverScreenView } from "./GameOverScreenView";
 
 const meta = {
+  title: "components/game/werewolf/GameOverScreenView",
   component: GameOverScreenView,
   args: {
     onReturnToLobby: fn(),

--- a/src/components/game/werewolf/GhostCluePanel.stories.tsx
+++ b/src/components/game/werewolf/GhostCluePanel.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from "storybook/test";
 import { GhostCluePanelView } from "./GhostCluePanel";
 
 const meta = {
+  title: "components/game/werewolf/GhostCluePanel",
   component: GhostCluePanelView,
   args: {
     onClueChange: fn(),

--- a/src/components/game/werewolf/GhostNightObserverScreen.stories.tsx
+++ b/src/components/game/werewolf/GhostNightObserverScreen.stories.tsx
@@ -10,6 +10,7 @@ import { GameMode, GameStatus } from "@/lib/types";
 import { GhostNightObserverScreen } from "./GhostNightObserverScreen";
 
 const meta = {
+  title: "components/game/werewolf/GhostNightObserverScreen",
   component: GhostNightObserverScreen,
 } satisfies Meta<typeof GhostNightObserverScreen>;
 

--- a/src/components/game/werewolf/NarratorPlayerRoleLists.stories.tsx
+++ b/src/components/game/werewolf/NarratorPlayerRoleLists.stories.tsx
@@ -7,6 +7,7 @@ import { NarratorPlayerRoleLists } from "./NarratorPlayerRoleLists";
 import { NightMarkerEffect } from "./NightActionMarker";
 
 const meta = {
+  title: "components/game/werewolf/NarratorPlayerRoleLists",
   component: NarratorPlayerRoleLists,
 } satisfies Meta<typeof NarratorPlayerRoleLists>;
 

--- a/src/components/game/werewolf/NightActionMarker.stories.tsx
+++ b/src/components/game/werewolf/NightActionMarker.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { NightActionMarker, NightMarkerEffect } from "./NightActionMarker";
 
 const meta = {
+  title: "components/game/werewolf/NightActionMarker",
   component: NightActionMarker,
 } satisfies Meta<typeof NightActionMarker>;
 

--- a/src/components/game/werewolf/NightOutcomeSummary.stories.tsx
+++ b/src/components/game/werewolf/NightOutcomeSummary.stories.tsx
@@ -5,6 +5,7 @@ import { WerewolfRole } from "@/lib/game/modes/werewolf";
 import { NightOutcomeSummary } from "./NightOutcomeSummary";
 
 const meta = {
+  title: "components/game/werewolf/NightOutcomeSummary",
   component: NightOutcomeSummary,
   args: {
     players: [

--- a/src/components/game/werewolf/NightPhaseOrderList.stories.tsx
+++ b/src/components/game/werewolf/NightPhaseOrderList.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { NightPhaseOrderList } from "./NightPhaseOrderList";
 
 const meta = {
+  title: "components/game/werewolf/NightPhaseOrderList",
   component: NightPhaseOrderList,
 } satisfies Meta<typeof NightPhaseOrderList>;
 

--- a/src/components/game/werewolf/PlayerNightSnoozeScreen.stories.tsx
+++ b/src/components/game/werewolf/PlayerNightSnoozeScreen.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { PlayerNightSnoozeScreen } from "./PlayerNightSnoozeScreen";
 
 const meta = {
+  title: "components/game/werewolf/PlayerNightSnoozeScreen",
   component: PlayerNightSnoozeScreen,
 } satisfies Meta<typeof PlayerNightSnoozeScreen>;
 

--- a/src/components/game/werewolf/PlayerNightSummary.stories.tsx
+++ b/src/components/game/werewolf/PlayerNightSummary.stories.tsx
@@ -6,6 +6,7 @@ import type { PublicLobbyPlayer } from "@/server/types";
 import { PlayerNightSummary } from "./PlayerNightSummary";
 
 const meta = {
+  title: "components/game/werewolf/PlayerNightSummary",
   component: PlayerNightSummary,
 } satisfies Meta<typeof PlayerNightSummary>;
 

--- a/src/components/game/werewolf/PlayerRoleDisplay.stories.tsx
+++ b/src/components/game/werewolf/PlayerRoleDisplay.stories.tsx
@@ -5,6 +5,7 @@ import { GameMode, Team } from "@/lib/types";
 import { PlayerRoleDisplay } from "./PlayerRoleDisplay";
 
 const meta = {
+  title: "components/game/werewolf/PlayerRoleDisplay",
   component: PlayerRoleDisplay,
 } satisfies Meta<typeof PlayerRoleDisplay>;
 

--- a/src/components/game/werewolf/PlayerTargetSelection.stories.tsx
+++ b/src/components/game/werewolf/PlayerTargetSelection.stories.tsx
@@ -6,6 +6,7 @@ import { WerewolfRole } from "@/lib/game/modes/werewolf/roles";
 import { PlayerTargetSelectionView } from "./PlayerTargetSelection";
 
 const meta = {
+  title: "components/game/werewolf/PlayerTargetSelection",
   component: PlayerTargetSelectionView,
   args: {
     onMutate: fn(),

--- a/src/components/game/werewolf/VeteranActionPanelView.stories.tsx
+++ b/src/components/game/werewolf/VeteranActionPanelView.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from "storybook/test";
 import { VeteranActionPanelView } from "./VeteranActionPanelView";
 
 const meta = {
+  title: "components/game/werewolf/VeteranActionPanelView",
   component: VeteranActionPanelView,
   args: {
     onAlert: fn(),

--- a/src/components/lobby/ExpandedRoleList.stories.tsx
+++ b/src/components/lobby/ExpandedRoleList.stories.tsx
@@ -9,6 +9,7 @@ import gameConfigReducer from "@/store/game-config-slice";
 import { ExpandedRoleList } from "./ExpandedRoleList";
 
 const meta = {
+  title: "components/lobby/ExpandedRoleList",
   component: ExpandedRoleList,
   decorators: [
     (Story) => {

--- a/src/components/lobby/JoinPrompt.stories.tsx
+++ b/src/components/lobby/JoinPrompt.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from "storybook/test";
 import { JoinPromptView } from "./JoinPrompt";
 
 const meta = {
+  title: "components/lobby/JoinPrompt",
   component: JoinPromptView,
   args: {
     onPlayerNameChange: fn(),

--- a/src/components/lobby/LobbyLayout.stories.tsx
+++ b/src/components/lobby/LobbyLayout.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { LobbyLayout } from "./LobbyLayout";
 
 const meta = {
+  title: "components/lobby/LobbyLayout",
   component: LobbyLayout,
 } satisfies Meta<typeof LobbyLayout>;
 

--- a/src/components/lobby/PlayerList.stories.tsx
+++ b/src/components/lobby/PlayerList.stories.tsx
@@ -11,6 +11,7 @@ import { PLAYER_LIST_COPY } from "./PlayerList.copy";
 const noop = () => {};
 
 const meta = {
+  title: "components/lobby/PlayerList",
   component: PlayerList,
   args: {
     onRefetch: noop,

--- a/src/components/lobby/RoleBucketConfig.stories.tsx
+++ b/src/components/lobby/RoleBucketConfig.stories.tsx
@@ -32,6 +32,7 @@ const populatedBuckets: AdvancedRoleBucket[] = [
 ];
 
 const meta = {
+  title: "components/lobby/RoleBucketConfig",
   component: RoleBucketConfigView,
   args: {
     gameMode: GameMode.Werewolf,

--- a/src/components/lobby/RoleListEntry.stories.tsx
+++ b/src/components/lobby/RoleListEntry.stories.tsx
@@ -8,6 +8,7 @@ import gameConfigReducer from "@/store/game-config-slice";
 import { RoleListEntry } from "./RoleListEntry";
 
 const meta = {
+  title: "components/lobby/RoleListEntry",
   component: RoleListEntry,
   decorators: [
     (Story) => {

--- a/src/components/lobby/ShareLobby.stories.tsx
+++ b/src/components/lobby/ShareLobby.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { ShareLobby } from "./ShareLobby";
 
 const meta = {
+  title: "components/lobby/ShareLobby",
   component: ShareLobby,
 } satisfies Meta<typeof ShareLobby>;
 

--- a/src/components/lobby/WerewolfConfigPanel.stories.tsx
+++ b/src/components/lobby/WerewolfConfigPanel.stories.tsx
@@ -7,6 +7,7 @@ import { WerewolfConfigPanel } from "./WerewolfConfigPanel";
 import { WEREWOLF_CONFIG_PANEL_COPY } from "./WerewolfConfigPanel.copy";
 
 const meta = {
+  title: "components/lobby/WerewolfConfigPanel",
   component: WerewolfConfigPanel,
 } satisfies Meta<typeof WerewolfConfigPanel>;
 

--- a/src/components/lobby/secret-villain/CustomPowerTableEditor.stories.tsx
+++ b/src/components/lobby/secret-villain/CustomPowerTableEditor.stories.tsx
@@ -6,6 +6,7 @@ import { SpecialActionType } from "@/lib/game/modes/secret-villain/types";
 import { CustomPowerTableEditor } from "./CustomPowerTableEditor";
 
 const meta = {
+  title: "components/lobby/secret-villain/CustomPowerTableEditor",
   component: CustomPowerTableEditor,
 } satisfies Meta<typeof CustomPowerTableEditor>;
 

--- a/src/components/lobby/secret-villain/SecretVillainConfigPanel.stories.tsx
+++ b/src/components/lobby/secret-villain/SecretVillainConfigPanel.stories.tsx
@@ -11,6 +11,7 @@ import { GameMode } from "@/lib/types";
 import { SecretVillainConfigPanel } from "./SecretVillainConfigPanel";
 
 const meta = {
+  title: "components/lobby/secret-villain/SecretVillainConfigPanel",
   component: SecretVillainConfigPanel,
 } satisfies Meta<typeof SecretVillainConfigPanel>;
 


### PR DESCRIPTION
Adds Storybook screenshot capture on PRs, modeled on [rmartz/personal-budget](https://github.com/rmartz/personal-budget/blob/main/.github/workflows/ci-actions.yml). On a PR, the new job resolves the changed files to their story files, starts Storybook, and posts screenshots of the affected stories to the PR.

## What's added

- **`storybook-screenshots` job** (PR-only): generates a screenshot config for changed stories, boots Storybook, waits for it (2-min internal cap), and captures via `yoavf/auto-pr-screenshots-action`. Skips booting Storybook entirely when no changed file maps to a story.
- **`storybook-build` job**: `pnpm build-storybook` as a build-health check.
- **`scripts/generate-storybook-screenshots-config.mjs`**: parses changed story files and emits `.github/screenshots.dynamic.yml`.

## Two deviations from the reference (both necessary)

1. **Story IDs use Storybook's own `toId`.** The reference script hand-rolls a kebab-case that splits camelCase (`GameRolesList` → `game-roles-list`), but this Storybook version's `toId` does not (`gameroleslist`). A verbatim port produced story IDs that don't exist, so no screenshots. The script now imports `toId`/`storyNameFromExport` from `storybook/internal/csf` — correct by construction. Validated: the generator reproduces **all 214** real story IDs from a Storybook index build, 0 mismatches.

2. **Explicit titles added to 46 stories.** The reference reads `meta.title`; this repo relies on Storybook auto-titles (only 1 of 47 stories had an explicit title). Each title is set to that story's **current auto-title**, so a before/after Storybook index build confirms **all 214 story IDs are unchanged** — no sidebar reorganization, purely surfacing the implicit title.

## Timeouts

Per-job caps on the two new jobs use [personal-budget#273](https://github.com/rmartz/personal-budget/pull/273)'s tuned baseline: Storybook Build `2m`, Storybook Screenshots `3m`.

## Notes / follow-ups

- **Full timeout baseline not included here.** #273 also caps every *existing* job across all workflows and adds a `workflow-timeouts.spec.ts` enforcement test. That's a separate CI-tightening concern (and overlaps the open #694). I've scoped this PR to the storybook feature + its own jobs' caps; the repo-wide baseline should be its own PR — see my summary comment.
- **Third-party action** `yoavf/auto-pr-screenshots-action@v1.4.0-beta` is pinned by tag (matching the reference). Pinning to a commit SHA would be a reasonable supply-chain hardening, since the job runs with `contents: write` + `pull-requests: write`.
- This PR changes 46 story files, so its own `storybook-screenshots` run will exercise the feature end-to-end.

---
*Created by Claude Opus 4.8*
