### PR TITLE
ci: move Storybook screenshots to a per-PR image branch

### DIFF
--- a/.github/scripts/storybook-screenshots.mjs
+++ b/.github/scripts/storybook-screenshots.mjs
@@ -1,14 +1,17 @@
 #!/usr/bin/env node
 /**
  * Captures Playwright screenshots for every Storybook story whose source file
- * changed in the PR, pushes them to the `gh-screenshots` branch, and posts (or
- * updates) a PR comment with an inline gallery.
+ * changed in the PR, pushes them to a per-PR `gh-screenshots-pr-<N>` branch,
+ * and posts (or updates) a PR comment with an inline gallery.
  *
  * Self-hosted (no third-party action): story IDs are read from Storybook's own
  * `storybook-static/index.json`, so they never drift from Storybook's auto-title
  * algorithm. Screenshots are captured with Playwright against a tiny static
- * server, committed to a long-lived `gh-screenshots` branch, and surfaced via a
- * single marker-tagged PR comment that is updated in place on re-runs.
+ * server, then force-pushed to a per-PR orphan branch — each PR owns its own
+ * image branch, so there is no cross-PR shared resource and concurrent PR runs
+ * never race. The set is surfaced via a single marker-tagged PR comment updated
+ * in place on re-runs. The per-PR branch is deleted when the PR closes by
+ * .github/workflows/storybook-screenshots-cleanup.yml.
  *
  * Expected environment variables:
  *   GITHUB_TOKEN  – token with contents:write and pull-requests:write
@@ -19,7 +22,7 @@
  */
 
 import { execSync } from "child_process";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { readFileSync, rmSync, writeFileSync } from "fs";
 import { createServer } from "http";
 import { extname, join } from "path";
 import { chromium } from "playwright";
@@ -31,7 +34,8 @@ const CHANGED_FILES = process.env.CHANGED_FILES ?? "";
 const PR_HEAD_SHA = process.env.PR_HEAD_SHA ?? "";
 
 const COMMENT_MARKER = "<!-- storybook-screenshots-bot -->";
