### PR TITLE
ci!: gate Vercel preview deploys to feat/feature/fix branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,7 @@ After creating a git worktree (`git worktree add .git-worktrees/<name> -b <branc
 - Commit messages: imperative verbs (Add, Implement, Fix, Update, Extract, Remove). No `feat:`/`fix:` prefixes.
 - PR titles must follow Conventional Commits format: `<type>: description` or `<type>(<scope>): description`. This Conventional Commits requirement applies to PR titles only; commit messages remain imperative and should not use `feat:`/`fix:` prefixes. Valid types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `style`, `perf`, `ci`, `build`, `revert`. A `!` suffix is allowed before the colon to denote breaking changes (e.g., `feat!: remove legacy auth`). This is enforced by CI.
 - PR descriptions must use `Closes #123`, `Fixes #123`, or `Resolves #123` to trigger GitHub's automatic issue close on merge. Phrases like "Addresses #123" or "Related to #123" do NOT trigger auto-close.
+- **Vercel preview deploys are gated by branch prefix.** To conserve the daily preview-deploy quota, `scripts/vercel-ignore-build.sh` (wired via `ignoreCommand` in `vercel.json`) builds previews only for `feat/`, `feature/`, and `fix/` branches (plus production `main`); `chore/`, `docs/`, `refactor/`, `test/`, Dependabot, and agent (`copilot/`, `claude/`) branches are skipped. Use the correct prefix if a PR needs a preview for UAT. A label-driven replacement (deploy only when `ready for UAT`) is tracked as a follow-up.
 
 ## Storybook
 

--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Vercel "Ignored Build Step" — decides whether a deployment should build.
+#   exit 1 => proceed with the build/deploy
+#   exit 0 => skip (Vercel cancels the deployment)
+#
+# Goal: conserve the daily Vercel preview-deploy quota. A preview deploy only
+# exists to enable UAT, so most PRs don't need one — only feature and bug-fix
+# work does. We therefore build previews ONLY for feat/feature/fix branches and
+# skip everything else (docs, chore, refactor, test, deps, etc.).
+#
+# The Ignored Build Step runs against a commit and only has the git ref
+# ($VERCEL_GIT_COMMIT_REF) — NOT the PR title. This repo's branch-name
+# conventions make the prefix a reliable proxy for the PR's conventional-commit
+# type: feat: PRs come from feat/ or feature/ branches, fix: PRs from fix/.
+# A label-driven "deploy only when `ready for UAT`" design is the better long
+# term answer but needs the Vercel API; it's tracked as a follow-up issue.
+set -euo pipefail
+
+# Production (the main branch) must always deploy — the quota concern is
+# previews only.
+if [ "${VERCEL_ENV:-}" = "production" ]; then
+  echo "VERCEL_ENV=production — building."
+  exit 1
+fi
+
+ref="${VERCEL_GIT_COMMIT_REF:-}"
+case "$ref" in
+  main | master | feat/* | feature/* | fix/*)
+    echo "Branch '$ref' is deploy-eligible — building preview."
+    exit 1
+    ;;
+  *)
+    echo "Branch '$ref' is not a feat/feature/fix branch — skipping preview deploy to conserve quota."
+    exit 0
+    ;;
+esac

--- a/vercel.json
+++ b/vercel.json
@@ -5,5 +5,6 @@
       "path": "/api/cron/prune-stale",
       "schedule": "0 5 * * *"
     }
-  ]
+  ],
+  "ignoreCommand": "bash scripts/vercel-ignore-build.sh"
 }


### PR DESCRIPTION
Restricts Vercel **preview** deploys to feature and bug-fix work so docs/chore/refactor/dependency PRs stop consuming the daily preview-deploy quota. A preview deploy only exists to enable UAT, so PRs that don't ship user-facing behavior don't need one.

## What changed

- **`scripts/vercel-ignore-build.sh`** (new): a Vercel [Ignored Build Step](https://vercel.com/kb/guide/how-do-i-use-the-ignored-build-step-field-on-vercel). Exit `1` = build, exit `0` = skip. It builds for production `main` and for `feat/`, `feature/`, `fix/` branches; everything else (chore/docs/refactor/test, Dependabot, `copilot/`/`claude/` agent branches) is skipped.
- **`vercel.json`**: `"ignoreCommand": "bash scripts/vercel-ignore-build.sh"` — wires the step in, **fully committed, no dashboard change required**.
- **`AGENTS.md`**: a Git Conventions note documenting the gating so a skipped preview isn't a mystery.

## Why branch-prefix, not PR title

You asked to gate on `feat:`/`fix:` **titles**. The Ignored Build Step runs against a commit and only has the git ref (`$VERCEL_GIT_COMMIT_REF`) — **not the PR title** (that needs the Vercel API, deferred below). This repo's branch conventions make the prefix a clean proxy: `feat:` PRs come from `feat/`/`feature/` branches, `fix:` PRs from `fix/`. The known gap is agent branches (`copilot/`, `claude/`) — a `feat:`-titled PR from one of those is skipped under prefix gating. The label-based follow-up closes that gap properly.

## Verified

Exercised the script across refs (1 = build, 0 = skip):

| `VERCEL_ENV` / ref | result |
| --- | --- |
| production / `main` | build |
| preview / `feat/*`, `feature/*`, `fix/*` | build |
| preview / `chore/*`, `docs/*`, `refactor/*` | skip |
| preview / `copilot/*`, `dependabot/*` | skip |

`format` / `lint` / `typecheck` / `test` all pass (`pre-push-verify.py`); `vercel.json` is prettier-clean.

## Follow-up

The label-driven design (deploy only when a PR is `ready for UAT`) is filed separately — it needs a Vercel API key and so is intentionally out of scope here.

---
*Created by Claude Opus 4.8*
