### PR TITLE
refactor(werewolf): split start-day action into smaller modules

### DIFF
--- a/src/lib/game/modes/werewolf/actions/start-day-resolution-setup.ts
+++ b/src/lib/game/modes/werewolf/actions/start-day-resolution-setup.ts
@@ -1,0 +1,118 @@
+import type { PlayerRoleAssignment } from "@/lib/types";
+
+import { WerewolfRole } from "../roles";
+import type {
+  AnyNightAction,
+  NightResolutionEvent,
+  WerewolfNighttimePhase,
+  WerewolfRoleTurnState,
+} from "../types";
+import { isTeamNightAction } from "../types";
+import { resolveNightActions } from "../utils";
+
+/**
+ * Builds the effective role assignments for a night by applying any mid-game
+ * roleOverrides (e.g. Alpha Wolf bite, Village Drunk sober) so all resolution
+ * logic uses the current effective role, not the original assignment.
+ */
+export function buildEffectiveAssignments(
+  roleAssignments: PlayerRoleAssignment[],
+  roleOverrides: Record<string, string> | undefined,
+): PlayerRoleAssignment[] {
+  return roleOverrides
+    ? roleAssignments.map((a) => {
+        const override = roleOverrides[a.playerId];
+        return override ? { ...a, roleDefinitionId: override } : a;
+      })
+    : roleAssignments;
+}
+
+/**
+ * Builds the priest wards to use during resolution: carries forward existing
+ * wards and adds any new ward from this night's Priest action BEFORE resolution
+ * so the ward protects the target on the same night it is placed.
+ */
+export function buildPriestWardsForResolution(
+  nightActions: Record<string, AnyNightAction>,
+  effectiveAssignments: PlayerRoleAssignment[],
+  rs: WerewolfRoleTurnState,
+): Record<string, string> {
+  const priestWardsForResolution: Record<string, string> = {
+    ...(rs.priest?.wards ?? {}),
+  };
+  const priestAction = nightActions[WerewolfRole.Priest];
+  if (
+    priestAction &&
+    !isTeamNightAction(priestAction) &&
+    priestAction.targetPlayerId
+  ) {
+    const priestPlayerId = effectiveAssignments.find(
+      (a) => a.roleDefinitionId === (WerewolfRole.Priest as string),
+    )?.playerId;
+    if (priestPlayerId) {
+      priestWardsForResolution[priestAction.targetPlayerId] = priestPlayerId;
+    }
+  }
+  return priestWardsForResolution;
+}
+
+interface RunNightResolutionParams {
+  nightPhase: WerewolfNighttimePhase;
+  effectiveAssignments: PlayerRoleAssignment[];
+  deadPlayerIds: string[];
+  rs: WerewolfRoleTurnState;
+  priestWardsForResolution: Record<string, string>;
+  oldManTimerPlayerId: string | undefined;
+  monarchPlayerId: string | undefined;
+  monarchKnightedPlayerIds: string[];
+}
+
+/**
+ * Runs night-action resolution, assembling the optional resolution context
+ * (priest wards, once-per-game charges, monarch protection, etc.) from the
+ * current role state and this night's derived inputs.
+ */
+export function runNightResolution(
+  p: RunNightResolutionParams,
+): NightResolutionEvent[] {
+  const { nightPhase, rs } = p;
+  return resolveNightActions(
+    nightPhase.nightActions,
+    p.effectiveAssignments,
+    p.deadPlayerIds,
+    nightPhase.smitedPlayerIds,
+    {
+      priestWards: p.priestWardsForResolution,
+      toughGuyHitIds: rs.toughGuy?.hitIds,
+      ...(p.oldManTimerPlayerId
+        ? { oldManTimerPlayerId: p.oldManTimerPlayerId }
+        : {}),
+      ...(rs.mirrorcaster?.charged ? { mirrorcasterCharged: true } : {}),
+      ...(rs.mercenary?.charged ? { mercenaryCharged: true } : {}),
+      ...(p.monarchPlayerId
+        ? {
+            monarchProtection: {
+              monarchPlayerId: p.monarchPlayerId,
+              monarchKnightedPlayerIds: p.monarchKnightedPlayerIds,
+            },
+          }
+        : {}),
+      ...(rs.arsonist?.dousedPlayerIds.length
+        ? { arsonistDousedPlayerIds: rs.arsonist.dousedPlayerIds }
+        : {}),
+    },
+  );
+}
+
+/**
+ * Resolves the Monarch's player ID (from original assignments) for the current
+ * game, or undefined if there is no Monarch in play.
+ */
+export function findMonarchPlayerId(
+  roleAssignments: PlayerRoleAssignment[],
+): string | undefined {
+  return roleAssignments.find(
+    (assignment) =>
+      assignment.roleDefinitionId === (WerewolfRole.Monarch as string),
+  )?.playerId;
+}

