### PR TITLE
chore: remove sync-env references from deployment schema

### DIFF
--- a/deployment/schema.yml
+++ b/deployment/schema.yml
@@ -20,9 +20,9 @@ allowed_patterns:
 allowed_keys:
   - FIREBASE_DATABASE_URL # Non-sensitive RTDB URL; also exposed as NEXT_PUBLIC_FIREBASE_DATABASE_URL
   - FIREBASE_PROJECT_ID # Non-sensitive; also exposed via NEXT_PUBLIC_FIREBASE_PROJECT_ID
-  - FIREBASE_SA_EMAIL # Service account email (identifier, not a key); used by sync-env --rotate-keys
-  - SENTRY_ORG # Non-sensitive org slug; used by sync-env --init sentry and withSentryConfig
-  - SENTRY_PROJECT # Non-sensitive project slug; used by sync-env --init sentry and withSentryConfig
+  - FIREBASE_SA_EMAIL # Service account email (identifier, not a key)
+  - SENTRY_ORG # Non-sensitive org slug; used by withSentryConfig
+  - SENTRY_PROJECT # Non-sensitive project slug; used by withSentryConfig
 
 # Keys matching these patterns are always rejected, even if they match allowed_patterns.
 # Belt-and-suspenders: catches common secret naming conventions.


### PR DESCRIPTION
Removes the `sync-env` references from `deployment/schema.yml`. `sync-env` is a `vercel-deploy-scripts` command being deprecated; it will be reworked under the new env-config design.

## Change

The `allowed_keys` comments dropped their `sync-env --rotate-keys` / `sync-env --init sentry` mentions:

```diff
- - FIREBASE_SA_EMAIL # Service account email (identifier, not a key); used by sync-env --rotate-keys
- - SENTRY_ORG # Non-sensitive org slug; used by sync-env --init sentry and withSentryConfig
- - SENTRY_PROJECT # Non-sensitive project slug; used by sync-env --init sentry and withSentryConfig
+ - FIREBASE_SA_EMAIL # Service account email (identifier, not a key)
+ - SENTRY_ORG # Non-sensitive org slug; used by withSentryConfig
+ - SENTRY_PROJECT # Non-sensitive project slug; used by withSentryConfig
```

The env config itself — the allowed keys and their non-sensitive rationale — is kept; only the VDS-tool references are removed. (`withSentryConfig` is a Next.js Sentry usage, not VDS, so that reference stays.)

The repo's only other `sync-env` reference is a global Claude skill (not in this repo), which will be reworked separately.

---
*Created by Claude Opus 4.8*
