### PR TITLE
ci: cache Playwright browsers in the shared setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,6 +6,14 @@ inputs:
     description: "Use --frozen-lockfile for pnpm install"
     required: false
     default: "true"
+  playwright:
+    description: >-
+      Space-separated Playwright browsers to install (e.g. "chromium"). When
+      set, the browser binaries are cached at ~/.cache/ms-playwright and
+      restored across runs and jobs, so only a cache miss pays the download.
+      Leave empty (default) for jobs that need no browser.
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -17,3 +25,44 @@ runs:
         cache: "pnpm"
     - run: pnpm install ${{ inputs.frozen-lockfile == 'true' && '--frozen-lockfile' || '--no-frozen-lockfile' }}
       shell: bash
+
+    # Cache the Playwright browser binaries so the ~130MB Chromium download is
+    # paid once and then shared by every browser job across both workflow files
+    # (the Actions cache is repo-global). Keyed on the lockfile so a Playwright
+    # version bump busts it; the prefix restore-key still restores the previous
+    # browsers on a partial hit, so a miss re-downloads only when the browser
+    # revision actually changed.
+    - name: Cache Playwright browsers
+      if: inputs.playwright != ''
+      id: playwright-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          playwright-${{ runner.os }}-
+
+    - name: Install Playwright browsers
+      if: inputs.playwright != ''
+      shell: bash
+      env:
+        PLAYWRIGHT_BROWSERS: ${{ inputs.playwright }}
+        CACHE_HIT: ${{ steps.playwright-cache.outputs.cache-hit }}
+      # On an exact cache hit the browser binary is already present, so only
+      # ensure the OS libraries (fast, no download). Otherwise install the
+      # browser plus its system deps. Retry either way: the browser/apt install
+      # hits transient CDN/apt failures.
+      run: |
+        if [ "$CACHE_HIT" = "true" ]; then
+          install_cmd="pnpm exec playwright install-deps $PLAYWRIGHT_BROWSERS"
+        else
+          install_cmd="pnpm exec playwright install --with-deps $PLAYWRIGHT_BROWSERS"
+        fi
+        for i in 1 2 3; do
+          if $install_cmd; then
+            exit 0
+          fi
+          echo "playwright install failed (attempt $i/3) — retrying in 5s"
+          sleep 5
+        done
+        exit 1

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -38,9 +38,9 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/ms-playwright
-        key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        key: playwright-${{ runner.os }}-${{ inputs.playwright }}-${{ hashFiles('pnpm-lock.yaml') }}
         restore-keys: |
-          playwright-${{ runner.os }}-
+          playwright-${{ runner.os }}-${{ inputs.playwright }}-
 
     - name: Install Playwright browsers
       if: inputs.playwright != ''

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -12,12 +12,34 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+      # Headless suites only (node / hooks / components) — no browser, so this
+      # job stays fast and skips the Playwright install. The browser-based
+      # storybook project runs separately in `storybook-tests`.
+      - run: pnpm exec vitest run --project node --project hooks --project components
+
+  storybook-tests:
+    name: Storybook Tests
+    runs-on: ubuntu-latest
     timeout-minutes: 4
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
-      - run: pnpm exec playwright install chromium --with-deps
-      - run: pnpm test
+      - name: Install Playwright Chromium
+        # Retry: the browser/system-deps install hits transient apt/CDN failures.
+        run: |
+          for i in 1 2 3; do
+            if pnpm exec playwright install chromium --with-deps; then
+              exit 0
+            fi
+            echo "playwright install failed (attempt $i/3) — retrying in 5s"
+            sleep 5
+          done
+          exit 1
+      - run: pnpm exec vitest run --project storybook
 
   lint:
     name: Lint

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -31,12 +31,14 @@ jobs:
       - name: Install Playwright Chromium
         # Retry: the browser/system-deps install hits transient apt/CDN failures.
         run: |
-          for i in 1 2 3; do
+          for i in 0 1 2; do
+            if [ $i -gt 0 ]; then
+              echo "playwright install failed (attempt $i/3) — retrying in 5s"
+              sleep 5
+            fi
             if pnpm exec playwright install chromium --with-deps; then
               exit 0
             fi
