### PR TITLE
ci: add per-job timeout caps across all CI workflows

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -13,6 +13,7 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
@@ -22,6 +23,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
@@ -30,6 +32,7 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
@@ -47,6 +50,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
@@ -55,6 +59,7 @@ jobs:
   sentry-release:
     name: Sentry Release
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     if: github.event_name == 'push'
     needs: [tests, lint, format, typecheck, build]
     steps:

--- a/.github/workflows/file-length.yml
+++ b/.github/workflows/file-length.yml
@@ -10,6 +10,7 @@ jobs:
   check:
     name: Check file lengths
     runs-on: ubuntu-latest
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -11,6 +11,7 @@ jobs:
   pr-title:
     name: Validate PR title
     runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
       - name: Check PR title format
         env:

--- a/.github/workflows/storybook-screenshots.yml
+++ b/.github/workflows/storybook-screenshots.yml
@@ -15,6 +15,7 @@ jobs:
   screenshots:
     name: Capture Storybook Screenshots
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
         with:

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
     "typescript-eslint": "^8.61.1",
     "vercel-deploy-scripts": "https://github.com/rmartz/vercel-deploy-scripts/archive/refs/tags/v3.1.0.tar.gz",
     "vite": "^8.0.16",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.9",
+    "yaml": "^2.9.0"
   },
   "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.0.0)(@vitest/browser-playwright@4.1.9)(happy-dom@20.10.6)(msw@2.14.6(@types/node@26.0.0)(typescript@6.0.3))(vite@8.0.16(@types/node@26.0.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
 packages:
 
@@ -10607,8 +10610,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@2.9.0:
-    optional: true
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/src/workflow-timeouts.spec.ts
+++ b/src/workflow-timeouts.spec.ts
@@ -1,0 +1,85 @@
+import { readdirSync, readFileSync } from "fs";
+import { resolve } from "path";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+// Per-job timeout caps in minutes, tuned from observed p95 + ~1.8x headroom
+// across recent successful runs. Browser-heavy jobs (tests run Playwright,
+// screenshots build + serve Storybook) are sized higher. Adding a job to any
+// workflow requires registering it here, or the test below fails — forcing a
+// deliberate cap rather than leaving a job unbounded.
+const EXPECTED_TIMEOUT_MINUTES: Record<string, Record<string, number>> = {
+  "ci-actions.yml": {
+    build: 2,
+    format: 2,
+    lint: 2,
+    "sentry-release": 2,
+    tests: 4,
+    typecheck: 1,
+  },
+  "file-length.yml": {
+    check: 2,
+  },
+  "pr-title-lint.yml": {
+    "pr-title": 1,
+  },
+  // The only job is a reusable-workflow caller (`uses:`), which cannot carry
+  // timeout-minutes — the upstream reusable workflow owns its own timeout.
+  "secret-scan.yml": {},
+  "storybook-screenshots.yml": {
+    screenshots: 5,
+  },
+};
+
+const workflowsDir = resolve(import.meta.dirname, "../.github/workflows");
+
+interface WorkflowJob {
+  "timeout-minutes"?: number;
+  uses?: string;
+}
+
+interface WorkflowFile {
+  fileName: string;
+  jobs: Record<string, WorkflowJob>;
+}
+
+function loadWorkflows(): WorkflowFile[] {
+  return readdirSync(workflowsDir)
+    .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
+    .map((fileName) => {
+      const parsed = parse(
+        readFileSync(resolve(workflowsDir, fileName), "utf-8"),
+      ) as { jobs: Record<string, WorkflowJob> };
+      return { fileName, jobs: parsed.jobs };
+    });
+}
+
+describe("GitHub Actions workflow timeouts", () => {
+  const workflows = loadWorkflows();
+
+  it("registers every workflow file in EXPECTED_TIMEOUT_MINUTES", () => {
+    const onDisk = workflows.map((workflow) => workflow.fileName).sort();
+    expect(onDisk).toEqual(Object.keys(EXPECTED_TIMEOUT_MINUTES).sort());
+  });
+
+  for (const { fileName, jobs } of workflows) {
+    for (const [jobId, job] of Object.entries(jobs)) {
+      const expected = EXPECTED_TIMEOUT_MINUTES[fileName]?.[jobId];
+
+      it(`${fileName} job "${jobId}" has its expected timeout`, () => {
+        if (job.uses !== undefined) {
+          // GitHub Actions rejects timeout-minutes on reusable-workflow callers.
+          expect(job["timeout-minutes"]).toBeUndefined();
+          expect(expected).toBeUndefined();
+          return;
+        }
+
+        expect(
+          expected,
+          `job "${jobId}" in ${fileName} needs a registered cap`,
+        ).toBeDefined();
+        expect(job["timeout-minutes"]).toBe(expected);
+      });
+    }
+  }
+});


### PR DESCRIPTION
Caps every CI job with `timeout-minutes` so a hung job fails fast rather than running to GitHub's 6-hour default. Modeled on [rmartz/personal-budget#273](https://github.com/rmartz/personal-budget/pull/273), with caps tuned from **this repo's** observed p95 + ~1.8× headroom across 15 recent successful runs per workflow.

## Caps

| Workflow | Job | p95 | Cap |
| --- | --- | --- | --- |
| ci-actions | tests | 118s | **4m** |
| ci-actions | lint | 46s | 2m |
| ci-actions | build | 47s | 2m |
| ci-actions | format | 28s | 2m |
| ci-actions | typecheck | 33s | 1m _(unchanged, from #715)_ |
| ci-actions | sentry-release | n/a (push-only) | 2m |
| file-length | check | 7s | 2m |
| pr-title-lint | pr-title | 4s | 1m |
| storybook-screenshots | screenshots | _no runs yet_ | **5m** _(estimate)_ |

Two deviations from #273's literal values, both because this repo's jobs do more browser work than personal-budget's:
- **tests = 4m** (not 3m): this repo's `pnpm test` runs the Storybook browser project under Playwright, so p95 is 118s.
- **screenshots = 5m**: the existing job does a full static Storybook build + `playwright install --with-deps` + serve + capture. No successful runs exist yet to measure, so this is a deliberately generous initial estimate — worth tuning down once we have observed p95.

`secret-scan`'s only job is a reusable-workflow caller (`uses:`), which GitHub Actions forbids from carrying `timeout-minutes` — the upstream workflow owns its timeout.

## Enforcement test

`src/workflow-timeouts.spec.ts` parses every workflow file and asserts each job has a registered cap (and that reusable callers omit one). A future un-capped job fails CI, forcing a deliberate choice rather than an unbounded job. Adds `yaml` as a devDependency for parsing.

Closes #693. Supersedes #694 (the older per-job-timeouts PR on that issue — narrower scope, plus a large `pnpm-lock.yaml` drift diff).

---
*Created by Claude Opus 4.8*
