### PR TITLE
ci: add a gating Storybook build job

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -92,7 +92,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     if: github.event_name == 'push'
-    needs: [tests, storybook-tests, lint, format, typecheck, build]
+    needs:
+      [tests, storybook-tests, lint, format, typecheck, build, storybook-build]
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -68,6 +68,25 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm build
 
+  # Gating coverage for the production Storybook bundle. build-storybook uses a
+  # different entrypoint/bundler than `pnpm build` (Next.js) and is a render
+  # surface the vitest `storybook-tests` job never exercises, so neither of
+  # those covers it. Without this job, build-storybook runs only inside the
+  # advisory, story-gated screenshots job (under continue-on-error), where a
+  # broken Storybook build is masked (neutralized) and — for a non-story change
+  # like a .storybook/ or preview/addon edit — never even runs. This job closes
+  # both holes. It is browser-free (build only, no render), so it omits the
+  # playwright input. Render coverage of the built bundle stays advisory by
+  # design (see docs/guidance / rmartz/ai#6).
+  storybook-build:
+    name: Storybook Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+      - run: pnpm build-storybook
+
   sentry-release:
     name: Sentry Release
     runs-on: ubuntu-latest

--- a/src/workflow-timeouts.spec.ts
+++ b/src/workflow-timeouts.spec.ts
@@ -14,6 +14,7 @@ const EXPECTED_TIMEOUT_MINUTES: Record<string, Record<string, number>> = {
     format: 2,
     lint: 2,
     "sentry-release": 2,
+    "storybook-build": 3,
     "storybook-tests": 4,
     tests: 2,
     typecheck: 1,


### PR DESCRIPTION
Closes the one gap found comparing our CI against the synthesized [Storybook browser-job CI guidance](https://github.com/rmartz/ai/blob/main/docs/guidance/storybook-screenshot-ci.md) (the [discussion #6](https://github.com/rmartz/ai/discussions/6) outcome).

## Compliance check

We already matched the guidance on everything else — the shared-`setup` Playwright cache with the `playwright-<os>-<browser-set>-<lockfile-hash>` key + coarse restore-key + `install-deps`-on-hit + retry (#765), browser-free non-browser jobs, job-level `continue-on-error` on the advisory screenshots job, and first-party build-then-serve capture (not a vendor action). The single gap was the **gating `build-storybook` job**.

## The gap

`build-storybook` ran **only** inside the advisory, story-gated `screenshots` job, under `continue-on-error`. That's the "double-hole" from the guidance:

1. **Masking** — a broken production Storybook build there is reported neutral (advisory), not red.
2. **Gate breadth** — a non-story change (`.storybook/` preset, preview decorator, addon/MDX config) has no changed `.stories.` file, so the screenshots job is skipped and the build **never runs**. It ships green.

Neither sibling covers it: `build` is `pnpm build` (Next.js — different entrypoint/bundler), and `storybook-tests` renders via Vitest's `addon-vitest` transform, which never runs `storybook build`.

## The fix

A dedicated **`Storybook Build`** gating job running `pnpm build-storybook` on every PR (non-advisory, separate from `build`). Closes both holes: it can't be masked (own job, no `continue-on-error`) and can't be gated off (runs on all PRs, so a `.storybook/`-only change still triggers it). It's **browser-free** (build only, no render), so it omits the `setup` composite's `playwright` input.

## Deliberately not doing

A `@storybook/test-runner` **render** gate. Per the guidance, this job buys **compile** coverage of the production bundle, not **render** coverage — a story that compiles + passes Vitest but throws only when the production bundle renders in real Chromium stays covered only by the advisory job. Gating that would add a third full browser render pass for a narrow class, so leaving the render advisory is a recorded proportionality choice, not an oversight.

## Verification

- `pnpm build-storybook` passes locally (~7s), so the gate is green on `main`.
- `format` / `lint` / `typecheck` pass (`pre-push-verify.py`); the `workflow-timeouts` enforcement test registers the new job (15 tests green).

---
*Created by Claude Opus 4.8*
