### PR TITLE
ci: split browser-based Storybook tests into their own job

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -12,12 +12,34 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+      # Headless suites only (node / hooks / components) — no browser, so this
+      # job stays fast and skips the Playwright install. The browser-based
+      # storybook project runs separately in `storybook-tests`.
+      - run: pnpm exec vitest run --project node --project hooks --project components
+
+  storybook-tests:
+    name: Storybook Tests
+    runs-on: ubuntu-latest
     timeout-minutes: 4
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
-      - run: pnpm exec playwright install chromium --with-deps
-      - run: pnpm test
+      - name: Install Playwright Chromium
+        # Retry: the browser/system-deps install hits transient apt/CDN failures.
+        run: |
+          for i in 1 2 3; do
+            if pnpm exec playwright install chromium --with-deps; then
+              exit 0
+            fi
+            echo "playwright install failed (attempt $i/3) — retrying in 5s"
+            sleep 5
+          done
+          exit 1
+      - run: pnpm exec vitest run --project storybook
 
   lint:
     name: Lint

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -31,12 +31,14 @@ jobs:
       - name: Install Playwright Chromium
         # Retry: the browser/system-deps install hits transient apt/CDN failures.
         run: |
-          for i in 1 2 3; do
+          for i in 0 1 2; do
+            if [ $i -gt 0 ]; then
+              echo "playwright install failed (attempt $i/3) — retrying in 5s"
+              sleep 5
+            fi
             if pnpm exec playwright install chromium --with-deps; then
               exit 0
             fi
-            echo "playwright install failed (attempt $i/3) — retrying in 5s"
-            sleep 5
           done
           exit 1
       - run: pnpm exec vitest run --project storybook

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     if: github.event_name == 'push'
-    needs: [tests, lint, format, typecheck, build]
+    needs: [tests, storybook-tests, lint, format, typecheck, build]
     steps:
       - uses: actions/checkout@v7
         with:

--- a/src/workflow-timeouts.spec.ts
+++ b/src/workflow-timeouts.spec.ts
@@ -14,7 +14,8 @@ const EXPECTED_TIMEOUT_MINUTES: Record<string, Record<string, number>> = {
     format: 2,
     lint: 2,
     "sentry-release": 2,
-    tests: 4,
+    "storybook-tests": 4,
+    tests: 2,
     typecheck: 1,
   },
   "file-length.yml": {


### PR DESCRIPTION
Splits the browser-based Storybook test project out of the `Tests` job into its own `Storybook Tests` job, so the headless suites no longer pay the Playwright browser-install cost or inherit its flakiness.

## Why

`Tests` ran `pnpm test` (all four Vitest projects — `node`, `hooks`, `components`, `storybook`) behind a `playwright install chromium --with-deps`. Only the `storybook` project needs a browser, yet the fast headless suites were gated on the heavyweight, occasionally-flaky (apt/CDN) browser install. This is the classic browser-vs-headless split.

## Change

- **`Tests`** — headless projects only: `vitest run --project node --project hooks --project components`. No Playwright install. Timeout 4 → **2 min** (locally these run in ~16s).
- **`Storybook Tests`** (new) — installs Chromium (wrapped in a 3× retry for transient apt/CDN failures) and runs `vitest run --project storybook`. Timeout **4 min**.
- Both reuse the existing `./.github/actions/setup` composite.
- Register `storybook-tests` in `src/workflow-timeouts.spec.ts` (the enforcement test asserts every job has a registered cap).

## Notes

- **Same coverage** — no checks removed, just reorganized. Not a CI loosening; both jobs remain gating. A red **Storybook Tests** vs **Tests** now tells you immediately whether a story or core logic broke, and lets the headless suite re-run without the browser cost.
- **Timeouts are initial estimates** — re-tune from observed p95 after the split jobs run a few times, per the methodology used in the original timeout-baseline.
- Verified locally: the headless split runs 2143 tests green; the enforcement test passes with the new job registered; prettier clean. (The `storybook` project itself runs in CI, where Chromium is installed.)

---
*Created by Claude Opus 4.8*
