### PR TITLE
ci!: add deployment config validation check (gated to deployment/**)

### DIFF
--- a/.github/workflows/config-validate.yml
+++ b/.github/workflows/config-validate.yml
@@ -1,0 +1,31 @@
+name: Config Validation
+
+# Validates deployment/*.yml against deployment/schema.yml. Gated to runs that
+# actually change the deployment config (or the validator itself) — the check's
+# only inputs are under deployment/ plus this script/workflow, so a paths
+# allowlist is safe here: if none of them changed, there is nothing to validate.
+on:
+  pull_request:
+    paths:
+      - "deployment/**"
+      - "scripts/validate-config.mjs"
+      - ".github/workflows/config-validate.yml"
+  push:
+    branches: [main]
+    paths:
+      - "deployment/**"
+      - "scripts/validate-config.mjs"
+      - ".github/workflows/config-validate.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-config:
+    name: Validate deployment config
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+      - run: node scripts/validate-config.mjs

--- a/scripts/validate-config.mjs
+++ b/scripts/validate-config.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * Validates deployment config files against deployment/schema.yml.
+ *
+ * Reads each environment listed in deployment/environments.yml, loads the
+ * corresponding deployment/{env}.yml, and checks every key against:
+ *   1. denied_patterns  — reject immediately (belt-and-suspenders)
+ *   2. allowed_patterns — accept if matched
+ *   3. allowed_keys     — accept if listed explicitly
+ *
+ * Exits 0 if all configs are valid, 1 if any violations are found.
+ * Accepts optional --env=<name> to validate a single environment.
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const deploymentDir = join(root, "deployment");
+
+function parseYamlSimple(content) {
+  // Minimal YAML parser for the constrained flat-key: value format used here.
+  // Does not handle anchors, multiline values, or nested structures.
+  const result = {};
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.replace(/#.*$/, "").trim();
+    if (!line) continue;
+    const colonIndex = line.indexOf(":");
+    if (colonIndex === -1) continue;
+    const key = line.slice(0, colonIndex).trim();
+    const value = line
+      .slice(colonIndex + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+    if (key) result[key] = value;
+  }
+  return result;
+}
+
+function parseYamlList(content, listKey) {
+  const lines = content.split("\n");
+  const items = [];
+  let inList = false;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith(`${listKey}:`)) {
+      inList = true;
+      continue;
+    }
+    if (inList) {
+      if (trimmed.startsWith("- ")) {
+        items.push(
+          trimmed
+            .slice(2)
+            .replace(/#.*$/, "")
+            .replace(/^["']|["']$/g, "")
+            .trim(),
+        );
+      } else if (trimmed && !trimmed.startsWith("#")) {
+        inList = false;
+      }
+    }
+  }
+  return items;
+}
+
+function globMatch(pattern, key) {
+  const regex = new RegExp(
+    "^" +
+      pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") +
+      "$",
+  );
+  return regex.test(key);
+}
+
+function loadSchema() {
+  const content = readFileSync(join(deploymentDir, "schema.yml"), "utf8");
+  return {
+    allowedPatterns: parseYamlList(content, "allowed_patterns"),
+    allowedKeys: parseYamlList(content, "allowed_keys"),
+    deniedPatterns: parseYamlList(content, "denied_patterns"),
+  };
+}
+
+function loadEnvironments() {
+  const content = readFileSync(join(deploymentDir, "environments.yml"), "utf8");
+  const envs = parseYamlList(content, "active");
+  const parsed = parseYamlSimple(content);
+  const singleEnv = parsed["single_environment"] === "true";
+  return { environments: envs, singleEnvironment: singleEnv };
+}
+
+function validateConfig(envName, schema) {
+  const configPath = join(deploymentDir, `${envName}.yml`);
+  if (!existsSync(configPath)) {
+    return [`deployment/${envName}.yml not found`];
+  }
+
+  const content = readFileSync(configPath, "utf8");
+  const inVariablesSection = [];
+  let inVars = false;
+  let foundVariablesBlock = false;
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.replace(/#.*$/, "");
+    const trimmed = line.trim();
+    if (trimmed === "variables:") {
+      inVars = true;
+      foundVariablesBlock = true;
+      continue;
+    }
+    if (inVars && trimmed && !trimmed.startsWith("#")) {
+      // A non-indented line signals a new top-level section — stop collecting
+      if (!line.startsWith(" ")) {
+        inVars = false;
+        continue;
+      }
+      const colonIndex = trimmed.indexOf(":");
+      if (colonIndex !== -1) {
+        const key = trimmed.slice(0, colonIndex).trim();
+        // Skip commented-out example lines (original line starts with whitespace + #)
+        if (!rawLine.trim().startsWith("#") && key) {
+          inVariablesSection.push(key);
+        }
+      }
+    }
+  }
+
+  const errors = [];
+  if (!foundVariablesBlock) {
+    errors.push(
+      `  MISSING  variables:  (no variables: block found in deployment/${envName}.yml)`,
+    );
+    return errors;
+  }
+  for (const key of inVariablesSection) {
+    const isDenied = schema.deniedPatterns.some((p) => globMatch(p, key));
+    if (isDenied) {
+      errors.push(
+        `  DENIED   ${key}  (matches a denied_pattern in schema.yml)`,
+      );
+      continue;
+    }
+    const isAllowed =
+      schema.allowedPatterns.some((p) => globMatch(p, key)) ||
+      schema.allowedKeys.includes(key);
+    if (!isAllowed) {
+      errors.push(
+        `  REJECTED ${key}  (not in allowed_patterns or allowed_keys in schema.yml)`,
+      );
+    }
+  }
+  return errors;
+}
+
+const args = process.argv.slice(2);
+const envArg = args.find((a) => a.startsWith("--env="))?.slice(6);
+
+const { environments, singleEnvironment } = loadEnvironments();
+const schema = loadSchema();
+
+const toValidate = envArg ? [envArg] : environments;
+
+if (!singleEnvironment && environments.length < 2 && !envArg) {
+  console.error(
+    "ERROR: environments.yml lists fewer than 2 environments but single_environment is not true.\n" +
+      "Set single_environment: true if this project intentionally uses one environment.",
+  );
+  process.exit(1);
+}
+
+let anyErrors = false;
+for (const env of toValidate) {
+  const errors = validateConfig(env, schema);
+  if (errors.length > 0) {
+    console.error(`\ndeployment/${env}.yml — ${errors.length} violation(s):`);
+    for (const e of errors) console.error(e);
+    anyErrors = true;
+  } else {
+    console.log(`deployment/${env}.yml — OK`);
+  }
+}
+
+if (anyErrors) {
+  console.error(
+    "\nFix the violations above or update deployment/schema.yml to allow these keys.",
+  );
+  process.exit(1);
+}

--- a/src/workflow-timeouts.spec.ts
+++ b/src/workflow-timeouts.spec.ts
@@ -17,6 +17,9 @@ const EXPECTED_TIMEOUT_MINUTES: Record<string, Record<string, number>> = {
     tests: 4,
     typecheck: 1,
   },
+  "config-validate.yml": {
+    "validate-config": 2,
+  },
   "file-length.yml": {
     check: 2,
   },


### PR DESCRIPTION
Adds a deployment-config validation CI check, ported from the [firebase-nextjs-template `config-validate.yml`](https://github.com/rmartz/firebase-nextjs-template/blob/main/.github/workflows/config-validate.yml) + `validate-config.mjs`. It is **pure Node — no dependency on `vercel-deploy-scripts`** — so it stands on its own ahead of the `envctl` replacement.

## What it does

`scripts/validate-config.mjs` reads `deployment/environments.yml` (`active:` list), then validates each `deployment/{env}.yml`'s `variables:` block against `deployment/schema.yml`:

1. reject any key matching a `denied_pattern` (`*SECRET*`, `*_TOKEN*`, `*PRIVATE_KEY*`, …),
2. otherwise accept if it matches an `allowed_pattern` (`NEXT_PUBLIC_*`) or is in `allowed_keys`.

The `Config Validation` workflow runs `node scripts/validate-config.mjs`, reusing the existing `./.github/actions/setup` composite.

## Gating

Per #753, the workflow is gated to runs that change the deployment config or the validator itself:

```yaml
paths:
  - "deployment/**"
  - "scripts/validate-config.mjs"
  - ".github/workflows/config-validate.yml"
```

A paths **allowlist** is correct and safe here (unlike the test/build jobs): the check's only inputs are those files, so if none changed there is nothing to validate. This deviates from the reference, which runs ungated — the gate is the one intentional addition.

## Verification

- `node scripts/validate-config.mjs` passes against the current `deployment/production.yml` (all 10 keys allowed).
- Negative check: injecting a `*_TOKEN*` key is correctly **DENIED** (exit 1).
- `timeout-minutes: 2`, registered in `src/workflow-timeouts.spec.ts` (enforcement test green).
- prettier clean.

## Notes

- This is net-new — the repo never had this workflow (nothing was wrongly removed by the VDS cleanup; the removed `secret-scan.yml` was the VDS-dependent one). It complements the forthcoming `envctl` rather than depending on it.

Closes #753.

---
*Created by Claude Opus 4.8*
