### PR TITLE
ci(sentry)!: skip commit association until the GitHub integration is set up

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -86,16 +86,11 @@ jobs:
         with:
           environment: production
           version: ${{ github.sha }}
-          # Associate commits explicitly instead of `set_commits: auto`. Auto
-          # resolves the *previous release* and needs its commit to exist in
-          # git history; because we squash-merge (and Vercel builds create
-          # releases keyed on commit SHAs), the previous release is often a
-          # commit that no longer exists on main, so auto fails with "Could not
-          # find the SHA of the previous release". Manual mode uses an explicit
-          # range: github.event.before is main's tip before this push — always a
-          # reachable main commit — so the range (before, sha] is exactly the
-          # commits this push introduced.
-          set_commits: manual
-          repo: ${{ github.repository }}
-          commit: ${{ github.sha }}
-          previous_commit: ${{ github.event.before }}
+          # Create/finalize the release only — do not associate commits.
+          # Commit association (`set_commits: auto`/`manual`) requires the repo
+          # to be registered in Sentry via its GitHub integration; it is not, so
+          # sentry-cli fails ("Unknown repo" in manual mode, "Could not find the
+          # SHA of the previous release" in auto mode). Skipping keeps release
+          # tracking working; re-enable set_commits once the Sentry GitHub
+          # integration is configured (tracked as a follow-up).
+          set_commits: skip


### PR DESCRIPTION
The `Sentry Release` job is still red on `main` after #769. Pulling the latest failing run's log shows #769 **did** take effect — the error changed, which is the key diagnostic:

```
releases set-commits <sha> --commit rmartz/hidden-role-game@<before>..<sha>
error: Unknown repo 'rmartz/hidden-role-game'
```

## The real root cause

Both failure modes have the same origin: **commit association requires the repository to be registered in Sentry via its GitHub integration, and it isn't.**

- `set_commits: auto` (original) → sentry-cli tries to resolve the previous release's commit → "Could not find the SHA of the previous release."
- `set_commits: manual` (#769) → sentry-cli gets an explicit `repo@range` but Sentry has no such repo registered → "Unknown repo."

Neither the clone depth, squash-merges, nor preview releases were ever the true blocker — those were symptoms. The actual prerequisite (a Sentry↔GitHub integration with this repo added) is a **Sentry dashboard configuration**, not something the workflow can supply.

## The fix

Set `set_commits: skip`. The job still **creates and finalizes** the release and marks the `production` environment — release tracking keeps working. It just doesn't attempt the commit association that has no backing integration.

This is deliberately *not* `ignore_missing` (#766): that flag pretends to associate commits while hiding a missing base. `skip` is the honest statement that we are not associating commits at all — because the infrastructure for it isn't in place. Commit association was never actually succeeding, so nothing functional is lost.

## Re-enabling commit tracking later

Tracked in #771: connect `rmartz/hidden-role-game` to Sentry's org-level GitHub integration, then flip `set_commits` back to `auto` (with the integration, Sentry resolves commits server-side from GitHub, which handles our squash-merge workflow). That first step is a Sentry dashboard action I can't perform from CI.

## Verification

- Confirmed the mechanism from the actual failing job log (`--commit rmartz/hidden-role-game@… → Unknown repo`).
- YAML parses; `set_commits: skip` resolves; prettier clean; `workflow-timeouts` enforcement test green.
- The definitive check is the first green `Sentry Release` run once this lands.

Completes the arc of #768 (gate preview releases) → #769 (explicit set-commits) → this (skip until integration exists).

---
*Created by Claude Opus 4.8*