--- a/src/lib/game/modes/werewolf/actions/start-day-role-tracking.ts
+++ b/src/lib/game/modes/werewolf/actions/start-day-role-tracking.ts
@@ -1,0 +1,153 @@
+import type { Game, PlayerRoleAssignment } from "@/lib/types";
+
+import { WerewolfRole } from "../roles";
+import type {
+  AnyNightAction,
+  NightResolutionEvent,
+  ToughGuyAbsorbedNightResolutionEvent,
+  WerewolfNighttimePhase,
+  WerewolfRoleTurnState,
+} from "../types";
+import { isTeamNightAction } from "../types";
+import { confirmEvilEmpathResultAction } from "./confirm-evil-empath-result";
+import { didWolfCubDie } from "./helpers";
+
+/**
+ * Extracts the accumulated Tough Guy hit IDs after a night: carries forward
+ * prior hits and appends any player who absorbed an attack this night.
+ */
+export function computeToughGuyHitIds(
+  nightResolution: NightResolutionEvent[],
+  rs: WerewolfRoleTurnState,
+): string[] {
+  const newToughGuyHitIds = nightResolution
+    .filter(
+      (e): e is ToughGuyAbsorbedNightResolutionEvent =>
+        e.type === "tough-guy-absorbed",
+    )
+    .map((e) => e.targetPlayerId);
+  return [...(rs.toughGuy?.hitIds ?? []), ...newToughGuyHitIds];
+}
+
+/**
+ * Extracts the Illusion Artist's confirmed target for this night, if any, to
+ * carry into roleState. Seer result resolution reads this to invert the result
+ * when the Seer's target matches this player.
+ */
+export function computeIllusionTargetId(
+  nightActions: Record<string, AnyNightAction>,
+): string | undefined {
+  const illusionRawAction = nightActions[WerewolfRole.IllusionArtist as string];
+  const illusionAction =
+    illusionRawAction && !isTeamNightAction(illusionRawAction)
+      ? illusionRawAction
+      : undefined;
+  return illusionAction?.confirmed && illusionAction.targetPlayerId
+    ? illusionAction.targetPlayerId
+    : undefined;
+}
+
+/**
+ * Ensures the Evil Empath's adjacency result is computed before start-day when
+ * the Evil Empath was the final active night phase but the result was never
+ * resolved (e.g. narrator advanced directly to start-day). Mutates the game via
+ * the same action used in setNightPhaseAction — same guard used there.
+ */
+export function ensureEvilEmpathResultComputed(
+  game: Game,
+  nightPhase: WerewolfNighttimePhase,
+): void {
+  const finalPhaseKey =
+    nightPhase.nightPhaseOrder[nightPhase.currentPhaseIndex];
+  if (finalPhaseKey !== (WerewolfRole.EvilEmpath as string)) return;
+
+  const finalPhaseAction = nightPhase.nightActions[finalPhaseKey];
+  const alreadyComputed =
+    finalPhaseAction &&
+    !("votes" in finalPhaseAction) &&
+    finalPhaseAction.confirmed === true &&
+    finalPhaseAction.resultRevealed === true;
+  if (!alreadyComputed) {
+    confirmEvilEmpathResultAction.apply(game, {}, "");
+  }
+}
+
+/**
+ * Computes the Evil Empath's revealedResult after a night: if the Evil Empath
+ * died this night and has a last known result, expose it so Werewolves see it.
+ */
+export function computeEvilEmpathRevealedResult(
+  ts: { roleState?: WerewolfRoleTurnState },
+  effectiveAssignments: PlayerRoleAssignment[],
+  newDeadIds: string[],
+): boolean | undefined {
+  const evilEmpathLastResult = ts.roleState?.evilEmpath?.lastResult;
+  const evilEmpathAssignment = effectiveAssignments.find(
+    (a) => a.roleDefinitionId === (WerewolfRole.EvilEmpath as string),
+  );
+  return (
+    ts.roleState?.evilEmpath?.revealedResult ??
+    (evilEmpathAssignment !== undefined &&
+    newDeadIds.includes(evilEmpathAssignment.playerId) &&
+    evilEmpathLastResult !== undefined
+      ? evilEmpathLastResult
+      : undefined)
+  );
+}
+
+/**
+ * Whether a once-per-game targeting role (Witch, Exposer) has used its ability:
+ * either it was already marked used, or it acted this night with a target.
+ */
+export function computeOnceTargetAbilityUsed(
+  nightActions: Record<string, AnyNightAction>,
+  role: WerewolfRole,
+  alreadyUsed: boolean,
+): boolean {
+  const action = nightActions[role as string];
+  return (
+    alreadyUsed ||
+    (action !== undefined &&
+      !isTeamNightAction(action) &&
+      action.targetPlayerId !== undefined)
+  );
+}
+
+/**
+ * Increments the Veteran's alert usage count if the Veteran alerted this night.
+ */
+export function computeVeteranAlertsUsed(
+  nightActions: Record<string, AnyNightAction>,
+  rs: WerewolfRoleTurnState,
+): number {
+  const veteranNightAction = nightActions[WerewolfRole.Veteran];
+  const alertedThisNight =
+    veteranNightAction !== undefined &&
+    !isTeamNightAction(veteranNightAction) &&
+    veteranNightAction.alerted === true;
+  return (rs.veteran?.alertsUsed ?? 0) + (alertedThisNight ? 1 : 0);
+}
+
+/**
+ * Extracts The Thing's tapped player ID for this night, so they see the
+ * notification during the following daytime.
+ */
+export function computeThingTapped(
+  nightActions: Record<string, AnyNightAction>,
+): string | undefined {
+  const thingAction = nightActions[WerewolfRole.TheThing];
+  return thingAction !== undefined && !isTeamNightAction(thingAction)
+    ? thingAction.targetPlayerId
+    : undefined;
+}
+
+/**
+ * Whether the Wolf Cub has died: either previously recorded, or died this night.
+ */
+export function computeWolfCubDied(
+  newDeadIds: string[],
+  game: Game,
+  rs: WerewolfRoleTurnState,
+): boolean {
+  return rs.wolfCub?.died === true || didWolfCubDie(newDeadIds, game);
+}

