### PR TITLE
chore: flag `?? ""` optional coercion with a warn-tier eslint rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ After creating a git worktree (`git worktree add .git-worktrees/<name> -b <branc
 - Strict mode throughout. No `any` types. No `@ts-ignore`.
 - Do not use `null` unless required for API compatibility or when explicitly distinguishing `null` from `undefined`. Prefer `undefined` for absent/optional values throughout the codebase.
 - Prefer explicit `interface` names scoped to their component (e.g., `interface OwnerAdvanceCardProps` not `interface Props`).
+- **Coercing an optional to a falsy sentinel is a code smell — treat it as a prompt to reconsider the type.** `optional ?? ""` (and its siblings `?? 0`, `?? false`) is type-valid by construction, so no type-aware rule catches it — but it hides an absent value behind a type that claims the value is always present. eslint flags `?? ""` at `warn` severity (`no-restricted-syntax-warn`, advisory only — it does not fail CI). Before silencing it, ask whether the field should be **optional** in its type (`string | undefined`) with the absence handled explicitly, rather than papered over with a default. Keep the empty-string default only when it is a genuinely correct, meaningful value (a display fallback, a mock helper) — not merely to satisfy a type that should have been optional.
 
 ## File Organization
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,16 @@ import tseslint from "typescript-eslint";
 // ESLint has landed native per-rule multi-threshold support and migrate off it.
 const maxLinesWarn = { rules: { "max-lines": builtinRules.get("max-lines") } };
 
+// ⚠️ UNSUPPORTED — same aliasing technique as maxLinesWarn (see #789). The core
+// `no-restricted-syntax` is already registered at `error` for the hard bans
+// (IIFEs, `.then()`, inline import types, etc.). A rule carries a single
+// severity, so a soft `warn`-tier restriction can't live in that same rule
+// entry — aliasing the built-in under a second plugin namespace lets us also
+// register it at `warn` for advisory code smells that aren't outright invalid.
+const restrictedSyntaxWarn = {
+  rules: { "no-restricted-syntax": builtinRules.get("no-restricted-syntax") },
+};
+
 export default tseslint.config(
   {
     ignores: [
@@ -105,6 +115,32 @@ export default tseslint.config(
           selector: "MemberExpression[property.name='toBeInTheDocument']",
           message:
             "Don't use .toBeInTheDocument() — use .toBeDefined() or check .textContent.",
+        },
+      ],
+    },
+  },
+  // Advisory `warn`-tier restriction (not a hard ban — see restrictedSyntaxWarn).
+  // Coalescing an optional to the empty string (`optional ?? ""`) is type-valid
+  // by construction, so no type-aware rule flags it — but it silently hides an
+  // absent value behind a type that claims the string is always present. It's a
+  // code smell, not an error: often the honest fix is to model the field as
+  // optional and handle `undefined`. Warn (not error) because empty-string is
+  // sometimes a legitimate default (display fallbacks, mock helpers); triage the
+  // warnings rather than auto-failing CI on them.
+  {
+    files: ["src/**/*.{ts,tsx}", "*.{ts,tsx}"],
+    plugins: { "no-restricted-syntax-warn": restrictedSyntaxWarn },
+    rules: {
+      "no-restricted-syntax-warn/no-restricted-syntax": [
+        "warn",
+        {
+          selector:
+            'LogicalExpression[operator="??"] > Literal.right[value=""]',
+          message:
+            'Coercing an optional to "" hides an absent value behind a ' +
+            "required-string type. This is a code smell, not an error — often " +
+            "the better fix is to model the field as optional and handle " +
+            "undefined. If the empty-string default is genuinely correct, keep it.",
         },
       ],
     },


### PR DESCRIPTION
Adds an advisory eslint rule that flags coercing an optional value to the empty string (`optional ?? ""`) — a pattern that is type-valid by construction (so no type-aware rule catches it) but silently hides an absent value behind a type claiming the string is always present. Often the honest fix is to model the field as optional and handle `undefined`; sometimes the empty-string default is genuinely correct. Because it isn't inherently invalid, the rule runs at **`warn`** severity (does not fail CI).

## Technical notes

- The core `no-restricted-syntax` rule is already registered at `error` for the hard bans (IIFEs, `.then()`, inline import types). A rule carries a single severity, so the soft `warn`-tier restriction can't share that entry. This reuses the repo's existing aliasing technique (the `max-lines-warn` pattern via `eslint/use-at-your-own-risk` — the #789 canary) to register the built-in under a second namespace, `no-restricted-syntax-warn`.
- Selector: `LogicalExpression[operator="??"] > Literal.right[value=""]`. Validated against a fixture — matches only `?? ""`, leaving `?? "none"`, `|| ""`, `?? []`, `?? 0`, `?? false` untouched. Currently fires on the **24** existing `?? ""` sites in `src` (a mix of genuine smells and legitimate display/mock fallbacks — `warn` lets those be triaged rather than blocking the build).
- Documents the smell in `AGENTS.md` under TypeScript conventions as a prompt to reconsider the type.

Scoped intentionally to `?? ""` only; the broader falsy-sentinel superset (`?? []`, `?? {}`, etc.) is far noisier and left out.

---
*Created by Claude Opus 4.8*