-            echo "playwright install failed (attempt $i/3) — retrying in 5s"
-            sleep 5
           done
           exit 1
       - run: pnpm exec vitest run --project storybook

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -28,17 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup
-      - name: Install Playwright Chromium
-        # Retry: the browser/system-deps install hits transient apt/CDN failures.
-        run: |
-          for i in 1 2 3; do
-            if pnpm exec playwright install chromium --with-deps; then
-              exit 0
-            fi
-            echo "playwright install failed (attempt $i/3) — retrying in 5s"
-            sleep 5
-          done
-          exit 1
+        with:
+          playwright: chromium
       - run: pnpm exec vitest run --project storybook
 
   lint:

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     if: github.event_name == 'push'
-    needs: [tests, lint, format, typecheck, build]
+    needs: [tests, storybook-tests, lint, format, typecheck, build]
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/storybook-screenshots.yml
+++ b/.github/workflows/storybook-screenshots.yml
@@ -45,10 +45,8 @@ jobs:
 
       - uses: ./.github/actions/setup
         if: steps.stories.outputs.found == 'true'
-
-      - name: Install Playwright Chromium
-        if: steps.stories.outputs.found == 'true'
-        run: pnpm exec playwright install --with-deps chromium
+        with:
+          playwright: chromium
 
       - name: Build Storybook
         if: steps.stories.outputs.found == 'true'

--- a/src/workflow-timeouts.spec.ts
+++ b/src/workflow-timeouts.spec.ts
@@ -14,7 +14,8 @@ const EXPECTED_TIMEOUT_MINUTES: Record<string, Record<string, number>> = {
     format: 2,
     lint: 2,
     "sentry-release": 2,
-    tests: 4,
+    "storybook-tests": 4,
+    tests: 2,
     typecheck: 1,
   },
   "file-length.yml": {


### PR DESCRIPTION
Stops the two browser CI jobs from each downloading Chromium from scratch. Both `storybook-tests` (`ci-actions.yml`) and `screenshots` (`storybook-screenshots.yml`) ran their own `playwright install chromium --with-deps` — two independent ~130MB downloads every run, with no sharing. This centralizes the install + a browser-binary cache in the shared `setup` composite, so the download is paid once and reused.

> **Stacked on #749** (`ci: split browser-based Storybook tests into their own job`). This PR targets `chore/split-storybook-tests` — review/merge #749 first; GitHub retargets this to `main` automatically once #749 lands. It builds directly on the `storybook-tests` job #749 introduces.

## What changed

- **`.github/actions/setup/action.yml`** — new optional `playwright` input (default `""`). When set (e.g. `chromium`) the composite:
  - restores/saves the browser cache at `~/.cache/ms-playwright` via `actions/cache`, keyed `playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}` with a `playwright-${{ runner.os }}-` restore-key;
  - on an **exact** cache hit runs `playwright install-deps <browser>` (OS libs only, no download); otherwise `playwright install --with-deps <browser>`;
  - retries the install 3× (the retry #749 added now lives here).
- **`ci-actions.yml`** — `storybook-tests` now calls `setup` with `playwright: chromium` and drops its bespoke install step.
- **`storybook-screenshots.yml`** — `screenshots` does the same (keeping its `if: found == 'true'` gate on the `setup` step).

Non-browser jobs (lint/format/tsc/build/tests) omit the input, so they never touch Playwright.

## Why a cache, not a shared pre-step

The two jobs live in different workflow files and run on separate parallel runners, so there's no shared filesystem or shared job to hang one download off. The **Actions cache is repo-global**, so keying both jobs on the same cache is the correct "share it" mechanism — exactly analogous to how `setup-node`'s `cache: pnpm` already shares the pnpm store. First run populates; every later run and both jobs restore it and skip the download.

## Cache-key behavior

`hashFiles('pnpm-lock.yaml')` busts the exact key whenever the lockfile changes (including a Playwright bump). The `playwright-${{ runner.os }}-` restore-key means a busted exact key still restores the most recent browsers, so `playwright install` re-downloads **only** when the browser revision actually changed — otherwise it's a near-noop that just ensures OS deps.

## Payoff

Saves the Chromium download (~15–40s) on every browser job after the first, and removes a network-download flake source — the same flakiness that forced the 3× retry here and contributes to the screenshots job being advisory.

## Verification

All three YAML files parse; `format`/`lint`/`typecheck` pass (`pre-push-verify.py`); the `workflow-timeouts` enforcement test passes (job set unchanged). The cache path/behavior can only be fully observed on a CI run — worth a glance at the first post-merge run to confirm the cache saves and a subsequent run hits it.

---
*Created by Claude Opus 4.8*
