### PR TITLE
chore(security): add 7-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Let releases age before applying them, to reduce exposure to compromised
+    # package versions (supply-chain attacks are typically caught and yanked
+    # within days). Applies to all update types.
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
@@ -22,6 +27,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
Adds a 7-day `cooldown` to both Dependabot update configs (npm and github-actions) so a release must age 7 days before Dependabot opens an update PR.

## Why

Compromised package versions from supply-chain attacks are typically detected and yanked within a few days of publication. Letting updates sit for a week before applying them means we mostly skip over malicious releases that get pulled in that window, rather than bumping to them immediately.

## Change

```yaml
cooldown:
  default-days: 7
```

`default-days` applies to all update types (major/minor/patch) for that ecosystem. Added to both the `npm` and `github-actions` entries. No other behavior changes — the weekly schedule, grouping, and commit-message config are untouched.

---
*Created by Claude Opus 4.8*
