### PR TITLE
ci: make the Storybook screenshots job advisory

### DIFF
--- a/.github/workflows/storybook-screenshots.yml
+++ b/.github/workflows/storybook-screenshots.yml
@@ -19,6 +19,12 @@ jobs:
   screenshots:
     name: Capture Storybook Screenshots
     runs-on: ubuntu-latest
+    # Advisory: this is preview tooling (posts a screenshot gallery), not a
+    # correctness gate. It depends on Playwright + a git push + the GitHub API,
+    # any of which can fail transiently. A failure must never block a code
+    # merge, so report green regardless. The timeout-minutes below still bounds
+    # a hang.
+    continue-on-error: true
     timeout-minutes: 5
     # Forked PRs receive a read-only GITHUB_TOKEN that cannot push to the
     # gh-screenshots branch, so skip them rather than fail.


### PR DESCRIPTION
Makes the Storybook screenshots job advisory by adding `continue-on-error: true`.

## Why

The `screenshots` job is **preview tooling** — it captures a Storybook screenshot gallery and posts it as a PR comment. It is not a correctness gate, and it depends on Playwright, a `git push` to the `gh-screenshots` branch, and the GitHub API — any of which can fail transiently. A failure or hang there should never block a code merge.

## Change

```yaml
  screenshots:
    name: Capture Storybook Screenshots
    continue-on-error: true   # advisory: never block merge on preview tooling
    ...
```

The existing `timeout-minutes: 5` still bounds a hang, and the forked-PR guard (`if:`) and `concurrency` group are unchanged.

## ⚠️ This is a CI loosening — requires sign-off

Adding `continue-on-error` makes a job non-gating, which is a CI loosening. Per the project's CI directive it stands alone in this dedicated PR and needs the **`CI change approved`** label before it can merge. `/review` will flag it and apply `escalation needed` until that label is applied.

The correctness gates (`Tests`, `Storybook Tests`, `Lint`, `Format`, `Typecheck`, `Build`) are unaffected and remain gating.

---
*Created by Claude Opus 4.8*