--- a/src/lib/game/modes/werewolf/actions/start-day-turn-state.ts
+++ b/src/lib/game/modes/werewolf/actions/start-day-turn-state.ts
@@ -1,0 +1,97 @@
+import type { Game, PlayerRoleAssignment } from "@/lib/types";
+import { GameStatus } from "@/lib/types";
+
+import { WerewolfRole } from "../roles";
+import type {
+  AnyNightAction,
+  NightResolutionEvent,
+  WerewolfRoleTurnState,
+} from "../types";
+import { WerewolfPhase } from "../types";
+import { checkWinCondition, WerewolfWinner } from "../utils";
+
+interface BuildDaytimeStatusParams {
+  turn: number;
+  nightActions: Record<string, AnyNightAction>;
+  revealedPlayerIds: string[];
+  nightResolution: NightResolutionEvent[];
+  newExposerReveal: { playerId: string; roleId: string } | undefined;
+  knightedPlayerId: string | undefined;
+  smitedPlayerIds: string[] | undefined;
+  updatedDeadIds: string[];
+  lastTargets: Record<string, string>;
+  roleOverrides: Record<string, string> | undefined;
+  newRoleState: WerewolfRoleTurnState;
+}
+
+/**
+ * Builds the Playing game status for the transition into the daytime phase,
+ * including only the optional fields that have relevant values.
+ */
+export function buildDaytimeStatus(
+  p: BuildDaytimeStatusParams,
+): Game["status"] {
+  return {
+    type: GameStatus.Playing,
+    turnState: {
+      turn: p.turn,
+      phase: {
+        type: WerewolfPhase.Daytime,
+        startedAt: Date.now(),
+        nightActions: p.nightActions,
+        revealedPlayerIds: p.revealedPlayerIds,
+        ...(p.nightResolution.length > 0
+          ? { nightResolution: p.nightResolution }
+          : {}),
+        ...(p.newExposerReveal ? { exposerReveal: p.newExposerReveal } : {}),
+        ...(p.knightedPlayerId !== undefined
+          ? { knightedPlayerId: p.knightedPlayerId }
+          : {}),
+        ...(p.smitedPlayerIds?.length
+          ? { smitedPlayerIds: p.smitedPlayerIds }
+          : {}),
+      },
+      deadPlayerIds: p.updatedDeadIds,
+      ...(Object.keys(p.lastTargets).length > 0
+        ? { lastTargets: p.lastTargets }
+        : {}),
+      ...(p.roleOverrides ? { roleOverrides: p.roleOverrides } : {}),
+      ...(Object.keys(p.newRoleState).length > 0
+        ? { roleState: p.newRoleState }
+        : {}),
+    },
+  };
+}
+
+/**
+ * Applies end-of-night win conditions after the daytime turn state is built.
+ * - Tanner wins immediately if killed at night.
+ * - Otherwise, run the standard win-condition check unless the Hunter died
+ *   this night (in which case resolution is deferred to the revenge target).
+ * Mutates game.status in place when a terminal condition is met.
+ */
+export function applyStartDayEndConditions(
+  game: Game,
+  effectiveAssignments: PlayerRoleAssignment[],
+  newDeadIds: string[],
+  updatedDeadIds: string[],
+  hunterDiedThisNight: boolean,
+): void {
+  const tannerAssignment = effectiveAssignments.find(
+    (a) => a.roleDefinitionId === (WerewolfRole.Tanner as string),
+  );
+  if (tannerAssignment && newDeadIds.includes(tannerAssignment.playerId)) {
+    game.status = {
+      type: GameStatus.Finished,
+      winner: WerewolfWinner.Tanner,
+    };
+    return;
+  }
+
+  if (!hunterDiedThisNight) {
+    const winResult = checkWinCondition(game, updatedDeadIds);
+    if (winResult) {
+      game.status = winResult;
+    }
+  }
+}

