### PR TITLE
chore(lint)!: statically enforce prose code-style conventions

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -62,6 +62,52 @@ export default tseslint.config(
       "react-hooks/exhaustive-deps": "error",
     },
   },
+  // Static enforcement of prose code-style conventions (AGENTS.md): type-only
+  // imports go through `import type`; no inline `import("…").Type`; no IIFEs;
+  // async/await over `.then()`; and the Vitest conventions (`it()` not `test()`,
+  // no `.toBeInTheDocument()`). Rules the review process used to enforce by eye.
+  {
+    files: ["src/**/*.{ts,tsx}", "*.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/consistent-type-imports": [
+        "error",
+        { fixStyle: "separate-type-imports" },
+      ],
+      "@typescript-eslint/no-import-type-side-effects": "error",
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "TSImportType",
+          message:
+            'No inline import("…").Type — use a module-level `import type { … } from "…"`.',
+        },
+        {
+          selector: "CallExpression > FunctionExpression.callee",
+          message:
+            "No IIFEs — extract a named helper or compute the value with a plain expression.",
+        },
+        {
+          selector: "CallExpression > ArrowFunctionExpression.callee",
+          message:
+            "No IIFEs — extract a named helper or compute the value with a plain expression.",
+        },
+        {
+          selector: "CallExpression[callee.property.name='then']",
+          message: "Use async/await, not a .then() chain.",
+        },
+        {
+          selector:
+            "CallExpression[callee.name='test'][callee.type='Identifier']",
+          message: "Use it() from Vitest, not test().",
+        },
+        {
+          selector: "MemberExpression[property.name='toBeInTheDocument']",
+          message:
+            "Don't use .toBeInTheDocument() — use .toBeDefined() or check .textContent.",
+        },
+      ],
+    },
+  },
   {
     files: ["**/*.{js,mjs,cjs}"],
     extends: [...tseslint.configs.recommended],

--- a/src/app/HomePageView.tsx
+++ b/src/app/HomePageView.tsx
@@ -12,7 +12,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { GAME_MODES } from "@/lib/game/modes";
-import { GameMode } from "@/lib/types";
+import type { GameMode } from "@/lib/types";
 
 import { HOME_PAGE_COPY } from "./page.copy";
 

--- a/src/app/[gameMode]/lobby/[lobbyId]/page.tsx
+++ b/src/app/[gameMode]/lobby/[lobbyId]/page.tsx
@@ -149,6 +149,11 @@ export default function LobbyPage() {
     startGameMutation.mutate({ gameMode });
   }
 
+  async function handleTransferOwner(playerId: string) {
+    await flushConfigSync();
+    transferOwnerMutation.mutate(playerId);
+  }
+
   const startGameMutationRef = useRef(startGameMutation);
   startGameMutationRef.current = startGameMutation;
   const flushConfigSyncRef = useRef(flushConfigSync);
@@ -269,11 +274,7 @@ export default function LobbyPage() {
           onRemovePlayer={(playerId: string) => {
             removeMutation.mutate(playerId);
           }}
-          onTransferOwner={(playerId: string) => {
-            void flushConfigSync().then(() => {
-              transferOwnerMutation.mutate(playerId);
-            });
-          }}
+          onTransferOwner={(playerId) => void handleTransferOwner(playerId)}
           onRenamePlayer={(playerName) => {
             renameMutation.mutate(playerName);
           }}

--- a/src/app/api/debug/game/route.ts
+++ b/src/app/api/debug/game/route.ts
@@ -5,9 +5,10 @@ import type {
   LobbyPlayer,
   ModeConfig,
   RoleBucket,
+  ShowRolesInPlay,
   TimerConfig,
 } from "@/lib/types";
-import { GameMode, ShowRolesInPlay } from "@/lib/types";
+import { GameMode } from "@/lib/types";
 import { createGame, getModeDefinition } from "@/server/game";
 import { ServerResponseStatus } from "@/server/types";
 import {

--- a/src/app/api/lobby/create/route.ts
+++ b/src/app/api/lobby/create/route.ts
@@ -5,7 +5,7 @@ import {
   isGameModeEnabled,
   parseGameMode,
 } from "@/lib/game/modes";
-import { GameMode } from "@/lib/types";
+import type { GameMode } from "@/lib/types";
 import { addLobby } from "@/server/lobby";
 import { type CreateLobbyRequest, ServerResponseStatus } from "@/server/types";
 import {

--- a/src/components/game/werewolf/PlayerNightSummary.tsx
+++ b/src/components/game/werewolf/PlayerNightSummary.tsx
@@ -3,7 +3,7 @@
 import groupBy from "lodash/groupBy";
 
 import type { WerewolfPlayerGameState } from "@/lib/game/modes/werewolf/player-state";
-import { VeteranCounterkillSource } from "@/lib/game/modes/werewolf/types";
+import type { VeteranCounterkillSource } from "@/lib/game/modes/werewolf/types";
 import { getPlayerName } from "@/lib/player";
 import type { PlayerGameState } from "@/server/types";
 import type { DaytimeNightStatusEntry } from "@/server/types";

--- a/src/components/lobby/ExpandedRoleList.tsx
+++ b/src/components/lobby/ExpandedRoleList.tsx
@@ -1,5 +1,5 @@
 import type { GameMode, RoleDefinition, Team } from "@/lib/types";
-import { RoleConfigMode } from "@/lib/types";
+import type { RoleConfigMode } from "@/lib/types";
 
 import { ROLE_CONFIG_COPY } from "./RoleConfig.copy";
 import { RoleListEntry } from "./RoleListEntry";

--- a/src/components/lobby/RoleListEntry.tsx
+++ b/src/components/lobby/RoleListEntry.tsx
@@ -1,5 +1,5 @@
 import type { GameMode, RoleDefinition, Team } from "@/lib/types";
-import { RoleConfigMode } from "@/lib/types";
+import type { RoleConfigMode } from "@/lib/types";
 
 import { RoleConfigEntry } from "./RoleConfigEntry";
 

--- a/src/components/lobby/ShowRolesInPlayPicker.tsx
+++ b/src/components/lobby/ShowRolesInPlayPicker.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/field";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { ShowRolesInPlay } from "@/lib/types";
+import type { ShowRolesInPlay } from "@/lib/types";
 
 import {
   SHOW_ROLES_IN_PLAY_PICKER_COPY,

--- a/src/hooks/firebaseAuth.ts
+++ b/src/hooks/firebaseAuth.ts
@@ -51,13 +51,15 @@ export function useFirebaseAuth(): { isReady: boolean } {
   useEffect(() => {
     let cancelled = false;
     setIsReady(false);
-    ensureSignedIn()
-      .then(() => {
+    const signIn = async () => {
+      try {
+        await ensureSignedIn();
         if (!cancelled) setIsReady(true);
-      })
-      .catch((err: unknown) => {
+      } catch (err: unknown) {
         console.error("[useFirebaseAuth] Sign-in failed", err);
-      });
+      }
+    };
+    void signIn();
     return () => {
       cancelled = true;
     };

--- a/src/lib/firebase/schema/player-state/werewolf.ts
+++ b/src/lib/firebase/schema/player-state/werewolf.ts
@@ -1,5 +1,5 @@
 import type { AnyNightAction, DaytimeVote } from "@/lib/game/modes/werewolf";
-import { TrialVerdict } from "@/lib/game/modes/werewolf";
+import type { TrialVerdict } from "@/lib/game/modes/werewolf";
 import type { WerewolfPlayerGameState } from "@/lib/game/modes/werewolf/player-state";
 import { GameMode } from "@/lib/types";
 import type { NightStatusEntry } from "@/server/types";

--- a/src/lib/game/initialization.ts
+++ b/src/lib/game/initialization.ts
@@ -5,9 +5,10 @@ import type {
   LobbyPlayer,
   PlayerRoleAssignment,
   RoleDefinition,
+  Team,
   VisiblePlayer,
 } from "@/lib/types";
-import { isSimpleRoleBucket, ShowRolesInPlay, Team } from "@/lib/types";
+import { isSimpleRoleBucket, ShowRolesInPlay } from "@/lib/types";
 import type { RoleInPlay } from "@/server/types";
 
 /**

--- a/src/lib/game/modes/avalon/actions/actions-tests/helpers.ts
+++ b/src/lib/game/modes/avalon/actions/actions-tests/helpers.ts
@@ -7,8 +7,14 @@ import {
 } from "@/lib/types";
 
 import { AvalonRole } from "../../roles";
-import type { AvalonTurnState, QuestPhase, TeamVotePhase } from "../../types";
-import { AvalonPhase, QuestCard, TeamVote } from "../../types";
+import type {
+  AvalonTurnState,
+  QuestCard,
+  QuestPhase,
+  TeamVote,
+  TeamVotePhase,
+} from "../../types";
+import { AvalonPhase } from "../../types";
 
 export const roleAssignments = [
   { playerId: "p1", roleDefinitionId: AvalonRole.Merlin },

--- a/src/lib/game/modes/avalon/player-state.ts
+++ b/src/lib/game/modes/avalon/player-state.ts
@@ -1,4 +1,4 @@
-import { GameMode } from "@/lib/types";
+import type { GameMode } from "@/lib/types";
 import type { BasePlayerGameState } from "@/server/types/game";
 
 import type { AvalonPhase, QuestCard, QuestResult, TeamVote } from "./types";

--- a/src/lib/game/modes/clocktower/player-state.ts
+++ b/src/lib/game/modes/clocktower/player-state.ts
@@ -1,4 +1,4 @@
-import { GameMode } from "@/lib/types";
+import type { GameMode } from "@/lib/types";
 import type { BasePlayerGameState } from "@/server/types/game";
 
 import type { ClocktowerNomination } from "./types";

--- a/src/lib/game/modes/clocktower/roles/_types.ts
+++ b/src/lib/game/modes/clocktower/roles/_types.ts
@@ -1,5 +1,5 @@
 import type { RoleDefinition } from "@/lib/types";
-import { Team } from "@/lib/types";
+import type { Team } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
 // Character type enum

--- a/src/lib/game/modes/clocktower/roles/index.ts
+++ b/src/lib/game/modes/clocktower/roles/index.ts
@@ -2,7 +2,7 @@ export * from "./_distribution";
 export * from "./_types";
 
 import type { ClocktowerRoleDefinition } from "./_types";
-import { ClocktowerRole } from "./_types";
+import type { ClocktowerRole } from "./_types";
 import { CLOCKTOWER_DEMON_ROLES } from "./demons";
 import { CLOCKTOWER_MINION_ROLES } from "./minions";
 import { CLOCKTOWER_OUTSIDER_ROLES } from "./outsiders";

--- a/src/lib/game/modes/codenames/player-state.ts
+++ b/src/lib/game/modes/codenames/player-state.ts
@@ -1,4 +1,4 @@
-import { GameMode } from "@/lib/types";
+import type { GameMode } from "@/lib/types";
 import type { BasePlayerGameState } from "@/server/types/game";
 
 import type {

--- a/src/lib/game/modes/secret-villain/actions/policy-peek.ts
+++ b/src/lib/game/modes/secret-villain/actions/policy-peek.ts
@@ -1,6 +1,7 @@
 import type { Game, GameAction } from "@/lib/types";
 
-import { PolicyCard, SecretVillainPhase, SpecialActionType } from "../types";
+import type { PolicyCard } from "../types";
+import { SecretVillainPhase, SpecialActionType } from "../types";
 import { currentTurnState } from "../utils";
 import { advanceToNextElection } from "./advance-to-election";
 

--- a/src/lib/game/modes/secret-villain/actions/president-discard.ts
+++ b/src/lib/game/modes/secret-villain/actions/president-discard.ts
@@ -1,6 +1,7 @@
 import type { Game, GameAction } from "@/lib/types";
 
-import { PolicyCard, SecretVillainPhase } from "../types";
+import type { PolicyCard } from "../types";
+import { SecretVillainPhase } from "../types";
 import { currentTurnState } from "../utils";
 
 export const presidentDiscardAction: GameAction = {

--- a/src/lib/game/modes/secret-villain/actions/special-bad-reveal.ts
+++ b/src/lib/game/modes/secret-villain/actions/special-bad-reveal.ts
@@ -1,7 +1,8 @@
 import type { Game, GameAction } from "@/lib/types";
 import { GameStatus } from "@/lib/types";
 
-import { PolicyCard, SecretVillainPhase } from "../types";
+import type { PolicyCard } from "../types";
+import { SecretVillainPhase } from "../types";
 import { currentTurnState, drawCards, reshuffleIfNeeded } from "../utils";
 import {
   SecretVillainWinner,

--- a/src/lib/game/modes/secret-villain/player-state.ts
+++ b/src/lib/game/modes/secret-villain/player-state.ts
@@ -1,4 +1,4 @@
-import { GameMode } from "@/lib/types";
+import type { GameMode } from "@/lib/types";
 import type { BasePlayerGameState } from "@/server/types/game";
 
 import type { SvTheme } from "./themes";

--- a/src/lib/game/modes/secret-villain/services.ts
+++ b/src/lib/game/modes/secret-villain/services.ts
@@ -8,11 +8,14 @@ import { SECRET_VILLAIN_COPY } from "./copy";
 import { SecretVillainRole } from "./roles";
 import type { SvTheme } from "./themes";
 import { getSvThemeLabels } from "./themes";
-import type { SecretVillainTurnState, SvCustomPowerConfig } from "./types";
+import type {
+  SecretVillainTurnState,
+  SvBoardPreset,
+  SvCustomPowerConfig,
+} from "./types";
 import {
   SecretVillainPhase,
   SpecialActionType,
-  SvBoardPreset,
   VETO_UNLOCK_THRESHOLD,
 } from "./types";
 import {

--- a/src/lib/game/modes/secret-villain/utils/turn-state.spec.ts
+++ b/src/lib/game/modes/secret-villain/utils/turn-state.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import type { PolicyCard } from "../types";
 import {
-  PolicyCard,
   SecretVillainPhase,
   type SecretVillainTurnState,
   SvBoardPreset,

--- a/src/lib/game/modes/werewolf/player-state.ts
+++ b/src/lib/game/modes/werewolf/player-state.ts
@@ -1,5 +1,5 @@
 import type { Team } from "@/lib/types";
-import { GameMode } from "@/lib/types";
+import type { GameMode } from "@/lib/types";
 import type {
   BasePlayerGameState,
   NightStatusEntry,
@@ -7,7 +7,7 @@ import type {
 
 import type { WerewolfTimerConfig } from "./timer-config";
 import type { AnyNightAction } from "./types";
-import { DaytimeVote, TrialPhase, TrialVerdict } from "./types";
+import type { DaytimeVote, TrialPhase, TrialVerdict } from "./types";
 
 /**
  * Werewolf-specific extension of PlayerGameState. Includes all fields that

--- a/src/lib/game/modes/werewolf/roles/_types.ts
+++ b/src/lib/game/modes/werewolf/roles/_types.ts
@@ -1,7 +1,7 @@
 import type { RoleDefinition } from "@/lib/types";
-import { Team } from "@/lib/types";
+import type { Team } from "@/lib/types";
 
-import { TargetCategory, WakesAtNight } from "../types";
+import type { TargetCategory, WakesAtNight } from "../types";
 
 export enum WerewolfRoleCategory {
   EvilKilling = "evil-killing",

--- a/src/lib/game/modes/werewolf/services-tests/helpers.ts
+++ b/src/lib/game/modes/werewolf/services-tests/helpers.ts
@@ -1,7 +1,6 @@
-import type { WerewolfTurnState } from "@/lib/game/modes/werewolf";
+import type { DaytimeVote, WerewolfTurnState } from "@/lib/game/modes/werewolf";
 import type { WerewolfModeConfig } from "@/lib/game/modes/werewolf";
 import {
-  DaytimeVote,
   DEFAULT_WEREWOLF_TIMER_CONFIG,
   TrialPhase,
   WerewolfPhase,

--- a/src/lib/game/modes/werewolf/services-tests/trial.spec.ts
+++ b/src/lib/game/modes/werewolf/services-tests/trial.spec.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import type { WerewolfTurnState } from "@/lib/game/modes/werewolf";
+import type { DaytimeVote, WerewolfTurnState } from "@/lib/game/modes/werewolf";
 import {
-  DaytimeVote,
   DEFAULT_WEREWOLF_TIMER_CONFIG,
   TrialPhase,
   WerewolfPhase,

--- a/src/lib/game/state.ts
+++ b/src/lib/game/state.ts
@@ -9,10 +9,11 @@ import type {
   ModeConfig,
   PlayingGameStatus,
   RoleBucket,
+  ShowRolesInPlay,
   TimerConfig,
 } from "@/lib/types";
-import { GameStatus, ShowRolesInPlay } from "@/lib/types";
-import { GameMode } from "@/lib/types";
+import type { GameMode } from "@/lib/types";
+import { GameStatus } from "@/lib/types";
 import type { PlayerGameState, VisibleTeammate } from "@/server/types";
 import {
   assignRolesFromBuckets,

--- a/src/server/types/lobby.ts
+++ b/src/server/types/lobby.ts
@@ -12,7 +12,7 @@ import type {
   ShowRolesInPlay,
   TimerConfig,
 } from "@/lib/types";
-import { GameMode } from "@/lib/types";
+import type { GameMode } from "@/lib/types";
 
 export interface PublicLobbyPlayer {
   id: string;

--- a/src/store/game-config-helpers.ts
+++ b/src/store/game-config-helpers.ts
@@ -1,8 +1,13 @@
 import { sum } from "lodash";
 
 import { GAME_MODES, getAdvancedBucketMaxCapacity } from "@/lib/game/modes";
-import type { ModeConfig, RoleBucket, SimpleRoleBucket } from "@/lib/types";
-import { GameMode, isSimpleRoleBucket, RoleConfigMode } from "@/lib/types";
+import type {
+  GameMode,
+  ModeConfig,
+  RoleBucket,
+  SimpleRoleBucket,
+} from "@/lib/types";
+import { isSimpleRoleBucket, RoleConfigMode } from "@/lib/types";
 
 import type { GameConfigState } from "./game-config-state";
 

--- a/src/store/game-config-slice.ts
+++ b/src/store/game-config-slice.ts
@@ -4,16 +4,13 @@ import { createSlice } from "@reduxjs/toolkit";
 import { GAME_MODES } from "@/lib/game/modes";
 import type {
   AdvancedRoleBucket,
+  GameMode,
   ModeConfig,
   ModeConfigField,
+  ShowRolesInPlay,
   TimerConfig,
 } from "@/lib/types";
-import {
-  GameMode,
-  isSimpleRoleBucket,
-  RoleConfigMode,
-  ShowRolesInPlay,
-} from "@/lib/types";
+import { isSimpleRoleBucket, RoleConfigMode } from "@/lib/types";
 import type { GameConfig } from "@/server/types";
 
 import {

--- a/src/store/game-config-state.ts
+++ b/src/store/game-config-state.ts
@@ -1,6 +1,11 @@
 import { DEFAULT_GAME_MODE, GAME_MODES } from "@/lib/game/modes";
-import type { ModeConfig, RoleBucket, TimerConfig } from "@/lib/types";
-import { GameMode, RoleConfigMode, ShowRolesInPlay } from "@/lib/types";
+import type {
+  GameMode,
+  ModeConfig,
+  RoleBucket,
+  TimerConfig,
+} from "@/lib/types";
+import { RoleConfigMode, ShowRolesInPlay } from "@/lib/types";
 
 export interface GameConfigState {
   gameMode: GameMode;


### PR DESCRIPTION
Increases static enforcement of the code-style conventions that AGENTS.md states in prose but only `/review` enforced by eye. No new dependency — every rule is core ESLint or `typescript-eslint` (already installed). Measured against the whole tree first, so the migration is bounded and known.

## Rules added

| Rule | Enforces (AGENTS.md) | Current violations |
|---|---|---|
| `@typescript-eslint/consistent-type-imports` | "module-level `import type`" | 30 — **auto-fixed** |
| `@typescript-eslint/no-import-type-side-effects` | (companion) | 0 |
| `no-restricted-syntax`: inline `import("…").Type` | "no function-style imports" | 0 |
| `no-restricted-syntax`: IIFEs | "no IIFEs" | 0 |
| `no-restricted-syntax`: `.then()` | "async/await, not `.then()`" | 2 — **fixed** |
| `no-restricted-syntax`: `test()` | "use `it()` from Vitest" | 0 |
| `no-restricted-syntax`: `.toBeInTheDocument()` | test convention | 0 |

Six of the seven have **zero** current violations — they're pure future-proofing insurance the tree already satisfies. The two with violations:

- **`consistent-type-imports`** — `eslint --fix` converted 30 files' type-only imports to `import type` (`separate-type-imports` style, matching the repo).
- **`.then()` → async/await** — the two existing chains (`lobby/[lobbyId]/page.tsx`, `hooks/firebaseAuth.ts`) converted to named async functions called with `void` — avoiding both `.then()` and the newly-banned IIFE, and not tripping `no-misused-promises`. Behavior-preserving. (Addresses the async/await item of #795.)

## Deliberately not included

- **`switch-exhaustiveness-check`** (4 violations) — split to its own issue: its fixes are domain decisions (unhandled `TargetCategory.Special/None` and an `undefined` case in game display logic), not mechanical, so they don't belong in a style-rules PR.
- **`no-default-export`** — filed as a decision (#819): 0 violations, but a config/dependency tradeoff to weigh.
- **`no-null` (prefer `undefined`)** — 118 domain usages + legitimate exceptions; too noisy to enforce, stays prose.

## Verification

- `format` / `lint` / `typecheck` pass (`pre-push-verify`); **2438 tests pass**.
- No dependency or lockfile changes.

---
*Created by Claude Opus 4.8*
