### PR TITLE
fix!: pin jose to 5.x to restore server routes (firebase-admin ESM require)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,10 @@
       "msw",
       "protobufjs",
       "sharp"
-    ]
+    ],
+    "overrides": {
+      "jose": "^5.10.0"
+    }
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  jose: ^5.10.0
+
 importers:
 
   .:
@@ -4027,8 +4030,8 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  jose@6.2.3:
-    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -6886,7 +6889,7 @@ snapshots:
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
       hono: 4.12.29
-      jose: 6.2.3
+      jose: 5.10.0
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
@@ -9591,7 +9594,7 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  jose@6.2.3: {}
+  jose@5.10.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -9650,7 +9653,7 @@ snapshots:
     dependencies:
       '@types/jsonwebtoken': 9.0.10
       debug: 4.4.3
-      jose: 6.2.3
+      jose: 5.10.0
       limiter: 1.1.5
       lru-cache: 11.5.1
       lru-memoizer: 3.0.0

--- a/src/lib/firebase/jose-cjs-guard.spec.ts
+++ b/src/lib/firebase/jose-cjs-guard.spec.ts
@@ -1,0 +1,42 @@
+// @vitest-environment node
+import { execFileSync } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+// Regression guard for the jose v6 ESM-only production outage. `src/lib/firebase/
+// admin.ts` imports `firebase-admin/auth` at module top level (getAdminAuth,
+// used by /api/auth/firebase-token), so every server route that imports admin.ts
+// loads it. firebase-admin's transitive jwks-rsa/src/utils.js runs
+// `const jose = require("jose")`. jose@6 is ESM-only, so any runtime that cannot
+// require() an ES module throws ERR_REQUIRE_ESM — the route module fails to load
+// and returns a 500 HTML page, which the client's res.json() surfaces as
+// "SyntaxError: The string did not match the expected pattern." On Vercel that
+// runtime is Turbopack's external-module loader, which does NOT use Node 24's
+// native require(ESM) support. We pin jose to the last CJS-capable major (5.x)
+// via pnpm.overrides in package.json. (Same failure and fix as
+// rmartz/group-picks#408 and rmartz/trip-planner#438.)
+//
+// This test loads the exact failing module in a child Node process with
+// require(ESM) DISABLED (--no-experimental-require-module), faithfully
+// reproducing that "cannot require ESM" environment. It stays green while jose
+// is CJS-capable and goes RED the moment jose@6 re-enters the require path (e.g.
+// the override is dropped before jwks-rsa/firebase-admin load jose via dynamic
+// import). Red here = the override is still needed; green with the override
+// removed = it is finally safe to remove.
+describe("jose stays CommonJS-requireable for the firebase-admin auth path", () => {
+  it("jwks-rsa loads in a runtime where require(ESM) is unavailable", () => {
+    const script = [
+      'const { createRequire } = require("module");',
+      'const faReq = createRequire(require.resolve("firebase-admin"));',
+      'faReq("jwks-rsa/src/utils");',
+    ].join("\n");
+
+    expect(() =>
+      execFileSync(
+        process.execPath,
+        ["--no-experimental-require-module", "-e", script],
+        { cwd: process.cwd(), stdio: "pipe" },
+      ),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
**Production outage fix.** Starting a debug game (and any other server route touching Firebase Admin) returns a 500, surfaced client-side as `SyntaxError: The string did not match the expected pattern` — the client's `res.json()` choking on a 500 HTML error page.

## Root cause (confirmed from Vercel runtime logs)

```
Error [ERR_REQUIRE_ESM]: require() of ES Module .../jose@6.2.3/dist/webapi/index.js
from .../jwks-rsa@4.1.0/src/utils.js not supported.
  at Context.externalImport [turbopack]_runtime.js
```

`src/lib/firebase/admin.ts` imports `firebase-admin/auth` at module top level (`getAdminAuth`, used by `/api/auth/firebase-token`). `firebase-admin`'s transitive `jwks-rsa@4.1.0/src/utils.js` runs `const jose = require("jose")`, but **`jose@6` is ESM-only**. Vercel's **Turbopack external-module loader doesn't use Node 24's native `require(ESM)`**, so the require throws — the whole `admin.ts` module fails to load, and **every server route that imports it 500s** (not just debug).

Same failure and fix as [rmartz/group-picks#408](https://github.com/rmartz/group-picks/pull/408) and rmartz/trip-planner#438. (In group-picks only middleware broke because route handlers ran on Node 24's `require(ESM)`; here the route bundle uses the Turbopack loader, so route handlers break too — bigger blast radius, same root cause.)

## Fix

`pnpm.overrides` pins `jose` to the last CJS-capable major (`^5.10.0`), so the `require` resolves. `jose` 5→6 is essentially an ESM-only **packaging** change, so `jwks-rsa@4.1.0` (which declares `jose@^6.1.3`) works unchanged. After the override the tree resolves a single `jose@5.10.0`; `jose@6` is gone.

## Regression guard

`src/lib/firebase/jose-cjs-guard.spec.ts` loads `firebase-admin`'s `jwks-rsa/src/utils` in a child Node process with `require(ESM)` **disabled** (`--no-experimental-require-module`), faithfully reproducing the Vercel/Turbopack runtime. Green while jose is CJS-capable, **red the moment `jose@6` re-enters the require path** — that red/green is the signal for when this override is safe to drop.

## Verified

- With the override, `jose` resolves to `5.10.0`; the guard loads the previously-failing module OK under the no-`require(ESM)` runtime (it threw `ERR_REQUIRE_ESM` before).
- `pre-push-verify` green — format / lint / tsc / test (incl. the guard).
- `fix/` branch → a Vercel preview will build; verify `/api/debug/game` returns JSON on the preview before promoting.

## Follow-up (separate)

Longer-term, `admin.ts` splitting the `firebase-admin/auth` import so a route that only needs the database (like debug) doesn't drag in the auth/jwks-rsa chain — but this PR is the incident restore.

---
*Created by Claude Opus 4.8*
