### PR TITLE
fix(sentry)!: only create Sentry releases for production deploys

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,25 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {};
 
+// Only create Sentry releases / upload source maps for production deploys.
+//
+// The Sentry build plugin creates a release named after the build's commit SHA
+// whenever an auth token is present. On Vercel the token is set for every
+// environment, so *preview* builds were creating releases keyed on
+// feature-branch commits. Because we squash-merge, those commits are discarded
+// when the PR merges — so the release list fills with releases whose commit no
+// longer exists in main's history. The `Sentry Release` CI job then runs
+// `sentry-cli releases set-commits <sha> --auto`, which resolves the *previous*
+// release's commit to compute the range; when that previous release is a
+// squashed preview commit it can't be found and the job fails ("Could not find
+// the SHA of the previous release in the git history … amended or squashed").
+//
+// Gating release creation + source-map upload to production means every release
+// corresponds to a durable main commit, so `set-commits --auto` always finds a
+// reachable previous release. Runtime error capture in previews is unaffected —
+// that comes from the SDK init in the instrumentation files, not this plugin.
+const isProductionDeploy = process.env["VERCEL_ENV"] === "production";
+
 export default withSentryConfig(nextConfig, {
   org: "reedmartz",
   project: "hidden-role-game",
@@ -10,4 +29,11 @@ export default withSentryConfig(nextConfig, {
   widenClientFileUpload: true,
   tunnelRoute: "/monitoring",
   silent: !process.env["CI"],
+  release: {
+    create: isProductionDeploy,
+    finalize: isProductionDeploy,
+  },
+  sourcemaps: {
+    disable: !isProductionDeploy,
+  },
 });


### PR DESCRIPTION
Fixes the recurring `Sentry Release` failure on `main` at its root, instead of suppressing it with `--ignore-missing` (the approach in #766).

## Root cause

The `Sentry Release` job runs `sentry-cli releases set-commits <sha> --auto`. `--auto` computes the commit range by resolving the **previous release's commit** — and that commit isn't in `main`'s history:

```
error: Could not find the SHA of the previous release in the git history.
… it means that the commit we are looking for was amended or squashed and cannot be retrieved.
```

This is the **"squashed"** branch of the error, not the shallow-clone branch — the job already uses `fetch-depth: 0`, so increasing depth (and `--ignore-missing`) doesn't address the real problem. The chain:

1. `next.config.ts` wraps the app in `withSentryConfig` with an `authToken`. The Sentry build plugin **creates a release named after the build's commit SHA whenever a token is present** (default `release.create`).
2. The token was removed from the GitHub CI build step (`7de2a604`), but it lives in **Vercel's** env — so **every Vercel build creates a release**, including **preview** builds on feature-branch commits.
3. We **squash-merge**, so those feature-branch commits are discarded on merge. The release list fills with releases whose commit no longer exists in `main`.
4. When the GitHub `set-commits --auto` runs on the next `main` push, the *previous* release is often one of those squashed preview commits → not found → job fails.

## The fix

Gate the Sentry **build plugin** (release creation + source-map upload) to production deploys only (`VERCEL_ENV === "production"`):

```ts
const isProductionDeploy = process.env["VERCEL_ENV"] === "production";
// …
release:    { create: isProductionDeploy, finalize: isProductionDeploy },
sourcemaps: { disable: !isProductionDeploy },
```

Now every Sentry release corresponds to a **durable `main` commit**, so `set-commits --auto` always resolves a reachable previous release. Preview **runtime error capture is unaffected** — that comes from the SDK init in the instrumentation files (`instrumentation*.ts`, `sentry.*.config.ts`), not this build plugin. Previews just stop creating releases / uploading source maps (ephemeral, and preview deploys are already quota-gated per #763).

## Honest caveat — one possible transient

This stops *new* preview releases, but it can't retroactively remove the stale preview releases already in Sentry. If the single most-recent release in the project right now is a squashed preview commit, the **first** `main` push after this merges may still fail `set-commits --auto` once; it self-heals on the next production release (whose predecessor is then a durable `main` commit). To make it green immediately, delete the stale preview releases in the Sentry UI (I don't have Sentry access to do this). This is still strictly better than `--ignore-missing`, which permanently hides the failure — including cases where a base genuinely is missing for a real reason.

## Alternative considered

The GitHub `action-release` job is somewhat redundant with the plugin (both create the production release). Consolidating onto one owner is a larger change; this PR keeps both (the release names align — `github.sha` == the production `VERCEL_GIT_COMMIT_SHA`) and just removes the ephemeral-preview pollution that breaks `--auto`.

Supersedes #766 (which should be closed).

## Verification

`pnpm build` succeeds with the new options; `format` / `lint` / `typecheck` / `test` all pass (`pre-push-verify.py`).

---
*Created by Claude Opus 4.8*