-const SCREENSHOTS_BRANCH = "gh-screenshots";
+// Per-PR image branch — each PR owns its own, so runs never race across PRs.
+const SCREENSHOTS_BRANCH = `gh-screenshots-pr-${PR_NUMBER}`;
 const STORYBOOK_PORT = 6006;
 
 const MIME_TYPES = {
@@ -143,7 +147,7 @@ async function captureScreenshots() {
 }
 
 // ---------------------------------------------------------------------------
-// Push screenshots to the gh-screenshots branch
+// Push screenshots to the per-PR gh-screenshots-pr-<N> branch
 // ---------------------------------------------------------------------------
 
 function pushScreenshots(screenshots) {
@@ -155,50 +159,27 @@ function pushScreenshots(screenshots) {
   );
   execSync('git config user.name "github-actions[bot]"');
 
-  // Fetch the remote branch if it exists, creating a local tracking ref.
-  let branchExists = false;
-  try {
-    execSync(
-      `git fetch origin ${SCREENSHOTS_BRANCH}:refs/heads/${SCREENSHOTS_BRANCH}`,
-      { stdio: "pipe" },
-    );
-    branchExists = true;
-  } catch {
-    // Branch doesn't exist yet — created as an orphan below.
-  }
-
-  if (branchExists) {
-    execSync(`git worktree add ${tmpDir} ${SCREENSHOTS_BRANCH}`);
-  } else {
-    execSync(`git worktree add --orphan -b ${SCREENSHOTS_BRANCH} ${tmpDir}`);
-  }
-
-  const prDir = `${tmpDir}/pr-${PR_NUMBER}`;
-  // Clear stale screenshots from previous runs before writing the new set.
-  rmSync(prDir, { recursive: true, force: true });
-  mkdirSync(prDir, { recursive: true });
+  // Each PR owns its image branch (gh-screenshots-pr-<N>), so runs never race
+  // across PRs — there is no shared mutable resource. Rebuild the full set each
+  // run as a fresh orphan branch and force-push it: no fetch/merge, no stale
+  // files, and the branch stays image-only (carries no repo history). Intra-PR
+  // serialization is handled by the workflow's per-PR concurrency group, so the
+  // force-push never races with another run of the same PR.
+  rmSync(tmpDir, { recursive: true, force: true });
+  execSync(`git worktree add --orphan -b ${SCREENSHOTS_BRANCH} ${tmpDir}`);
 
   const fileNames = screenshots.map(({ story, buffer }) => {
     const safeName = story.id.replace(/[^a-zA-Z0-9-]/g, "-");
     const fileName = `${safeName}.png`;
-    writeFileSync(`${prDir}/${fileName}`, buffer);
+    writeFileSync(`${tmpDir}/${fileName}`, buffer);
     return { story, fileName };
   });
 
   execSync(`git -C ${tmpDir} add -A`);
-
-  const status = execSync(`git -C ${tmpDir} status --porcelain`, {
-    encoding: "utf8",
-  }).trim();
-  if (status) {
-    execSync(
-      `git -C ${tmpDir} commit -m "Add screenshots for PR #${PR_NUMBER} (${shortSha})"`,
-    );
-    execSync(`git -C ${tmpDir} push origin ${SCREENSHOTS_BRANCH}`);
-  } else {
-    console.log("Screenshots unchanged — skipping commit.");
-  }
-
+  execSync(
+    `git -C ${tmpDir} commit -m "Screenshots for PR #${PR_NUMBER} (${shortSha})"`,
+  );
+  execSync(`git -C ${tmpDir} push --force origin ${SCREENSHOTS_BRANCH}`);
   execSync(`git worktree remove --force ${tmpDir}`);
   return fileNames;
 }
@@ -208,7 +189,7 @@ function pushScreenshots(screenshots) {
 // ---------------------------------------------------------------------------
 
 function buildRawUrl(fileName) {
-  return `https://raw.githubusercontent.com/${REPO}/${SCREENSHOTS_BRANCH}/pr-${PR_NUMBER}/${fileName}`;
+  return `https://raw.githubusercontent.com/${REPO}/${SCREENSHOTS_BRANCH}/${fileName}`;
 }
 
 function buildCommentBody(fileNames) {

--- a/.github/workflows/storybook-screenshots-cleanup.yml
+++ b/.github/workflows/storybook-screenshots-cleanup.yml
@@ -1,0 +1,29 @@
+name: Storybook Screenshots Cleanup
+
+# When a PR closes (merged or not), delete its per-PR screenshots branch
+# (gh-screenshots-pr-<N>) so the image branches don't accumulate unboundedly.
+# Trade-off: the screenshot images in that PR's review comment 404 after close —
+# acceptable for ephemeral preview tooling (the review already happened).
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    name: Delete per-PR screenshots branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Delete gh-screenshots-pr-<number> if present
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="gh-screenshots-pr-${{ github.event.pull_request.number }}"
+          if gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${BRANCH}"; then
+            echo "Deleted ${BRANCH}."
+          else
+            echo "No ${BRANCH} branch to delete (PR had no story changes, or already removed)."
+          fi

--- a/.github/workflows/storybook-screenshots.yml
+++ b/.github/workflows/storybook-screenshots.yml
@@ -11,6 +11,10 @@ permissions:
   contents: write
   pull-requests: write
 
+# Per-PR concurrency: serialize only same-PR runs (cancel the older when a newer
+# one starts). Cross-PR safety needs no group — each PR force-pushes its own
+# image branch (gh-screenshots-pr-<N>), so two different PRs never share a
+# resource. This group only stops two runs of the SAME PR force-pushing at once.
 concurrency:
   group: storybook-screenshots-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/src/workflow-timeouts.spec.ts
+++ b/src/workflow-timeouts.spec.ts
@@ -26,6 +26,9 @@ const EXPECTED_TIMEOUT_MINUTES: Record<string, Record<string, number>> = {
   "pr-title-lint.yml": {
     "pr-title": 1,
   },
+  "storybook-screenshots-cleanup.yml": {
+    cleanup: 1,
+  },
   "storybook-screenshots.yml": {
     screenshots: 5,
   },


### PR DESCRIPTION
Moves Storybook screenshot storage off the single shared `gh-screenshots` branch onto a **per-PR image branch** (`gh-screenshots-pr-<N>`), adopting the core idea from [rmartz/group-picks#339](https://github.com/rmartz/group-picks/issues/339): the disease is "one mutable resource shared across all PRs," and a per-PR surface is concurrency-safe **by construction**.

## Why

Previously every PR pushed a `pr-<N>/` directory to one shared `gh-screenshots` branch. That shared resource caused two problems (flagged in the prior CI review):
1. **Push race** — two concurrent PRs both `git push` the shared branch; the loser fails non-fast-forward and its gallery silently doesn't land. Our bare push had no retry.
2. **Unbounded growth** — the shared branch accumulated a `pr-<N>/` dir for every PR ever, with no cleanup.

A per-PR branch removes the shared resource entirely, so neither problem can occur — strictly better than making the shared-branch race converge (the push-retry I'd previously floated is now unnecessary).

## Changes

- **`storybook-screenshots.mjs`** — `pushScreenshots()` builds a fresh **orphan** branch per run and **force-pushes** it (no fetch/merge, image-only history, no stale files). `buildRawUrl` points at the per-PR branch root. Dropped the now-unused `mkdirSync` import.
- **`storybook-screenshots.yml`** — **kept** the per-PR concurrency group (clarified in a comment): cross-PR safety now comes from per-PR branches, so the group only needs to serialize runs of the *same* PR (so two force-pushes of one PR don't race). Per #339, a per-ref group for intra-PR serialization is the sanctioned exception to "delete the concurrency block."
- **`storybook-screenshots-cleanup.yml`** (new) — on `pull_request: closed`, deletes that PR's `gh-screenshots-pr-<N>` branch (tolerates a missing branch), so branches don't accumulate. Registered in the timeout enforcement test.

## Trade-off

Deleting the per-PR branch on close (merged or not) means the screenshot images in that PR's review comment **404 after the PR closes**. That's acceptable for ephemeral preview tooling — the review already happened — and it's what keeps storage bounded (the #339 "TTL or on-close" cleanup requirement).

## What this does NOT change

- **Inline sticky PR comment** is unchanged — still the upserted marker-tagged gallery (the feature #339 keeps vs the artifact-only alternative).
- Self-hosted capture, story-change gating, advisory status (#750), and the always-on Storybook Tests suite are all untouched.
- Not adopted here (noted in #339 as future/optional): Vercel Blob hosting, and capturing inside the Vitest browser-mode run to drop the screenshots job's own `playwright install`. Lower priority; can follow.

## Verification

- `git worktree add --orphan -b … <path>` confirmed to produce a single image-only commit (tested locally on git 2.50).
- eslint clean (incl. the dropped import); enforcement test green (12 tests, cleanup job registered); prettier clean.

---
*Created by Claude Opus 4.8*
