### PR TITLE
fix(sentry)!: set release commits explicitly instead of --auto

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -97,3 +97,16 @@ jobs:
         with:
           environment: production
           version: ${{ github.sha }}
+          # Associate commits explicitly instead of `set_commits: auto`. Auto
+          # resolves the *previous release* and needs its commit to exist in
+          # git history; because we squash-merge (and Vercel builds create
+          # releases keyed on commit SHAs), the previous release is often a
+          # commit that no longer exists on main, so auto fails with "Could not
+          # find the SHA of the previous release". Manual mode uses an explicit
+          # range: github.event.before is main's tip before this push — always a
+          # reachable main commit — so the range (before, sha] is exactly the
+          # commits this push introduced.
+          set_commits: manual
+          repo: ${{ github.repository }}
+          commit: ${{ github.sha }}
+          previous_commit: ${{ github.event.before }}


### PR DESCRIPTION
The `Sentry Release` job is still red on `main` with the same error, even after #768 gated preview releases. This fixes it at the level that's actually failing: the `set-commits` call.

## Why #768 wasn't enough

I pulled the failing job log (run for `c7d3939c`, the #763 push). Confirmed:

- The job checks out `fetch-depth: 0` (full history) and **still** fails — so this is the *"amended or squashed"* branch of the error, not clone depth.
- `INPUT_PREVIOUS_COMMIT:` is empty, so `sentry-cli releases set-commits <sha> --auto` **auto-resolves the previous release** and needs *its* commit to exist in git history.

`set_commits: auto` is the fragile part. It depends on the previous release's commit being reachable. Because we **squash-merge** and Vercel builds create releases keyed on commit SHAs, the most-recent prior release is frequently a commit that no longer exists on `main`. #768 stops *new* preview releases, but it can't:
- evict the stale preview releases already sitting at the top of Sentry's release list, or
- cover PR branches that predate the gate (their preview builds still ran the old config).

So `--auto` keeps landing on an unreachable previous release. #768 is still worth keeping (less Sentry noise, quota savings) — it just isn't the CI fix.

## The fix

Switch the action to `set_commits: manual` with an explicit range:

```yaml
set_commits: manual
repo: ${{ github.repository }}
commit: ${{ github.sha }}
previous_commit: ${{ github.event.before }}
```

`github.event.before` is `main`'s tip **before** this push — always a reachable `main` commit (we never rebase `main`). So `set-commits` associates exactly the commits in `(before, sha]` (the squash-merge commit this push introduced) and **never consults the previous-release pointer**. This is robust to squash-merges and to any residual/preview releases, so it doesn't depend on the Sentry release list being clean.

This is not suppression (contrast `--ignore-missing`, #766): commit association still happens, with the correct, explicitly-specified base.

## Verification

- Pulled and read the actual failing job log to confirm the mechanism (full clone + empty `previous_commit` + `--auto`).
- YAML parses; the manual inputs resolve as expected; `prettier` clean; the `workflow-timeouts` enforcement test passes (job set unchanged).
- Full confirmation is the first green `Sentry Release` run once this lands on `main`.

Fixes the failure tracked by #766 (already closed) and completes the fix started in #768.

---
*Created by Claude Opus 4.8*
