### PR TITLE
ci(security): pin GitHub Actions to commit SHAs with version comments

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,8 +18,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@v5
-    - uses: actions/setup-node@v6
+    - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: 24.x
         cache: "pnpm"
@@ -35,7 +35,7 @@ runs:
     - name: Cache Playwright browsers
       if: inputs.playwright != ''
       id: playwright-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.cache/ms-playwright
         key: playwright-${{ runner.os }}-${{ inputs.playwright }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       code_changed: ${{ steps.detect.outputs.code_changed }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - id: detect
@@ -61,7 +61,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.code_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       # Headless suites only (node / hooks / components) — no browser, so this
       # job stays fast and skips the Playwright install. The browser-based
@@ -75,7 +75,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.code_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
         with:
           playwright: chromium
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - run: pnpm lint
 
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - run: pnpm run format:check
 
@@ -106,7 +106,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.code_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - run: pnpm tsc
 
@@ -117,7 +117,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.code_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - run: pnpm build
 
@@ -138,7 +138,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.code_changed == 'true'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - run: pnpm build-storybook
 
@@ -150,10 +150,10 @@ jobs:
     needs:
       [tests, storybook-tests, lint, format, typecheck, build, storybook-build]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - uses: getsentry/action-release@v3
+      - uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528 # v3.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: reedmartz

--- a/.github/workflows/config-validate.yml
+++ b/.github/workflows/config-validate.yml
@@ -26,6 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - run: node scripts/validate-config.mjs

--- a/.github/workflows/package-pins.yml
+++ b/.github/workflows/package-pins.yml
@@ -27,6 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup
       - run: pnpm run check:pins

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -41,7 +41,7 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/setup

--- a/.github/workflows/storybook-screenshots.yml
+++ b/.github/workflows/storybook-screenshots.yml
@@ -41,7 +41,7 @@ jobs:
     # gh-screenshots branch, so skip them rather than fail.
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Hardens CI against a compromised- or repointed-tag supply-chain attack (the `tj-actions/changed-files` March 2025 class) by pinning every GitHub Action to the **immutable commit SHA** its tag currently resolves to, with the semver kept in a trailing comment.

## What changed

Every `uses:` across `.github/workflows/*` and `.github/actions/setup/` moves from a mutable major tag to `@<40-char-sha> # <version>`:

| Action | Pin |
|---|---|
| `actions/checkout` (×13) | `@9c091bb…` `# v7.0.0` |
| `actions/cache` | `@0057852…` `# v4.3.0` |
| `actions/setup-node` | `@48b55a0…` `# v6.4.0` |
| `pnpm/action-setup` | `@fc06bc1…` `# v5.0.0` |
| `getsentry/action-release` | `@ff07929…` `# v3.7.0` |

## Why the comment matters

The `# vX.Y.Z` comment is not just documentation — Dependabot's `github-actions` ecosystem reads it to know which version the opaque SHA corresponds to, and on a new release updates **both the SHA and the comment** in one PR. So the pin self-maintains (no `dependabot.yml` change needed — the ecosystem and 7-day cooldown are already configured), and bump PRs stay human-readable instead of showing only `sha1…→sha2…`.

## Notes

- Security **tightening** (no step/job/trigger removed), so it reviews normally.
- Each SHA is the commit the trusted major tag resolved to at authoring time (resolved via the GitHub API, annotated tags dereferenced to their commit).
- A follow-up PR (stacked on this one) adds a CI check that fails if any action is not SHA-pinned with a semver comment, to prevent regression.

Verified: `format` / `lint` / `typecheck` pass (`pre-push-verify`).

---
*Created by Claude Opus 4.8*