--- a/src/lib/game/modes/werewolf/actions/start-day.ts
+++ b/src/lib/game/modes/werewolf/actions/start-day.ts
@@ -1,25 +1,15 @@
 import type { Game, GameAction } from "@/lib/types";
-import { GameStatus } from "@/lib/types";
 
 import { getWerewolfModeConfig } from "../lobby-config";
 import { WerewolfRole } from "../roles";
 import { getOrderedAffectedPlayerIds } from "../services";
 import type {
   AttackNightResolutionEvent,
-  ToughGuyAbsorbedNightResolutionEvent,
   WerewolfNighttimePhase,
   WerewolfRoleTurnState,
 } from "../types";
-import { isTeamNightAction, WerewolfPhase } from "../types";
-import {
-  checkWinCondition,
-  currentTurnState,
-  isOwnerPlaying,
-  resolveNightActions,
-  WerewolfWinner,
-} from "../utils";
-import { confirmEvilEmpathResultAction } from "./confirm-evil-empath-result";
-import { didWolfCubDie } from "./helpers";
+import { WerewolfPhase } from "../types";
+import { currentTurnState, isOwnerPlaying } from "../utils";
 import {
   computeArsonistDousedPlayerIds,
   computeDraculaWives,
@@ -40,6 +30,26 @@ import {
   computeOldManTimerPlayerId,
   computePriestWards,
 } from "./start-day-night-resolution";
+import {
+  buildEffectiveAssignments,
+  buildPriestWardsForResolution,
+  findMonarchPlayerId,
+  runNightResolution,
+} from "./start-day-resolution-setup";
+import {
+  computeEvilEmpathRevealedResult,
+  computeIllusionTargetId,
+  computeOnceTargetAbilityUsed,
+  computeThingTapped,
+  computeToughGuyHitIds,
+  computeVeteranAlertsUsed,
+  computeWolfCubDied,
+  ensureEvilEmpathResultComputed,
+} from "./start-day-role-tracking";
+import {
+  applyStartDayEndConditions,
+  buildDaytimeStatus,
+} from "./start-day-turn-state";
 
 export const startDayAction: GameAction = {
   isValid(game: Game, callerId: string) {
@@ -53,36 +63,20 @@ export const startDayAction: GameAction = {
 
     const rs = ts.roleState ?? {};
 
-    // Build effective role assignments — apply any mid-game roleOverrides
-    // (Alpha Wolf bite, Village Drunk sober) so all resolution logic uses
-    // the current effective role, not the original assignment.
-    const roleOverrides = ts.roleOverrides;
-    const effectiveAssignments = roleOverrides
-      ? game.roleAssignments.map((a) => {
-          const override = roleOverrides[a.playerId];
-          return override ? { ...a, roleDefinitionId: override } : a;
-        })
-      : game.roleAssignments;
+    // Apply any mid-game roleOverrides so all resolution logic uses the current
+    // effective role, not the original assignment.
+    const effectiveAssignments = buildEffectiveAssignments(
+      game.roleAssignments,
+      ts.roleOverrides,
+    );
 
-    // Build priest wards: carry forward existing wards and add any new ward
-    // from this night's Priest action BEFORE resolution so the ward protects
-    // the target on the same night it is placed.
-    const priestWardsForResolution: Record<string, string> = {
-      ...(rs.priest?.wards ?? {}),
-    };
-    const priestAction = nightPhase.nightActions[WerewolfRole.Priest];
-    if (
-      priestAction &&
-      !isTeamNightAction(priestAction) &&
-      priestAction.targetPlayerId
-    ) {
-      const priestPlayerId = effectiveAssignments.find(
-        (a) => a.roleDefinitionId === (WerewolfRole.Priest as string),
-      )?.playerId;
-      if (priestPlayerId) {
-        priestWardsForResolution[priestAction.targetPlayerId] = priestPlayerId;
-      }
-    }
+    // Priest wards used during resolution protect the target on the same night
+    // the ward is placed.
+    const priestWardsForResolution = buildPriestWardsForResolution(
+      nightPhase.nightActions,
+      effectiveAssignments,
+      rs,
+    );
 
     // Old Man timer: fires after (#werewolves + 2) nights.
     const oldManTimerPlayerId = computeOldManTimerPlayerId(
@@ -96,35 +90,18 @@ export const startDayAction: GameAction = {
       monarchKnightingsUsed,
       knightedPlayerId,
     } = computeMonarchKnightingState(nightPhase.nightActions, rs);
-    const monarchPlayerId = game.roleAssignments.find(
-      (assignment) =>
-        assignment.roleDefinitionId === (WerewolfRole.Monarch as string),
-    )?.playerId;
+    const monarchPlayerId = findMonarchPlayerId(game.roleAssignments);
 
-    const nightResolution = resolveNightActions(
-      nightPhase.nightActions,
+    const nightResolution = runNightResolution({
+      nightPhase,
       effectiveAssignments,
-      ts.deadPlayerIds,
-      nightPhase.smitedPlayerIds,
-      {
-        priestWards: priestWardsForResolution,
-        toughGuyHitIds: rs.toughGuy?.hitIds,
-        ...(oldManTimerPlayerId ? { oldManTimerPlayerId } : {}),
-        ...(rs.mirrorcaster?.charged ? { mirrorcasterCharged: true } : {}),
-        ...(rs.mercenary?.charged ? { mercenaryCharged: true } : {}),
-        ...(monarchPlayerId
-          ? {
-              monarchProtection: {
-                monarchPlayerId,
-                monarchKnightedPlayerIds,
-              },
-            }
-          : {}),
-        ...(rs.arsonist?.dousedPlayerIds.length
-          ? { arsonistDousedPlayerIds: rs.arsonist.dousedPlayerIds }
-          : {}),
-      },
-    );
+      deadPlayerIds: ts.deadPlayerIds,
+      rs,
+      priestWardsForResolution,
+      oldManTimerPlayerId,
+      monarchPlayerId,
+      monarchKnightedPlayerIds,
+    });
 
     const newDeadIds: string[] = nightResolution
       .filter(
@@ -132,27 +109,17 @@ export const startDayAction: GameAction = {
       )
       .map((e) => e.targetPlayerId);
 
-    // Track Tough Guy hits: players who absorbed an attack this night.
-    const newToughGuyHitIds = nightResolution
-      .filter(
-        (e): e is ToughGuyAbsorbedNightResolutionEvent =>
-          e.type === "tough-guy-absorbed",
-      )
-      .map((e) => e.targetPlayerId);
-    const toughGuyHitIds = [
-      ...(rs.toughGuy?.hitIds ?? []),
-      ...newToughGuyHitIds,
-    ];
+    // Tough Guy hits: players who absorbed an attack this night.
+    const toughGuyHitIds = computeToughGuyHitIds(nightResolution, rs);
 
-    // Consume priest wards for any warded player who was attacked this night,
-    // regardless of whether other protections also saved them.
+    // Consume priest wards for any warded player who was attacked this night.
     const priestWards = computePriestWards(
       nightResolution,
       priestWardsForResolution,
     );
 
-    // One-Eyed Seer lock: if the OES investigated a werewolf this night, lock them on.
-    // If the OES's locked target died this night, the lock is cleared.
+    // One-Eyed Seer lock: locks onto an investigated werewolf; cleared if the
+    // locked target died this night.
     const oneEyedSeerLockedTargetId = computeOesLockedTargetId(
       nightPhase.nightActions,
       effectiveAssignments,
@@ -160,71 +127,33 @@ export const startDayAction: GameAction = {
       rs.oneEyedSeer?.lockedTargetId,
     );
 
-    // Exposer reveal: if the Exposer confirmed a target this night, capture the
-    // new reveal for this day's summary on the daytime phase.
+    // Exposer reveal: capture any new reveal for this day's summary.
     const { newExposerReveal, exposerReveal } = computeExposerReveal(
       nightPhase.nightActions,
       effectiveAssignments,
       rs.exposer?.reveal,
     );
 
-    // Illusion Artist: extract the target from this night's action to carry into
-    // roleState.illusionArtist.illusionTargetId. Seer result resolution reads
-    // this to invert the result when the Seer's target matches this player.
-    const illusionRawAction =
-      nightPhase.nightActions[WerewolfRole.IllusionArtist as string];
-    const illusionAction =
-      illusionRawAction && !isTeamNightAction(illusionRawAction)
-        ? illusionRawAction
-        : undefined;
-    const illusionTargetId =
-      illusionAction?.confirmed && illusionAction.targetPlayerId
-        ? illusionAction.targetPlayerId
-        : undefined;
+    const illusionTargetId = computeIllusionTargetId(nightPhase.nightActions);
 
-    // Evil Empath: if the Evil Empath was the last (active) night phase and the
-    // result was never computed (e.g. narrator advanced directly to start-day,
-    // or the generic skip/confirm flow set confirmed without resultRevealed),
-    // auto-compute it now — same guard used in setNightPhaseAction.
-    const finalPhaseKey =
-      nightPhase.nightPhaseOrder[nightPhase.currentPhaseIndex];
-    const finalPhaseAction = nightPhase.nightActions[finalPhaseKey ?? ""];
-    const evilEmpathAlreadyComputed =
-      finalPhaseKey === (WerewolfRole.EvilEmpath as string) &&
-      finalPhaseAction &&
-      !("votes" in finalPhaseAction) &&
-      finalPhaseAction.confirmed === true &&
-      finalPhaseAction.resultRevealed === true;
-    if (
-      finalPhaseKey === (WerewolfRole.EvilEmpath as string) &&
-      !evilEmpathAlreadyComputed
-    ) {
-      confirmEvilEmpathResultAction.apply(game, {}, "");
-    }
+    // Auto-compute the Evil Empath result if it was the final active phase but
+    // was never resolved (same guard used in setNightPhaseAction).
+    ensureEvilEmpathResultComputed(game, nightPhase);
 
-    // Evil Empath: carry the last known adjacency result forward so it can be
-    // revealed to Werewolves when the Evil Empath dies.
+    // Carry the last known adjacency result forward so it can be revealed to
+    // Werewolves when the Evil Empath dies.
     const evilEmpathLastResult = ts.roleState?.evilEmpath?.lastResult;
-
-    // Evil Empath death trigger: if the Evil Empath died this night and there is
-    // a last result, set revealedResult so Werewolves see it. Use
-    // effectiveAssignments so mid-game roleOverrides are respected.
-    const evilEmpathAssignment = effectiveAssignments.find(
-      (a) => a.roleDefinitionId === (WerewolfRole.EvilEmpath as string),
+    const evilEmpathRevealedResult = computeEvilEmpathRevealedResult(
+      ts,
+      effectiveAssignments,
+      newDeadIds,
     );
-    const evilEmpathRevealedResult =
-      ts.roleState?.evilEmpath?.revealedResult ??
-      (evilEmpathAssignment !== undefined &&
-      newDeadIds.includes(evilEmpathAssignment.playerId) &&
-      evilEmpathLastResult !== undefined
-        ? evilEmpathLastResult
-        : undefined);
 
     // Build lastTargets for roles that prevent consecutive same-player targeting.
     const lastTargets = buildLastTargets(nightPhase.nightActions);
 
-    // Vigilante self-death: if the Vigilante killed a Good-team player, they die too.
-    // Skip if the Vigilante was already killed this night (e.g. by wolves).
+    // Vigilante self-death: if the Vigilante killed a Good-team player, they die
+    // too. Skip if already killed this night. Mutates newDeadIds in place.
     applyVigilanteSelfDeath(
       nightPhase.nightActions,
       effectiveAssignments,
@@ -232,7 +161,7 @@ export const startDayAction: GameAction = {
       newDeadIds,
     );
 
-    // Mortician ability: check if the Mortician killed a Werewolf this night.
+    // Mortician ability: ends if the Mortician killed a Werewolf this night.
     const morticianAbilityEnded = computeMorticianAbilityEnded(
       nightPhase.nightActions,
       effectiveAssignments,
@@ -249,79 +178,48 @@ export const startDayAction: GameAction = {
       hunterAssignment !== undefined &&
       newDeadIds.includes(hunterAssignment.playerId);
 
-    // Once-per-game ability tracking: detect if a once-per-game role acted
-    // this night (has a targetPlayerId, not skipped). This handles all paths
-    // (player confirm, narrator override) in one place.
-    const witchAction = nightPhase.nightActions[WerewolfRole.Witch as string];
-    const witchAbilityUsed =
-      rs.witch?.abilityUsed === true ||
-      (witchAction !== undefined &&
-        !isTeamNightAction(witchAction) &&
-        witchAction.targetPlayerId !== undefined);
+    // Once-per-game ability tracking for target-based roles.
+    const witchAbilityUsed = computeOnceTargetAbilityUsed(
+      nightPhase.nightActions,
+      WerewolfRole.Witch,
+      rs.witch?.abilityUsed === true,
+    );
+    const exposerAbilityUsed = computeOnceTargetAbilityUsed(
+      nightPhase.nightActions,
+      WerewolfRole.Exposer,
+      rs.exposer?.abilityUsed === true,
+    );
 
-    const exposerNightAction =
-      nightPhase.nightActions[WerewolfRole.Exposer as string];
-    const exposerAbilityUsed =
-      rs.exposer?.abilityUsed === true ||
-      (exposerNightAction !== undefined &&
-        !isTeamNightAction(exposerNightAction) &&
-        exposerNightAction.targetPlayerId !== undefined);
-
-    // Mirrorcaster charge tracking:
-    // - If uncharged and the protected target was attacked → gain charge
-    // - If charged → charge is consumed (attack was used this night)
     const mirrorcasterCharged = computeMirrorcasterCharged(
       nightPhase.nightActions,
       nightResolution,
       rs,
     );
 
-    // Mercenary charge/bribe tracking:
-    // - If uncharged (protect mode) and the protected target was attacked → gain charge (earn coin)
-    // - If charged (bribe mode) and a bribe target was submitted → append to bribedPlayerIds, clear charge
-    // - If charged (bribe mode) and no bribe target was submitted → carry charge forward
     const { mercenaryCharged, mercenaryBribedPlayerIds } =
       computeMercenaryState(nightPhase.nightActions, nightResolution, rs);
 
     const updatedDeadIds = [...ts.deadPlayerIds, ...newDeadIds];
 
-    // Dracula: add the night's wife target to the accumulated list.
-    // Exclude the target if they died the same night they were claimed.
     const draculaWives = computeDraculaWives(
       nightPhase.nightActions,
       rs,
       updatedDeadIds,
     );
 
-    // Zombie: add the night's infection target to the accumulated list (if not already infected).
-    // Exclude the target if they died the same night they were infected.
     const zombieInfected = computeZombieInfected(
       nightPhase.nightActions,
       rs,
       updatedDeadIds,
     );
 
-    // Veteran alert usage tracking: increment once per night the Veteran alerts.
-    const veteranNightAction = nightPhase.nightActions[WerewolfRole.Veteran];
-    const veteranAlertedThisNight =
-      veteranNightAction !== undefined &&
-      !isTeamNightAction(veteranNightAction) &&
-      veteranNightAction.alerted === true;
-    const veteranAlertsUsed =
-      (ts.roleState?.veteran?.alertsUsed ?? 0) +
-      (veteranAlertedThisNight ? 1 : 0);
+    const veteranAlertsUsed = computeVeteranAlertsUsed(
+      nightPhase.nightActions,
+      rs,
+    );
 
-    // The Thing tap: record the tapped player ID so they see the notification
-    // during the following daytime.
-    const thingAction = nightPhase.nightActions[WerewolfRole.TheThing];
-    const thingTapped =
-      thingAction !== undefined && !isTeamNightAction(thingAction)
-        ? thingAction.targetPlayerId
-        : undefined;
+    const thingTapped = computeThingTapped(nightPhase.nightActions);
 
-    // Arsonist: update the doused player list.
-    // If the Arsonist self-targeted (ignite), reset the doused list.
-    // If the Arsonist targeted another player (douse), add them to the list.
     const arsonistDousedPlayerIds = computeArsonistDousedPlayerIds(
       nightPhase.nightActions,
       game.roleAssignments,
@@ -329,8 +227,7 @@ export const startDayAction: GameAction = {
       updatedDeadIds,
     );
 
-    const wolfCubDied =
-      rs.wolfCub?.died === true || didWolfCubDie(newDeadIds, game);
+    const wolfCubDied = computeWolfCubDied(newDeadIds, game, rs);
     const revealedPlayerIds = getWerewolfModeConfig(game).autoRevealNightOutcome
       ? getOrderedAffectedPlayerIds(nightResolution)
       : [];
@@ -362,49 +259,28 @@ export const startDayAction: GameAction = {
       veteranAlertsUsed,
     });
 
-    game.status = {
-      type: GameStatus.Playing,
-      turnState: {
-        turn: ts.turn,
-        phase: {
-          type: WerewolfPhase.Daytime,
-          startedAt: Date.now(),
-          nightActions: nightPhase.nightActions,
-          revealedPlayerIds,
-          ...(nightResolution.length > 0 ? { nightResolution } : {}),
-          ...(newExposerReveal ? { exposerReveal: newExposerReveal } : {}),
-          ...(knightedPlayerId !== undefined ? { knightedPlayerId } : {}),
-          ...(nightPhase.smitedPlayerIds?.length
-            ? { smitedPlayerIds: nightPhase.smitedPlayerIds }
-            : {}),
-        },
-        deadPlayerIds: updatedDeadIds,
-        ...(Object.keys(lastTargets).length > 0 ? { lastTargets } : {}),
-        ...(ts.roleOverrides ? { roleOverrides: ts.roleOverrides } : {}),
-        ...(Object.keys(newRoleState).length > 0
-          ? { roleState: newRoleState }
-          : {}),
-      },
-    };
+    game.status = buildDaytimeStatus({
+      turn: ts.turn,
+      nightActions: nightPhase.nightActions,
+      revealedPlayerIds,
+      nightResolution,
+      newExposerReveal,
+      knightedPlayerId,
+      smitedPlayerIds: nightPhase.smitedPlayerIds,
+      updatedDeadIds,
+      lastTargets,
+      roleOverrides: ts.roleOverrides,
+      newRoleState,
+    });
 
-    // Tanner wins immediately if killed at night — checked after turn state
-    // is built so all deaths and night resolution are recorded.
-    const tannerAssignment = effectiveAssignments.find(
-      (a) => a.roleDefinitionId === (WerewolfRole.Tanner as string),
+    // Terminal win conditions checked after the turn state is built so all
+    // deaths and night resolution are recorded.
+    applyStartDayEndConditions(
+      game,
+      effectiveAssignments,
+      newDeadIds,
+      updatedDeadIds,
+      hunterDiedThisNight,
     );
-    if (tannerAssignment && newDeadIds.includes(tannerAssignment.playerId)) {
-      game.status = {
-        type: GameStatus.Finished,
-        winner: WerewolfWinner.Tanner,
-      };
-      return;
-    }
-
-    if (!hunterDiedThisNight) {
-      const winResult = checkWinCondition(game, updatedDeadIds);
-      if (winResult) {
-        game.status = winResult;
-      }
-    }
   },
 };


### PR DESCRIPTION
Splits `werewolf/actions/start-day.ts` (~595 lines, over the 400-line source cap) into smaller modules along clean seams, keeping the exported `startDayAction` and other public exports stable. Pure behavior-preserving refactor.

Scoped to the **source** file only; the companion test-split (#628) stacks on this branch once it lands.

## Verification

- `format` / `lint` / `typecheck` pass (`pre-push-verify.py`).

## Note

Recovered from an interrupted `/implement-all #730` run — the worker committed and pushed this branch but the process exited before it opened the PR. Opening it now.

Closes #726.

---
*Created by Claude Opus 4.8*
